### PR TITLE
Add top-level README, and bazel and kaniko Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+# Tekton Task Catalog
+
+This repository contains a catalog of `Task` resoruces, which are designed to be
+reusable in many pipelines.
+
+Each `Task` is provided in a separate directory along with a README.md and a
+Kubernetes manifest, so you can choose which `Task`s to install on your
+cluster.
+
+## `Task` Kinds
+
+There are two kinds of `Task`s:
+
+ 1. `ClusterTask` with a Cluster scope, which can be installed by a cluster
+    operator and made available to users in all namespaces
+ 2. `Task` with a Namespace scope, which is designed to be installed and used
+    only within that namespace.
+
+`Task`s in this repo are namespace-scoped `Task`s, but can be installed as
+`ClusterTask`s by changing the `kind`.
+
+## Using `Task`s
+
+First, install a `Task` onto your cluster:
+
+```
+$ kubectl apply -f bazel.yaml
+task.tekton.dev/bazel created
+```
+
+You can see which `Task`s are installed using `kubectl` as well:
+
+```
+$ kubectl get tasks
+NAME    AGE
+bazel   3s
+```
+
+*OR*
+
+```
+$ kubectl get clustertasks
+NAME            AGE
+cluster-bazel   3s
+```
+
+With the `Task` installed, you can define a `TaskRun` that runs that `Task`,
+being sure to provide values for required input parameters and resources:
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: bazel
+  inputs:
+    params:
+    - name: TARGET
+      value: //path/to/image:publish
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/my-user/my-repo
+```
+
+Next, create the `TaskRun` you defined:
+
+```
+$ kubectl apply -f example-run.yaml
+taskrun.tekton.dev/example-run created
+```
+
+You can check the status of the `TaskRun` using `kubectl`:
+
+```
+$ kubectl get taskrun example-run -oyaml
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  ...
+status:
+  completionTime: "2019-04-25T18:10:09Z"
+  conditions:
+  - lastTransitionTime: "2019-04-25T18:10:09Z"
+    status: True
+    type: Succeeded
+...
+```
+
+## Contributing and Support
+
+If you want to contribute to this repository, please see our [contributing](./CONTRIBUTING.md) guidelines.
+
+If you are looking for support, enter an [issue](https://github.com/tektoncd/catalog/issues/new) or join our [Slack workspace](https://tektoncd.slack.com/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Tekton Task Catalog
+# Tekton Catalog
 
-This repository contains a catalog of `Task` resources, which are designed to be
-reusable in many pipelines.
+This repository contains a catalog of `Task` resources (and someday
+`Pipeline`s and `Resource`s), which are designed to be reusable in many
+pipelines.
 
 Each `Task` is provided in a separate directory along with a README.md and a
 Kubernetes manifest, so you can choose which `Task`s to install on your

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tekton Task Catalog
 
-This repository contains a catalog of `Task` resoruces, which are designed to be
+This repository contains a catalog of `Task` resources, which are designed to be
 reusable in many pipelines.
 
 Each `Task` is provided in a separate directory along with a README.md and a

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -1,0 +1,73 @@
+## Bazel
+
+This tasks builds source into a container image using the [Bazel build
+tool](https://bazel.build), and [Bazel's container image
+support](https://github.com/bazelbuild/rules_docker).
+
+This assumes the source repo in question is using the
+[`container_push`](https://github.com/bazelbuild/rules_docker/#container_push-1)
+rule to build and push a container image. For example:
+
+```
+container_push(
+  name = "push",
+  format = "Docker", # Or "OCI"
+  image = ":image",
+  registry = "gcr.io",
+  repository = "my-project/my-app",
+  stamp = True,
+)
+```
+
+This target instructs Bazel to build and push a container image containing the
+application defined by the `:image` target, based on a suitable base image.
+
+The `rules_docker` repo defines build rules to construct images for a variety of
+popular programming languages, like
+[Python](https://github.com/bazelbuild/rules_),
+[Java](https://github.com/bazelbuild/rules_docker/#java_image),
+[Go](https://github.com/bazelbuild/rules_docker/#go_image) and many more.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/bazel/bazel.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **TARGET**: The Bazel `container_push` target to run to build and push the
+  container image.
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Bazel.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: bazel
+  inputs:
+    params:
+    - name: TARGET
+      value: //path/to/image:publish
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/my-user/my-repo
+```

--- a/bazel/bazel.yaml
+++ b/bazel/bazel.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: bazel
+spec:
+  inputs:
+    params:
+    - name: TARGET
+      description: The name of the Bazel target to run to build the image.
+
+    resources:
+    - name: source
+      type: git
+
+  # TODO: Define image output when Bazel's rules_docker writes image metadata
+  # about pushed images.
+
+  steps:
+  - name: build-and-push
+    image: gcr.io/cloud-builders/bazel
+    workingdir: /workspace/source
+    command: ['bazel', 'run', '${inputs.params.TARGET}']

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -1,0 +1,70 @@
+# Kaniko
+
+This build template builds source into a container image using Google's
+[`kaniko`](https://github.com/GoogleCloudPlatform/kaniko) tool.
+
+>kaniko doesn't depend on a Docker daemon and executes each command within a
+>Dockerfile completely in userspace.  This enables building container images in
+>environments that can't easily or securely run a Docker daemon, such as a
+>standard Kubernetes cluster.
+> - [Kaniko website](https://github.com/GoogleCloudPlatform/kaniko)
+
+kaniko is meant to be run as an image, `gcr.io/kaniko-project/executor`. This
+makes it a perfect tool to be part of Tekton.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kaniko/kaniko.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **IMAGE**: The Docker image name to apply to the newly built image.
+  (_required_)
+* **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
+  `./Dockerfile`)
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## ServiceAccount
+
+kaniko builds an image and pushes it to the destination defined as a parameter.
+In order to properly authenticate to the remote container registry, it needs to
+have the proper credentials. This is achieved using a `ServiceAccount`.
+
+For an example on how to create such a `ServiceAccount` to push an image to
+DockerHub, see the
+[Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+documentation page.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Kaniko
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: kaniko
+  inputs:
+    params:
+    - name: IMAGE
+      value: gcr.io/my-repo/my-image
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/my-user/my-repo
+```

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: kaniko
+spec:
+  inputs:
+    params:
+    - name: IMAGE
+      description: The name of the image to push
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+
+    resources:
+    - name: source
+      type: git
+
+  steps:
+  - name: build-and-push
+    workingdir: /workspace/source
+    image: gcr.io/kaniko-project/executor
+    command:
+    - /kaniko/executor
+    - --dockerfile=${inputs.params.DOCKERFILE}
+    - --destination=${inputs.params.IMAGE}
+
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: kaniko
+  inputs:
+    params:
+    - name: IMAGE
+      value: gcr.io/my-repo/my-image
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://gist.github.com/f1fb27779bc17009198e2cef946bf749.git


### PR DESCRIPTION
This migrates some initial contents from https://github.com/knative/build-templates