### PR TITLE
Add examples for using oc

### DIFF
--- a/openshift-cli/Dockerfile
+++ b/openshift-cli/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/centos:7
 RUN cd /tmp \
   && yum -y update \
   && yum install -y wget \
-  && wget https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz \
+  && wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz \
   && tar -xvzf oc.tar.gz \
   && mv oc /usr/local/bin/ \
   && rm -rf oc.tar.gz

--- a/openshift-cli/Dockerfile
+++ b/openshift-cli/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/centos:7
+
+RUN cd /tmp \
+  && yum -y update \
+  && yum install -y wget \
+  && wget https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz \
+  && tar -xvzf oc.tar.gz \
+  && mv oc /usr/local/bin/ \
+  && rm -rf oc.tar.gz
+
+ENTRYPOINT ["oc"]
+
+CMD ["help"]

--- a/openshift-cli/README.MD
+++ b/openshift-cli/README.MD
@@ -1,14 +1,14 @@
 ## Openshift-Client
 
-`oc` is a tool which is used to interact with OpenShift from the command line. The following section provides two examples to interact with Openshift Cluster from Tekton Pipelines.
+`oc` is a tool which is used to interact with OpenShift from the command line. The following section provides two examples to interact with OpenShift Cluster from Tekton Pipelines.
 
