### PR TITLE
Add securityContext to run as root for kaniko task 🤖

### DIFF
--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -37,3 +37,5 @@ spec:
     - --dockerfile=$(inputs.params.DOCKERFILE)
     - --context=/workspace/source/$(inputs.params.CONTEXT) # The user does not need to care the workspace and the source.
     - --destination=$(outputs.resources.image.url)
+    securityContext:
+      runAsUser: 0


### PR DESCRIPTION
# Changes

As of today, kaniko assumes it is running as root, which means, this
example fails on platform that default to run containers as random
uid (like OpenShift). Adding this securityContext make it explicit that
it needs to run as root.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
