### PR TITLE
Initial golang tasks

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,150 @@
+# Golang tasks
+
+These Tasks are Golang task to build, test and validate Go projects.
+
+## Install the tasks
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/golangci-lint.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/golang-build.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/golang-test.yaml
+```
+
+## `golangci-lint`
+
+### Inputs
+
+#### Parameters
+
+#### Resources
+
+* **package**: base package under validation
+* **flags**: flags to use for `golangci-lint` command (_default:_--verbose)
+* **version**: golangci-lint version to use (_default:_ v1.16)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+### `golang-build`
+
+### Inputs
+
+#### Parameters
+
+* **package**: base package under test
+* **packages**: packages to test (_default:_ ./...)
+* **version**: golang version to use for tests (_default:_ 1.12)
+* **flags**: flags to use for `go test` command (_default:_ -race  -cover -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+
+#### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+### `golang-test`
+
+### Inputs
+
+#### Parameters
+
+* **package**: base package to build in
+* **packages**: packages to test (_default:_ ./cmd/...)
+* **version**: golang version to use for builds (_default:_ 1.12)
+* **flags**: flags to use for `go test` command (_default:_ -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+
+#### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Usage
+
+### `golangci-lint`
+
+This TaskRun runs the Task to validate
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline) `pkg` package with
+`golangci-lint`.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: lint-my-code
+spec:
+  taskRef:
+    name: golangci-lint
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/tektoncd/pipeline
+    params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+    - name: flags
+      value: --verbose
+```
+
+### `golang-test`
+
+This TaskRun runs the Task to run unit-tests on
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: test-my-code
+spec:
+  taskRef:
+    name: golang-test
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/tektoncd/pipeline
+    params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+    - name: packages
+      value: ./pkg/...
+```
+
+### `golang-build`
+
+This TaskRun runs the Task to compile commands from
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+`golangci-lint`.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: build-my-code
+spec:
+  taskRef:
+    name: golang-build
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/tektoncd/pipeline
+    params:
+    - name: package
+      value: github.com/tektoncd/pipeline
+```

--- a/golang/build.yaml
+++ b/golang/build.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: golang-build
+spec:
+  inputs:
+    params:
+    - name: package
+      description: base package to build in
+    - name: packages
+      description: "packages to build (default: ./cmd/...)"
+      default: "./cmd/..."
+    - name: version
+      description: golang version to use for builds
+      default: "1.12"
+    - name: flags
+      description: flags to use for the test command
+      default: -v
+    - name: GOOS
+      description: "running program's operating system target"
+      default: linux
+    - name: GOARCH
+      description: "running program's architecture target"
+      default: amd64
+    resources:
+    - name: source
+      type: git
+      targetPath: src/${inputs.params.package}
+  steps:
+  - name: build
+    image: golang:${inputs.params.version}
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - /bin/bash
+    args:
+    - -c
+    - "go build ${inputs.params.flags} ${inputs.params.packages}"
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: GOOS
+      value: "${inputs.params.GOOS}"
+    - name: GOARCH
+      value: "${inputs.params.GOARCH}"

--- a/golang/lint.yaml
+++ b/golang/lint.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: golangci-lint
+spec:
+  inputs:
+    params:
+    - name: package
+      description: base package (and its children) under validation
+    - name: flags
+      description: flags to use for the test command
+      default: --verbose
+    - name: version
+      default: golangci-lint version to use
+      default: "v1.16"
+    - name: GOOS
+      description: "operating system target (default: node operating system)"
+      default:
+    - name: GOARCH
+      description: "architecture target (default: node architecture)"
+      default:
+    resources:
+    - name: source
+      type: git
+      targetPath: src/${inputs.params.package}
+  steps:
+  - name: lint
+    image: golangci/golangci-lint:${inputs.params.version}
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - /bin/bash
+    args:
+    - -c
+    - "golangci-lint run ${inputs.params.flags}"
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: GOOS
+      value: "${inputs.params.GOOS}"
+    - name: GOARCH
+      value: "${inputs.params.GOARCH}"

--- a/golang/tests.yaml
+++ b/golang/tests.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: golang-test
+spec:
+  inputs:
+    params:
+    - name: package
+      description: package (and its children) under test
+    - name: packages
+      description: "packages to test (default: ./...)"
+      default: "./..."
+    - name: version
+      description: golang version to use for tests
+      default: "1.12"
+    - name: flags
+      description: flags to use for the test command
+      default: -race -cover -v
+    - name: GOOS
+      description: "running program's operating system target"
+      default: linux
+    - name: GOARCH
+      description: "running program's architecture target"
+      default: amd64
+    resources:
+    - name: source
+      type: git
+      targetPath: src/${inputs.params.package}
+  steps:
+  - name: unit-test
+    image: golang:${inputs.params.version}
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - /bin/bash
+    args:
+    - -c
+    - "go test ${inputs.params.flags} ${inputs.params.packages}"
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: GOOS
+      value: "${inputs.params.GOOS}"
+    - name: GOARCH
+      value: "${inputs.params.GOARCH}"


### PR DESCRIPTION
# Changes

Related to https://github.com/tektoncd/pipeline/pull/954 and https://github.com/tektoncd/pipeline/pull/949, this provides initial Tasks for Golang.

This adds initial golang tasks : build (`golang-build`), tests (`golang-tests`) and linting (`golangci-lint`, using golangci-lint).

Improvements (todos):
- [ ] Define `Output` Resources: either of type `git` *or* `storage` ?
- [ ] Once tektoncd/pipeline#207 is fixed, remove the *bashisms*.
- [ ] … your feedback here :angel: 

Closes tektoncd/pipeline#532
Closes tektoncd/pipeline#558

/cc @chmouel @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