-Dockerfile of the oc binary has also been added and the image is available [here]( https://quay.io/repository/openshift-pipeline/openshift-cli).
+The `Dockerfile` of the `oc` binary has been added and the image is available [here]( https://quay.io/repository/openshift-pipeline/openshift-cli).
 
 ## Examples:
 
-- Using oc on the same cluster using serviceAccount
+- Using `oc` on the same cluster using serviceAccount
 
-- Using oc on a different cluster using clusterResource
+- Using `oc` on a different cluster using clusterResource
 
 ## Prerequisite 
 
@@ -16,9 +16,9 @@ Tekton needs to be installed on your OpenShift Cluster. Documentation for the sa
 
 ## Using oc on the same cluster using serviceAccount
 
-You can use the serviceAccount to interact on the same cluster with oc as follows: 
+You can use the serviceAccount resource to interact on the same cluster with `oc` as follows: 
 
-1. To interact with OpenShift in the cluster using oc, you need to create the [serviceAccount](https://docs.openshift.com/container-platform/3.11/dev_guide/service_accounts.html) resource with the required permissions and use that in the taskrun.
+1. To interact with OpenShift in the cluster using `oc`, you need to create the [serviceAccount](https://docs.openshift.com/container-platform/3.11/dev_guide/service_accounts.html) resource with the required permissions and use that in the taskrun.
     
     - Create the serviceAccount resource.
     
@@ -38,7 +38,7 @@ You can use the serviceAccount to interact on the same cluster with oc as follow
         oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingServiceaccount/rolebinding.yaml 
         ```
     
-2. Create a task which lists the steps for interacting with OpenShift
+2. Create a task which lists the steps for interacting with OpenShift.
     ```
     oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingServiceaccount/octask.yaml 
     ```
@@ -52,9 +52,9 @@ You can use the serviceAccount to interact on the same cluster with oc as follow
 
 ## Using oc on a different cluster using clusterResource
 
-You can use the clusterResource to interact on different cluster with oc as follows: 
+You can use the clusterResource to interact on a different cluster with `oc` as follows: 
 
-1. Create a [ClusterResource](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#cluster-resource) with details for the second cluster. For example, here is a [sample ClusterResource](https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingClusterResource/resource.yaml):
+1. Create a [clusterResource](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#cluster-resource) with details for the second cluster. For example, here is a [sample ClusterResource](https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingClusterResource/resource.yaml):
 
     ```yaml
     apiVersion: tekton.dev/v1alpha1

--- a/openshift-cli/README.MD
+++ b/openshift-cli/README.MD
@@ -1,0 +1,91 @@
+## Openshift-Client
+
+`oc` is a tool which is used to interact with OpenShift from the command line. The following section provides two examples to interact with Openshift Cluster from Tekton Pipelines.
+
+Dockerfile of the oc binary has also been added and the image is available [here]( https://quay.io/repository/openshift-pipeline/openshift-cli).
+
+## Examples:
+
+- Using oc on the same cluster using serviceAccount
+
+- Using oc on a different cluster using clusterResource
+
+## Prerequisite 
+
+Tekton needs to be installed on your OpenShift Cluster. Documentation for the same can be found [here](https://github.com/tektoncd/pipeline/blob/master/docs/install.md#installing-tekton-pipelines-on-openshift).
+
+## Using oc on the same cluster using serviceAccount
+
+You can use the serviceAccount to interact on the same cluster with oc as follows: 
+
+1. To interact with OpenShift in the cluster using oc, you need to create the [serviceAccount](https://docs.openshift.com/container-platform/3.11/dev_guide/service_accounts.html) resource with the required permissions and use that in the taskrun.
+    
+    - Create the serviceAccount resource.
+    
+        ```
+        oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingServiceaccount/serviceaccount.yaml 
+        ```
+    
+    - Create the role for the serviceAccount resource.
+    
+        ```
+        oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingServiceaccount/role.yaml 
+        ```
+    
+    - Create the roleBinding for the serviceAccount resource.
+    
+        ```
+        oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingServiceaccount/rolebinding.yaml 
+        ```
+    
+2. Create a task which lists the steps for interacting with OpenShift
+    ```
+    oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingServiceaccount/octask.yaml 
+    ```
+
+3. Create a taskrun to execute the task just created.
+    ```
+    oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingServiceaccount/octaskrun.yaml 
+    ```
+
+4. Check the logs of the task by accessing the container logs of a freshly created pod.
+
+## Using oc on a different cluster using clusterResource
+
+You can use the clusterResource to interact on different cluster with oc as follows: 
+
+1. Create a [ClusterResource](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#cluster-resource) with details for the second cluster. For example, here is a [sample ClusterResource](https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingClusterResource/resource.yaml):
+
+    ```yaml
+    apiVersion: tekton.dev/v1alpha1
+    kind: PipelineResource
+    metadata:
+      name: cluster-details
+    spec:
+      type: cluster
+      params:
+      - name: url
+        value: https://api.com
+      - name: name
+        value: oc-test
+      - name: username
+        value: test
+      - name: token
+        value: akakkakaaa
+      - name: cadata
+        value: data
+    ```
+ 
+2. Create a task which lists the steps used to interact with the OpenShift Cluster
+    
+    ```
+    oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingClusterResource/octaskresource.yaml 
+    ```
+
+3. Create a taskrun to execute the task you created. Make sure that the ClusterResource Name is used correctly in the taskrun.
+
+    ```
+    oc apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/openshift-cli/taskUsingClusterResource/octaskrunresource.yaml 
+    ```
+
+4. Check the logs of the task by accessing the container logs of the freshly created pod.

--- a/openshift-cli/taskUsingClusterResource/octaskresource.yaml
+++ b/openshift-cli/taskUsingClusterResource/octaskresource.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-openshift-command-clusterresource
+spec:
+  inputs:
+    resources:
+      - name: clusterdetails
+        type: cluster
+  steps:
+    - name: version
+      image: quay.io/openshift-pipeline/openshift-cli
+      command:
+        - /usr/local/bin/oc
+      args: ["--kubeconfig", "/workspace/${inputs.resources.clusterdetails.name}/kubeconfig", "--context", "${inputs.resources.clusterdetails.name}", "version"]
+    - name: pods
+      image: quay.io/openshift-pipeline/openshift-cli
+      command:
+       - /usr/local/bin/oc
+      args: ["--kubeconfig", "/workspace/${inputs.resources.clusterdetails.name}/kubeconfig", "--context", "${inputs.resources.clusterdetails.name}", "get", "pods"]
+    - name: user
+      image: quay.io/openshift-pipeline/openshift-cli
+      command:
+        - /usr/local/bin/oc
+      args: ["--kubeconfig", "/workspace/${inputs.resources.clusterdetails.name}/kubeconfig", "--context", "${inputs.resources.clusterdetails.name}", "whoami"]
+    - name: status
+      image: quay.io/openshift-pipeline/openshift-cli
+      command:
+        - /usr/local/bin/oc
+      args: ["--kubeconfig", "/workspace/${inputs.resources.clusterdetails.name}/kubeconfig", "--context", "${inputs.resources.clusterdetails.name}", "status"]

--- a/openshift-cli/taskUsingClusterResource/octaskrunresource.yaml
+++ b/openshift-cli/taskUsingClusterResource/octaskrunresource.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: task-run-openshift-command-clusterresource
+spec:
+  taskRef:
+    name: task-openshift-command-clusterresource
+  inputs:
+    resources:
+      - name: clusterdetails
+        resourceRef:
+          name: cluster-details

--- a/openshift-cli/taskUsingClusterResource/resource.yaml
+++ b/openshift-cli/taskUsingClusterResource/resource.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: cluster-details
+spec:
+  type: cluster
+  params:
+  - name: url
+    value: https://api.com
+  - name: name
+    value: oc-test
+  - name: username
+    value: test
+  - name: token
+    value: akakkakaaa
+  - name: cadata
+    value: data

--- a/openshift-cli/taskUsingServiceaccount/octask.yaml
+++ b/openshift-cli/taskUsingServiceaccount/octask.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-openshift-command
+  namespace: default
+spec:
+  steps:
+    - name: version
+      image: quay.io/openshift-pipeline/openshift-cli
+      command:
+        - /usr/local/bin/oc
+      args: ["version"]
+    - name: user
+      image: quay.io/openshift-pipeline/openshift-cli
+      command:
+        - /usr/local/bin/oc
+      args: ["whoami"]
+    - name: pods
+      image: quay.io/openshift-pipeline/openshift-cli
+      command:
+        - /usr/local/bin/oc
+      args: ["get", "pods"]

--- a/openshift-cli/taskUsingServiceaccount/octaskrun.yaml
+++ b/openshift-cli/taskUsingServiceaccount/octaskrun.yaml
@@ -1,0 +1,9 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: task-run-openshift-command
+  namespace: default
+spec:
+  serviceAccount: user
+  taskRef:
+    name: task-openshift-command

--- a/openshift-cli/taskUsingServiceaccount/role.yaml
+++ b/openshift-cli/taskUsingServiceaccount/role.yaml
@@ -1,0 +1,9 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: get-pod-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]

--- a/openshift-cli/taskUsingServiceaccount/rolebinding.yaml
+++ b/openshift-cli/taskUsingServiceaccount/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: get-pod-role-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: user
+    namespace: default
+roleRef:
+  kind: Role
+  name: get-pod-role
+  apiGroup: rbac.authorization.k8s.io

--- a/openshift-cli/taskUsingServiceaccount/serviceaccount.yaml
+++ b/openshift-cli/taskUsingServiceaccount/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: user
+  namespace: default


### PR DESCRIPTION
This will add examples of using oc binary in task
It will add a dockerfile of oc binary and two
examples

1. Using oc on same cluster using serviceAccount
2. Using oc on different cluster using clusterResource

Thanks