### PR TITLE
Added Task `update-image-digests`.

### DIFF
--- a/update-image-digests/README.md
+++ b/update-image-digests/README.md
@@ -1,0 +1,88 @@
+# Update Image Digests
+
+This Task updates all image resources that has digests exported built by a predecessor task in the same pipeline run.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/update-image-digests/update-image-digests.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **pipelineTask**: The name of the task that exports image digests in the pipeline.
+
+## Usage
+
+### Authorizing the Deployment
+
+In order to retrieve digests and update image resources, you must first define a `ServiceAccount`
+with permission to get and patch resources.
+
+To create a `ServiceAccount` with these permissions, you can run:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/update-image-digests/image-digest-updater.yaml
+```
+
+### Using the Task in a Pipeline
+
+The following Pipeline uses this Task to update the digest of an image resource outputted by Task
+`build`, so `test` can find the correct image to run tests.
+```
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: build-and-test
+spec:
+  resources:
+  - name: git-source
+    type: git
+  - name: built-image
+    type: image
+  tasks:
+  - name: build
+    resources:
+      inputs:
+      - name: git-source
+        resource: git-source
+      outputs:
+      - name: built-image
+        resource: built-image
+    taskRef:
+      name: source-to-image
+  - name: update-digest
+    params:
+    - name: pipelineTask
+      value: build
+    runAfter:
+    - build
+    taskRef:
+      name: update-image-digests
+  - name: test
+    resources:
+      inputs:
+      - from:
+        - build
+        name: built-image
+        resource: built-image
+    runAfter:
+    - update-digest
+    taskRef:
+      name: run-test-binary
+```
+
+### Runtime Assumptions
+
+This Task relies on the following implementation details of Tekton pipeline:
+* The pod running this Task has the `tekton.dev/pipelineRun` label set to the name of the
+  PipelineRun this pod belongs to, which is true if this Task is in a Pipeline.
+* The TaskRun of the Task is created after its predecessor Task finishes. It uses the name of the
+  PipelineRun and the `pipelineTask` parameter to uniquely identify the predecessor's TaskRun and
+  gets the image digests from the status of the predecessor.
+* The TaskRuns of all successor Tasks are created after this Task finishes, so the string
+  interpolation can find the updated digests.
+* The entrypoint image provides `sh`, `cat`, `egrep` and `xargs`. These utility binaries don't exist
+  in the `lachlanevenson/k8s-kubectl` and `stedolan/jq` images used by this Task.

--- a/update-image-digests/image-digest-updater.yaml
+++ b/update-image-digests/image-digest-updater.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-digest-updater-account
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: image-digest-updater
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns
+  verbs:
+  - list
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineresources
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: image-digest-updater-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: image-digest-updater
+subjects:
+- kind: ServiceAccount
+  name: image-digest-updater-account
+  namespace: default

--- a/update-image-digests/update-image-digests.yaml
+++ b/update-image-digests/update-image-digests.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: update-image-digests
+spec:
+  inputs:
+    params:
+    - name: pipelineTask
+      type: string
+      description: The name of the task in the pipeline that outputs image resources
+  volumes:
+  - name: data
+    emptyDir: {}
+  stepTemplate:
+    image: lachlanevenson/k8s-kubectl
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  steps:
+  - name: get-digests
+    command:
+    - sh
+    - -c
+    - >-
+      kubectl get taskrun.tekton.dev
+      --selector='tekton.dev/pipelineRun=$(PIPELINE_RUN),tekton.dev/pipelineTask=$(inputs.params.pipelineTask)'
+      --output='jsonpath={range ..resourcesResult[*]}{.name} {.digest}{"\n"}{end}'
+      > /data/digests
+    env:
+    - name: PIPELINE_RUN
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['tekton.dev/pipelineRun']
+  - name: check-digests
+    command:
+    - sh
+    - -c
+    - |-
+      xargs -n 2 -I {} sh -c 'egrep "^[0-9a-z.-]+ sha256:[0-9a-f]{64}$" <<EOF
+      {}
+      EOF' < /data/digests
+  - name: get-image-resources
+    command:
+    - sh
+    - -c
+    - >-
+      xargs -n 2 sh -c
+      'kubectl get pipelineresource.tekton.dev/$1 --output=json > /data/image-$1.json'
+      -- < /data/digests
+  - name: create-patches
+    image: stedolan/jq
+    command:
+    - sh
+    - -c
+    - >-
+      xargs -n 2 sh -c
+      'jq -c "{spec:{params:(.spec.params|[(.[]|select(.name!=\"digest\"))]+[{name:\"digest\",value:\"$2\"}])}}"
+      /data/image-$1.json > /data/patch-$1.json'
+      -- < /data/digests
+  - name: patch-image-resources
+    command:
+    - sh
+    - -c
+    - >-
+      xargs -n 2 sh -c
+      'kubectl patch pipelineresource.tekton.dev/$1 --type=merge --patch=$(cat < /data/patch-$1.json)'
+      -- < /data/digests


### PR DESCRIPTION
# Changes

The `update-image-digests` task works as follows:
1. After a predecessor task (specified via the `pipelineTask` parameter) finishes, retrieve its `resourcesResult` and construct a data file consists of (image-resource-name, digest) pairs.
2. Use `kubectl` to patch each image resource with its digest for each pair in the data file.
3. Then, all successor task could get the digests with string interpolation.

This is intended to be a workaround for https://github.com/tektoncd/pipeline/issues/216.
The `resourcesResoult` field is proposed to be removed in pipeline 0.9, where this Task will no
longer work.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
