### PR TITLE
Add a new Task that uses `kn` to create services

### DIFF
--- a/kn/README.md
+++ b/kn/README.md
@@ -15,6 +15,8 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn
 ### Parameters
 
 * **service:**: The name of the service to create
+* **force**: Whether to force creation, which overwrites existing services
+  (_default_: false)
 
 ### Resources
 

--- a/kn/README.md
+++ b/kn/README.md
@@ -1,0 +1,71 @@
+# Knative with `kn`
+
+This Task creates (or updates) a Knative service. It uses
+[`kn`](https://github.com/knative/client) for that, and supports only creating
+and updating services as of today.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn-create.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **service:**: The name of the service to create
+
+### Resources
+
+* **image**: A `image`-type `PipelineResource` specifying the location of the
+  service image to deploy.
+
+## Usage
+
+### Authorizing the Deployment
+
+In order to create Knative services, you must first define a `ServiceAccount`
+with permission to manage Knative services.
+
+To create a `ServiceAccount` with these permissions, you can run:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn-deployer.yaml
+```
+
+### Running the Task
+
+This TaskRun runs the Task to deploy the given image as a Knative service.
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  generateName: kn-create-
+spec:
+  serviceAccount: kn-deployer-account  # <-- run as the authorized SA
+
+  taskRef:
+    name: kn-create
+  inputs:
+    params:
+    - name: service
+      value: my-service
+    resources:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/my-repo/my-service-image
+```
+
+Run this with:
+
+```
+kubectl create -f taskrun.yaml
+```
+
+In this example, the Image resource has to be built before hand, most
+likely using a previous task.

--- a/kn/kn-create.yaml
+++ b/kn/kn-create.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: kn-create
+spec:
+  inputs:
+    params:
+    - name: service
+      description: Name of the service to create
+    resources:
+    - name: image
+      type: image
+  steps:
+  - name: create
+    image: gcr.io/knative-releases/github.com/knative/client/cmd/kn
+    command: ["/ko-app/kn"]
+    args:
+    - service
+    - create
+    - ${inputs.params.service}
+    - --image
+    - ${inputs.resources.image.url}
+    # TODO(jasonhall): Support limits/resources, env vars, etc.

--- a/kn/kn-create.yaml
+++ b/kn/kn-create.yaml
@@ -7,6 +7,9 @@ spec:
     params:
     - name: service
       description: Name of the service to create
+    - name: force
+      description: Whether to force creation, which overrites existing services.
+      default: false
     resources:
     - name: image
       type: image
@@ -20,4 +23,6 @@ spec:
     - ${inputs.params.service}
     - --image
     - ${inputs.resources.image.url}
+    - --force
+    - ${inputs.params.force}
     # TODO(jasonhall): Support limits/resources, env vars, etc.

--- a/kn/kn-deployer.yaml
+++ b/kn/kn-deployer.yaml
@@ -1,0 +1,33 @@
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kn-deployer-account
+  namespace: default
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kn-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: kn-deployer-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Also define a sample ServiceAccount, ClusterRole and ClusterRoleBinding
that can be used to authorize Knative Service deployments.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds a new Task that uses [`kn`](https://github.com/knative/client) to create Knative services.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

/assign @vdemeester 

-----

I think we'd probably like to rely on `kn` over `knctl` going forward since I believe that's expected to become the "standard" CLI for interacting with Knative. If that's okay, we should consider deleting the `knctl` task, or otherwise documenting that it's not the preferred solution.

When `kn` supports it, we should also add tasks to modify traffic splits, etc.