### PR TITLE
Use stepTemplate instead of containerTemplate as it is now gone

### DIFF
--- a/argocd/argocd.yaml
+++ b/argocd/argocd.yaml
@@ -14,7 +14,7 @@ spec:
         default: --
       - name: argocd-version
         default: v1.0.2
-  containerTemplate:
+  stepTemplate:
     envFrom:
       - configMapRef:
           name: argocd-env-configmap # used for server address


### PR DESCRIPTION
# Changes

We are currently using the latest release to run tests on
catalog. This means this fails with 0.7.0 and above.

`containerTemplate` is now `stepTemplate`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @abayer @ImJasonH @bobcatfish 

This is *why* I would like to tag catalog alongside the pipeline releases :angel: 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
