### PR TITLE
golang: Update golangci-lint release to v1.17.1

### DIFF
--- a/golang/lint.yaml
+++ b/golang/lint.yaml
@@ -12,7 +12,7 @@ spec:
       default: --verbose
     - name: version
       default: golangci-lint version to use
-      default: "v1.16"
+      default: "v1.17.1"
     - name: GOOS
       description: "running operating system target"
       default: linux


### PR DESCRIPTION
# Changes


Update [golangci-lint](https://github.com/golangci/golangci-lint/) release to [v1.17.1](https://github.com/golangci/golangci-lint/releases/tag/v1.17.1)

