### PR TITLE
kaniko: set --context correctly

### DIFF
--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -31,3 +31,4 @@ spec:
     - /kaniko/executor
     - --dockerfile=${inputs.params.DOCKERFILE}
     - --destination=${outputs.resources.image.url}
+    - --context=/workspace/source


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `kaniko` Task defines an input resource named `source`, which means source is in `/workspace/source`. It sets `workingdir: /workspace/source`, but the default flag value for `--context` is still `/workspace`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ no ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ yes ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

see https://github.com/tektoncd/pipeline/issues/888