### PR TITLE
feat(kn-create): Parameterize kn container image to be used

### DIFF
--- a/kn/README.md
+++ b/kn/README.md
@@ -13,10 +13,12 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn
 ## Inputs
 
 ### Parameters
+- **kn-image**: The kn binary container image to use for creating Knative services
 
-* **service:**: The name of the service to create
-* **force**: Whether to force creation, which overwrites existing services
-  (_default_: false)
+    _default_: `gcr.io/knative-releases/github.com/knative/client/cmd/kn`
+- **service**: The name of the service to create
+- **force**: Whether to force creation, which overwrites existing services
+  (_default_: `false`)
 
 ### Resources
 

--- a/kn/kn-create.yaml
+++ b/kn/kn-create.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   inputs:
     params:
+    - name: kn-image
+      description: kn binary image to be used to create Knative services
+      default: gcr.io/knative-releases/github.com/knative/client/cmd/kn
     - name: service
       description: Name of the service to create
     - name: force
@@ -15,12 +18,12 @@ spec:
       type: image
   steps:
   - name: create
-    image: gcr.io/knative-releases/github.com/knative/client/cmd/kn
+    image: $(inputs.params.kn-image)
     command: ["/ko-app/kn"]
     args:
-    - 'service'
-    - 'create'
-    - '$(inputs.params.service)'
-    - '--image=$(inputs.resources.image.url)'
-    - '--force=$(inputs.params.force)'
+    - service
+    - create
+    - $(inputs.params.service)
+    - --image=$(inputs.resources.image.url)
+    - --force=$(inputs.params.force)
     # TODO(jasonhall): Support limits/resources, env vars, etc.


### PR DESCRIPTION
  Fixes #72:

# Changes

  1. Uses parameter `kn-image` to specify the kn container image
  2. Sets the default to latest available released kn container image `gcr.io/knative-releases/github.com/knative/client/cmd/kn`
  3. Updates README.md to mention the kn-image parameter

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
