### PR TITLE
Add a specific version and context support for kaniko  

### DIFF
--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -9,7 +9,7 @@ This Task builds source into a container image using Google's
 >standard Kubernetes cluster.
 > - [Kaniko website](https://github.com/GoogleCloudPlatform/kaniko)
 
-kaniko is meant to be run as an image, `gcr.io/kaniko-project/executor`. This
+kaniko is meant to be run as an image, `gcr.io/kaniko-project/executor:v0.9.0`. This
 makes it a perfect tool to be part of Tekton.
 
 ## Install the Task
@@ -24,6 +24,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kanik
 
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
+
+* **CONTEXT**: The build context used by Kaniko (_default:_
+  `./`)
 
 ### Resources
 

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -8,7 +8,9 @@ spec:
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       default: ./Dockerfile
-
+    - name: CONTEXT
+      description: The build context used by Kaniko.
+      default: ./
     resources:
     - name: source
       type: git
@@ -21,7 +23,7 @@ spec:
   steps:
   - name: build-and-push
     workingdir: /workspace/source
-    image: gcr.io/kaniko-project/executor
+    image: gcr.io/kaniko-project/executor:v0.9.0
     # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
     # https://github.com/tektoncd/pipeline/pull/706
     env:
@@ -30,4 +32,5 @@ spec:
     command:
     - /kaniko/executor
     - --dockerfile=${inputs.params.DOCKERFILE}
+    - --context=/workspace/source/${inputs.params.CONTEXT} # The user does not need to care the workspace and the source.
     - --destination=${outputs.resources.image.url}


### PR DESCRIPTION
We need to pin to specific version rather than go with the dynamic latest commit. The version v0.9.0 seems to be a stable one.

Add the parameter context support for kaniko.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
