### PR TITLE
Use run image as image in export step

### DIFF
--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -93,7 +93,7 @@ spec:
     - "-layers=/layers"
     - "-helpers=${inputs.params.USE_CRED_HELPERS}"
     - "-app=."
-    - "-image=${outputs.resources.image.url}"
+    - "-image=${inputs.params.RUN_IMAGE}"
     - "-group=/layers/group.toml"
     - "${outputs.resources.image.url}"
     volumeMounts:


### PR DESCRIPTION
The image flag in the export step should point to the run image. 

+ Pointing at the output image produces a 'MANIFEST_UNKNOWN' unknown error fetching the unbuilt image.
