### PR TITLE
Support to set go11module in golang task

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -16,13 +16,14 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golan
 
 #### Parameters
 
-#### Resources
-
 * **package**: base package under validation
 * **flags**: flags to use for `golangci-lint` command (_default:_--verbose)
 * **version**: golangci-lint version to use (_default:_ v1.16)
 * **GOOS**: operating system target (_default:_ linux)
 * **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+
+#### Resources
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
@@ -39,6 +40,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golan
 * **flags**: flags to use for `go test` command (_default:_ -v)
 * **GOOS**: operating system target (_default:_ linux)
 * **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
 
 #### Resources
 
@@ -57,6 +59,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golan
 * **flags**: flags to use for `go test` command (_default:_ -race -cover -v)
 * **GOOS**: operating system target (_default:_ linux)
 * **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
 
 #### Resources
 

--- a/golang/build.yaml
+++ b/golang/build.yaml
@@ -22,6 +22,9 @@ spec:
     - name: GOARCH
       description: "running program's architecture target"
       default: amd64
+    - name: GO111MODULE
+      description: "value of module support"
+      default: auto
     resources:
     - name: source
       type: git
@@ -42,3 +45,5 @@ spec:
       value: "${inputs.params.GOOS}"
     - name: GOARCH
       value: "${inputs.params.GOARCH}"
+    - name: GO111MODULE
+      value: "${inputs.params.GO111MODULE}"

--- a/golang/lint.yaml
+++ b/golang/lint.yaml
@@ -19,6 +19,9 @@ spec:
     - name: GOARCH
       description: "running architecture target"
       default: amd64
+    - name: GO111MODULE
+      description: "value of module support"
+      default: auto
     resources:
     - name: source
       type: git
@@ -39,3 +42,5 @@ spec:
       value: "${inputs.params.GOOS}"
     - name: GOARCH
       value: "${inputs.params.GOARCH}"
+    - name: GO111MODULE
+      value: "${inputs.params.GO111MODULE}"

--- a/golang/tests.yaml
+++ b/golang/tests.yaml
@@ -22,6 +22,9 @@ spec:
     - name: GOARCH
       description: "running program's architecture target"
       default: amd64
+    - name: GO111MODULE
+      description: "value of module support"
+      default: auto
     resources:
     - name: source
       type: git
@@ -42,3 +45,5 @@ spec:
       value: "${inputs.params.GOOS}"
     - name: GOARCH
       value: "${inputs.params.GOARCH}"
+    - name: GO111MODULE
+      value: "${inputs.params.GO111MODULE}"


### PR DESCRIPTION
Signed-off-by: jtcheng <jtcheng@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Support to set GO11MODULE in `golangci-lint`, `golang-build`, `golang-test`
The default value of GO11MODULE is auto in golang.
We should allow to change the value, in order to force module support on or off regardless of directory location

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._