### PR TITLE
Add Task for Cloud Native Buildpacks

### DIFF
--- a/buildpacks/README.md
+++ b/buildpacks/README.md
@@ -1,0 +1,67 @@
+# Cloud Native Buildpacks
+
+This build template builds source into a container image using [Cloud Native
+Buildpacks](https://buildpacks.io).
+
+The Cloud Native Buildpacks website describes v3 buildpacks as:
+
+> ... pluggable, modular tools that translate source code into container-ready
+> artifacts such as OCI images. They replace Dockerfiles in the app development
+> lifecycle with a higher level of abstraction. ...  Cloud Native Buildpacks
+> embrace modern container standards, such as the OCI image format. They take
+> advantage of the latest capabilities of these standards, such as remote image
+> layer rebasing on Docker API v2 registries.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/buildpacks/cnb.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **IMAGE:** The image you wish to create. For example, "repo/example", or
+  "example.com/repo/image". (_required_)
+* **RUN_IMAGE:** The run image buildpacks will use as the base for IMAGE.
+  (_default:_ `packs/run:v3alpha2`)
+* **BUILDER_IMAGE** The image on which builds will run. ( default:
+  `packs/samples:v3alpha2`)
+* **USE_CRED_HELPERS:** Use Docker credential helpers. Set to `"true"` or
+  `"false"` as string values. (_default:_ `"true"`)
+* **CACHE** The name of the persistent app cache volume (_default:_ an empty
+  directory -- effectively no cache)
+* **USER_ID** The user ID of the builder image user (_default:_ 1000)
+* **GROUP_ID** The group ID of the builder image user (_default:_ 1000)
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using buildpacks.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: buildpacks-v3
+  inputs:
+    params:
+    - name: IMAGE
+      value: gcr.io/my-repo/my-image:tag
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/my-user/my-repo
+```

--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -1,0 +1,102 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: buildpacks-v3
+spec:
+  inputs:
+    params:
+    - name: IMAGE
+      description: The image you wish to create. For example, "repo/example", or "example.com/repo/image".
+    - name: RUN_IMAGE
+      description: The run image buildpacks will use as the base for IMAGE.
+      default: packs/run:rc
+    - name: BUILDER_IMAGE
+      description: The builder image (must include v3 lifecycle and compatible buildpacks).
+      default: heroku/buildpacks
+    - name: USE_CRED_HELPERS
+      description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
+      default: 'true'
+    - name: CACHE
+      description: The name of the persistent app cache volume
+      default: empty-dir
+    - name: USER_ID
+      description: The user ID of the builder image user
+      default: "1000"
+    - name: GROUP_ID
+      description: The group ID of the builder image user
+      default: "1000"
+
+    resources:
+    - name: source
+      type: git
+
+  steps:
+  - name: prepare
+    image: alpine
+    command: ["/bin/sh"]
+    args:
+    - "-c"
+    - >
+      chown -R "${inputs.params.USER_ID}:${inputs.params.GROUP_ID}" "/builder/home" &&
+      chown -R "${inputs.params.USER_ID}:${inputs.params.GROUP_ID}" /layers &&
+      chown -R "${inputs.params.USER_ID}:${inputs.params.GROUP_ID}" /workspace
+    volumeMounts:
+    - name: "${inputs.params.CACHE}"
+      mountPath: /layers
+
+  - name: detect
+    image: ${inputs.params.BUILDER_IMAGE}
+    workingdir: /workspace/source
+    command: ["/lifecycle/detector"]
+    args:
+    - "-app=."
+    - "-group=/layers/group.toml"
+    - "-plan=/layers/plan.toml"
+    volumeMounts:
+    - name: "${inputs.params.CACHE}"
+      mountPath: /layers
+
+  - name: analyze
+    image: ${inputs.params.BUILDER_IMAGE}
+    workingdir: /workspace/source
+    command: ["/lifecycle/analyzer"]
+    args:
+    - "-layers=/layers"
+    - "-helpers=${inputs.params.USE_CRED_HELPERS}"
+    - "-group=/layers/group.toml"
+    - "${inputs.params.IMAGE}"
+    volumeMounts:
+    - name: "${inputs.params.CACHE}"
+      mountPath: /layers
+
+  - name: build
+    image: ${inputs.params.BUILDER_IMAGE}
+    workingdir: /workspace/source
+    command: ["/lifecycle/builder"]
+    args:
+    - "-layers=/layers"
+    - "-app=."
+    - "-group=/layers/group.toml"
+    - "-plan=/layers/plan.toml"
+    volumeMounts:
+    - name: "${inputs.params.CACHE}"
+      mountPath: /layers
+
+  - name: export
+    image: ${inputs.params.BUILDER_IMAGE}
+    workingdir: /workspace/source
+    command: ["/lifecycle/exporter"]
+    args:
+    - "-layers=/layers"
+    - "-helpers=${inputs.params.USE_CRED_HELPERS}"
+    - "-app=."
+    - "-image=${inputs.params.RUN_IMAGE}"
+    - "-group=/layers/group.toml"
+    - "${inputs.params.IMAGE}"
+    volumeMounts:
+    - name: "${inputs.params.CACHE}"
+      mountPath: /layers
+
+  volumes:
+  - name: empty-dir
+    emptyDir: {}

--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -9,10 +9,10 @@ spec:
       description: The image you wish to create. For example, "repo/example", or "example.com/repo/image".
     - name: RUN_IMAGE
       description: The run image buildpacks will use as the base for IMAGE.
-      default: packs/run:rc
+      default: packs/run:v3alpha2
     - name: BUILDER_IMAGE
       description: The builder image (must include v3 lifecycle and compatible buildpacks).
-      default: heroku/buildpacks
+      default: packs/samples:v3alpha2
     - name: USE_CRED_HELPERS
       description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
       default: 'true'


### PR DESCRIPTION
This migrates the build template at https://github.com/knative/build-templates/blob/master/buildpacks/cnb.yaml

Notable changes:
* Passes `-app=.` with `workingdir: /workspace/source` instead of `-app=/workspace` since Tekton puts source in the `./source` subdir
* Uses `heroku/buildpacks` image, since it seemed to give better output while I was debugging; if buildpacks folks prefer the other image let me know, or we can change it in a future PR.

I tested this running on source at https://github.com/buildpack/sample-java-app and the task was able to detect it as Java and build it.

/cc @matthewmcnew @sclevine @ekcasey 