### PR TITLE
Revert 'remove script' and fix the Dockerfile

### DIFF
--- a/openshift-client/Dockerfile
+++ b/openshift-client/Dockerfile
@@ -1,16 +1,17 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
-RUN cd /tmp \
-  && yum -y update \
+RUN yum -y update \
   && yum install -y wget \
-  && yum clean all && \
-  &&  rm -rf /var/cache/yum && \
+  && yum clean all \
+  && rm -rf /var/cache/yum \
   && wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz \
   && tar -xvzf oc.tar.gz \
   && mv oc /usr/local/bin/oc-origin \
   && rm -rf oc.tar.gz
 
 ADD script.sh /usr/local/bin/oc
+
+RUN chmod +x /usr/local/bin/oc
 
 ENTRYPOINT ["/usr/local/bin/oc"]
 

--- a/openshift-client/Dockerfile
+++ b/openshift-client/Dockerfile
@@ -3,11 +3,14 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN cd /tmp \
   && yum -y update \
   && yum install -y wget \
-  && yum clean all \
+  && yum clean all && \
+  &&  rm -rf /var/cache/yum && \
   && wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz \
   && tar -xvzf oc.tar.gz \
-  && mv oc /usr/local/bin/oc \
+  && mv oc /usr/local/bin/oc-origin \
   && rm -rf oc.tar.gz
+
+ADD script.sh /usr/local/bin/oc
 
 ENTRYPOINT ["/usr/local/bin/oc"]
 

--- a/openshift-client/README.md
+++ b/openshift-client/README.md
@@ -58,7 +58,7 @@ spec:
   inputs:
     params:
     - name: ARGS
-      value: ["rollout", "latest", "myapp"]
+      value: rollout latest myapp
 ```
 
 The following `TaskRun` runs the commands against a different cluster than the one the `TaskRun` is running on. The cluster credentials are provided via a `PipelineResource` called `stage-cluster`.
@@ -79,5 +79,5 @@ spec:
         name: stage-cluster
     params:
     - name: ARGS
-      value: ["rollout", "latest", "myapp"]
+      value: rollout latest myapp
 ```

--- a/openshift-client/openshift-client-kubecfg-task.yaml
+++ b/openshift-client/openshift-client-kubecfg-task.yaml
@@ -13,7 +13,7 @@ spec:
         default: help
   steps:
     - name: oc
-      image: quay.io/openshift-pipeline/openshift-cli:latest
+      image: quay.io/openshift-pipeline/openshift-cli:0.5.0
       command: ["/usr/local/bin/oc"]
       args:
         - "--kubeconfig /workspace/${inputs.resources.cluster.name}/kubeconfig --context ${inputs.resources.cluster.name}"

--- a/openshift-client/openshift-client-kubecfg-task.yaml
+++ b/openshift-client/openshift-client-kubecfg-task.yaml
@@ -10,9 +10,7 @@ spec:
     params:
       - name: ARGS
         description: The OpenShift CLI arguments to run
-        type: array
-        default:
-          - "help"
+        default: help
   steps:
     - name: oc
       image: quay.io/openshift-pipeline/openshift-cli:latest

--- a/openshift-client/openshift-client-task.yaml
+++ b/openshift-client/openshift-client-task.yaml
@@ -7,9 +7,7 @@ spec:
     params:
       - name: ARGS
         description: The OpenShift CLI arguments to run
-        type: array
-        default:
-          - "help"
+        default: help
   steps:
     - name: oc
       image: quay.io/openshift-pipeline/openshift-cli:latest

--- a/openshift-client/openshift-client-task.yaml
+++ b/openshift-client/openshift-client-task.yaml
@@ -10,7 +10,7 @@ spec:
         default: help
   steps:
     - name: oc
-      image: quay.io/openshift-pipeline/openshift-cli:latest
+      image: quay.io/openshift-pipeline/openshift-cli:0.5.0
       command: ["/usr/local/bin/oc"]
       args:
         - "${inputs.params.ARGS}"

--- a/openshift-client/script.sh
+++ b/openshift-client/script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+command="/usr/local/bin/oc-origin"
+
+for args in "$@"; do
+    for arg in $args; do
+        command+=" $arg"
+    done
+done
+
+exec $command
+
+exit 0


### PR DESCRIPTION
This is breaking the backward compatibility, better release
a branch for 0.5 and then update the tasks

This change will fix the issue of client
task giving error on tekton 0.5.0

Also, tag the image with the pipeline version
in spite of always latest

Fix #78

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
