### PR TITLE
Fix kn-create Task to pass args in accepted manner

### DIFF
--- a/kn/kn-create.yaml
+++ b/kn/kn-create.yaml
@@ -18,11 +18,9 @@ spec:
     image: gcr.io/knative-releases/github.com/knative/client/cmd/kn
     command: ["/ko-app/kn"]
     args:
-    - service
-    - create
-    - ${inputs.params.service}
-    - --image
-    - ${inputs.resources.image.url}
-    - --force
-    - ${inputs.params.force}
+    - 'service'
+    - 'create'
+    - '$(inputs.params.service)'
+    - '--image=$(inputs.resources.image.url)'
+    - '--force=$(inputs.params.force)'
     # TODO(jasonhall): Support limits/resources, env vars, etc.


### PR DESCRIPTION
Fixes #73

# Changes

`kn` apparently doesn't like flags passed with spaces, and prefers `--foo=bar` style (with `=`). The error message when you pass flags with a space is...confusing.

I've confirmed this change makes the kn-create Task successfully attempt to create the Service.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ n/a ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ y ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide(https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
