### PR TITLE
Use image-type outputs instead of IMAGE params

### DIFF
--- a/buildpacks/README.md
+++ b/buildpacks/README.md
@@ -22,8 +22,6 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 
 ### Parameters
 
-* **IMAGE:** The image you wish to create. For example, "repo/example", or
-  "example.com/repo/image". (_required_)
 * **RUN_IMAGE:** The run image buildpacks will use as the base for IMAGE.
   (_default:_ `packs/run:v3alpha2`)
 * **BUILDER_IMAGE** The image on which builds will run. ( default:
@@ -40,6 +38,13 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
 
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container
@@ -54,9 +59,6 @@ spec:
   taskRef:
     name: buildpacks-v3
   inputs:
-    params:
-    - name: IMAGE
-      value: gcr.io/my-repo/my-image:tag
     resources:
     - name: source
       resourceSpec:
@@ -64,4 +66,12 @@ spec:
         params:
         - name: url
           value: https://github.com/my-user/my-repo
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/my-repo/my-image
 ```

--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   inputs:
     params:
-    - name: IMAGE
-      description: The image you wish to create. For example, "repo/example", or "example.com/repo/image".
     - name: RUN_IMAGE
       description: The run image buildpacks will use as the base for IMAGE.
       default: packs/run:v3alpha2
@@ -29,6 +27,11 @@ spec:
     resources:
     - name: source
       type: git
+
+  outputs:
+    resources:
+    - name: image
+      type: image
 
   steps:
   - name: prepare
@@ -64,7 +67,7 @@ spec:
     - "-layers=/layers"
     - "-helpers=${inputs.params.USE_CRED_HELPERS}"
     - "-group=/layers/group.toml"
-    - "${inputs.params.IMAGE}"
+    - "${outputs.resources.image.url}"
     volumeMounts:
     - name: "${inputs.params.CACHE}"
       mountPath: /layers
@@ -90,9 +93,9 @@ spec:
     - "-layers=/layers"
     - "-helpers=${inputs.params.USE_CRED_HELPERS}"
     - "-app=."
-    - "-image=${inputs.params.RUN_IMAGE}"
+    - "-image=${outputs.resources.image.url}"
     - "-group=/layers/group.toml"
-    - "${inputs.params.IMAGE}"
+    - "${outputs.resources.image.url}"
     volumeMounts:
     - name: "${inputs.params.CACHE}"
       mountPath: /layers

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -22,8 +22,6 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kanik
 
 ### Parameters
 
-* **IMAGE**: The Docker image name to apply to the newly built image.
-  (_required_)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 
@@ -57,9 +55,6 @@ spec:
   taskRef:
     name: kaniko
   inputs:
-    params:
-    - name: IMAGE
-      value: gcr.io/my-repo/my-image
     resources:
     - name: source
       resourceSpec:
@@ -67,4 +62,12 @@ spec:
         params:
         - name: url
           value: https://github.com/my-user/my-repo
+  outputs:
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/my-repo/my-image
 ```

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -30,6 +30,13 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kanik
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
 
+## Outputs
+
+### Resources
+
+* **image**: An `image`-type `PipelineResource` specifying the image that should
+  be built.
+
 ## ServiceAccount
 
 kaniko builds an image and pushes it to the destination defined as a parameter.

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   inputs:
     params:
-    - name: IMAGE
-      description: The name of the image to push
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       default: ./Dockerfile
@@ -15,6 +13,11 @@ spec:
     - name: source
       type: git
 
+  outputs:
+    resources:
+    - name: image
+      type: image
+
   steps:
   - name: build-and-push
     workingdir: /workspace/source
@@ -22,25 +25,4 @@ spec:
     command:
     - /kaniko/executor
     - --dockerfile=${inputs.params.DOCKERFILE}
-    - --destination=${inputs.params.IMAGE}
-
----
-
-apiVersion: tekton.dev/v1alpha1
-kind: TaskRun
-metadata:
-  name: example-run
-spec:
-  taskRef:
-    name: kaniko
-  inputs:
-    params:
-    - name: IMAGE
-      value: gcr.io/my-repo/my-image
-    resources:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://gist.github.com/f1fb27779bc17009198e2cef946bf749.git
+    - --destination=${outputs.resources.image.url}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updates kaniko and buildpacks Tasks to specify output images, and use the specified output image url instead of the `IMAGE` input param.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :heavy_check_mark:  ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ :heavy_check_mark: ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
