### PR TITLE
Be explicit about files being a string

### DIFF
--- a/conftest/conftest.yaml
+++ b/conftest/conftest.yaml
@@ -10,6 +10,7 @@ spec:
       targetPath: source
     params:
     - name: files
+      type: string
     - name: policy
       default: "policy"
     - name: output


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Although this appears to be the default I just started seeing errors:

```
invalid input params: param types don't match the user-specified type: [files]
```

with the following params:

```
params:
  - name: files
    value: Pipfile
```

Explicitly setting the type resolves this issue so doing that for now. I'm going to investigate further.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._
