### PR TITLE
Initial `knctl` task definition 🌮

### DIFF
--- a/knctl/README.md
+++ b/knctl/README.md
@@ -1,0 +1,50 @@
+# Knative with knctl
+
+This Task deploys (or update) a Knative service. It uses
+[`knctl`](https://github.com/cppforlife/knctl) for that, and supports
+only the `deploy` subcommand as of today.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/knctl/knctl-deploy.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **service:**: The name of the service to deploy
+
+### Resources
+
+* **image**: A `image`-type `PipelineResource` specifying the location of the
+  service image to deploy.
+
+## Usage
+
+This TaskRun runs the Task to deploy the given image as a Knative service.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: knctl-deploy-my-service
+spec:
+  taskRef:
+    name: knctl-deploy
+  inputs:
+    params:
+    - name: service
+      value: my-service
+    resources:
+    - name: images
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/my-repo/my-service-image
+```
+
+In this example, the Image resource has to be built before hand, most
+likely using a previous task.

--- a/knctl/knctl-deploy.yaml
+++ b/knctl/knctl-deploy.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: knctl-deploy
+spec:
+  inputs:
+    params:
+    - name: service
+      description: Name of the service to deploy
+    resources:
+    - name: image
+      type: image
+  steps:
+  # the first step is required as knctl doesn't support inCluster configuration.
+  - name: kubeconfig
+    image: gcr.io/cloud-builders/kubectl # it is huge
+    command: ["/bin/bash"]
+    args:
+    - -c
+    - mkdir -p /builder/home/.kube; kubectl config view > /builder/home/.kube/config
+  - name: rollout
+    image: quay.io/openshift-pipeline/knctl
+    command: ["/usr/bin/knctl"]
+    args:
+    - deploy
+    - --service
+    - ${inputs.params.service}
+    - --image
+    - ${inputs.resources.image.url}


### PR DESCRIPTION
# Changes

Adds a `knctl-deploy` task that will deploy an image (resource) as a
Knative service.

Enhancements:
- a general `knctl` task that would take any arguments as input (tektoncd/pipeline#207 is required for that **or** a wrapper like the one in `openshift-client` task)
- provide more parameters (`knctl deploy --help` has quite some :angel:)
- dig into [`knative/client`](https://github.com/knative/client) instead (or in addition to)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
