### PR TITLE
Added task for Kubeval

### DIFF
--- a/kubeval/README.md
+++ b/kubeval/README.md
@@ -1,0 +1,52 @@
+# Kubeval
+
+This task makes it possible to use [Kubeval](https://github.com/instrumenta/kubeval) within
+your Tekton pipelines. Kubeval is a tool used for validating Kubernetes configuration files.
+
+## Installation
+
+In order to use Kubeval with Tekton you need to first install the task.
+
+```console
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kubeval/kubeval.yaml
+```
+
+## Usage
+
+Once installed, the task can be used as follows:
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: kubeval-example
+spec:
+  taskRef:
+    name: kubeval
+  inputs:
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: revision
+          value: master
+        - name: url
+          value: https://github.com/instrumenta/conftest.git
+```
+
+By default the task will recursively scan the provided repository for YAML files and validate them against the Kubernetes schemas. You can change the default behavious, targetting particular directories, files or Kubernetes versions, using the parameters.
+
+## Inputs
+
+### Parameters
+
+* **files**: The files or directories to test to validate against the schemas
+* **output**: Which output format to use (_default:_ `stdout`)
+* **args**: An arrag of additional arguments to pass to Kubeval (_defaultt `[]`)
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+

--- a/kubeval/kubeval.yaml
+++ b/kubeval/kubeval.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: kubeval
+spec:
+  inputs:
+    resources:
+    - name: source
+      type: git
+      targetPath: source
+    params:
+    - name: files
+      default: "."
+    - name: output
+      default: "stdout"
+    - name: args
+      type: array
+      default: []
+
+  steps:
+  - name: kubeval
+    workingdir: /workspace/source
+    image: garethr/kubeval:latest
+    command:
+      - kubeval
+      - -d
+      - ${inputs.params.files}
+      - -o      
+      - ${inputs.params.output}
+      - $(inputs.params.args)


### PR DESCRIPTION
# Changes

Kubeval is a tool used to validate Kubernetes configuration against
the upstream object schemas. This commit adds a `Task` spec for using
Kubeval from Tekton, along with documentation of the parameters and usage.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._
