### PR TITLE
Add a git task to clone a repository without PipelineResource

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -1,0 +1,91 @@
+# Git tasks
+
+These Tasks are Git tasks to clone a repository in the workspace to be
+used by other tasks in a Pipeline.
+
+This is a `Task` that does the job of the `GitResource`
+`PipelineResource`. This is linked to
+[tektoncd/pipeline#1369](https://github.com/tektoncd/pipeline/issues/1369).
+
+## `fetch-git`
+
+### Inputs
+
+#### Parameters
+
+* **url**: git url to clone
+* **revision**: git revision to checkout (branch, tag, sha, ref…) (_default:_ master)
+* **workingDirectory**: working directory to clone (_default:_ .)
+* **submodules**: init and fetch recursively submodules (_default:_ true)
+
+## Usage
+
+### `fetch-git`
+
+This pipeline uses the Task to clone the
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline) repository
+and display the README in the next step
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: cat-readme
+spec:
+  steps:
+  - name: clone
+    image: ubuntu
+    workingdir: /workspace/src/
+    command:
+    - /bin/bash
+	- -c
+    args:
+    - "cat README"
+    volumeMounts:
+    - name: source
+      mountPath: /workspace/src
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: cat-pipeline-readme
+spec:
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: fetch-git
+    params:
+    - name: url
+      value: github.com/tektoncd/pipeline
+  - name: cat-readme
+    taskRef:
+      name: echo-readme
+```
+
+This pipeline can be used as the following `PipelineRun` does.
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: source
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: cat-pipeline-readme-run
+spec:
+  pipelineRef:
+    name: cat-pipeline-readme
+  podTemplate:
+    volumes:
+    - name: source
+      persistentVolumeClaim:
+        claimName: source
+```

--- a/git/fetch-git.yaml
+++ b/git/fetch-git.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: fetch-git
+spec:
+  inputs:
+    params:
+    - name: url
+      description: git url to clone
+      type: string
+    - name: revision
+      description: git revision to checkout (branch, tag, sha, ref…)
+      type: string
+      default: master
+    - name: workingDirectory
+      description: working directory to clone
+      type: string
+      default: .
+    - name: submodules
+      description: init and fetch recursively submodules
+      type: string
+      default: "true"
+  steps:
+  - name: clone
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    workingdir: /workspace/src/
+    command:
+    - /ko-app/git-init
+    args:
+    - -url
+    - $(inputs.params.url)
+    - -revision
+    - $(inputs.params.revision)
+    - -path
+    - $(inputs.params.workingDirectory)
+    - -submodules
+    - $(inputs.params.submodules)
+  stepTemplate:
+    volumeMounts:
+    - name: source
+      mountPath: /workspace/src


### PR DESCRIPTION
# Changes

This is part of documenting and providing Tasks in the catalog that
would help user not using PipelineResource.

Related to [tektoncd/pipeline#1369](https://github.com/tektoncd/pipeline/issues/1369).
Part of #95 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
