### PR TITLE
Add default value of LOCAL_CI_RUN flag

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -20,15 +20,17 @@ TMPF=$(mktemp /tmp/.mm.XXXXXX)
 clean() { rm -f ${TMPF}; }
 trap clean EXIT
 
+LOCAL_CI_RUN=${LOCAL_CI_RUN:-false}
 
 # Setup a test cluster.
 [[ -z ${LOCAL_CI_RUN} ]] && {
+
     # Initialize cluster
     initialize $@
-
-    # Install the latest Tekton CRDs.
-    kubectl apply --filename https://storage.googleapis.com/tekton-releases/latest/release.yaml
 }
+
+# Install the latest Tekton CRDs.
+kubectl apply --filename https://storage.googleapis.com/tekton-releases/latest/release.yaml
 
 # You can ignore some yaml tests by providing the TEST_YAML_IGNORES variable
 # with the test name separated by a space, for example:


### PR DESCRIPTION
This will add the default value of LOCAL_CI_RUN
flag and also move install tekton pipeline
out of not LOCAL_CI_RUN as locally also it needs
to be installed to run tests

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
