### PR TITLE
Tag Default Buildah Image as v1.11.0

### DIFF
--- a/buildah/README.md
+++ b/buildah/README.md
@@ -18,7 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 ### Parameters
 
 * **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
-  note below.  (_default:_ quay.io/buildah/stable)
+  note below.  (_default:_ quay.io/buildah/stable:v1.11.0)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a

--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -7,7 +7,7 @@ spec:
     params:
     - name: BUILDER_IMAGE
       description: The location of the buildah builder image.
-      default: quay.io/buildah/stable
+      default: quay.io/buildah/stable:v1.11.0
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       default: ./Dockerfile


### PR DESCRIPTION
Closes #118 

# Changes

Tagging default image used as `v1.11.0` to prevent breaking changes that may be introduced by `latest` tag.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
