### PR TITLE
Add Dockerfile-source to Knative Service Pipelines

### DIFF
--- a/kn/README.md
+++ b/kn/README.md
@@ -118,5 +118,9 @@ Run this with:
 kubectl create -f kn-update-taskrun.yaml
 ```
 
-In these example, the `image` resource can be built before hand, most
+In these examples, the `image` resource can be built before hand, most
 likely using a previous task.
+
+## Pipeline
+Checkout the sample Pipelines for building your git source and deploying
+as Knative Service [here](./knative-dockerfile-deploy/README.md).

--- a/kn/knative-dockerfile-deploy/README.md
+++ b/kn/knative-dockerfile-deploy/README.md
@@ -25,10 +25,11 @@ kubectl create namespace tkn-kn
 ```bash
 kubectl create secret docker-registry container-registry --docker-server=<DOCKER-REGISTRY> --docker-username=<USERNAME> --docker-password=<PASSWORD> --docker-email=<EMAIL>
 ```
+More about secrets for [`interacting with a private registry`](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
 #### Note:
-- If you are using `docker.io`: Push to (a new private repo at) `docker.io` via buildah and pull via `imagePullSecrets` does not work!
-  Please [create a new](https://hub.docker.com/repository/create) empty public repository for this tutorial and refer it in subsequent steps.
-- If you are using `quay.io`: Push to `quay.io` via buildah and pull via `imagePullSecrets` works well. [Get](https://quay.io/signin/) an account created at quay.
+- For using `docker.io`: Please [create a new](https://hub.docker.com/repository/create) empty public repository and refer it in subsequent steps.
+- For using `quay.io`: No need to create a repository beforehand.
 
 3. Create a ServiceAccount `kn-deployer-account` and
  - link `container-registry` secret created above in step 2
@@ -74,7 +75,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-  - If you've used the same names for namespace and secrets as mentioned above, you can configure the ServiceAccount with YAML file in this repo using:
+  - If you've used the same names for namespace and secrets as mentioned above, you can configure the ServiceAccount with the YAML file in this repo using:
 ```bash
 kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/kn_deployer.yaml
 ```

--- a/kn/knative-dockerfile-deploy/README.md
+++ b/kn/knative-dockerfile-deploy/README.md
@@ -10,8 +10,8 @@ It uses [buildah task](../../buildah/README.md) for building the source code and
 1. Latest Tekton Pipelines [install](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)ed.
 2. `kubectl` CLI [install](https://kubernetes.io/docs/tasks/tools/install-kubectl/)ed.
 3. `tkn` CLI [install](https://github.com/tektoncd/cli#installing-tkn)ed.
-4. User account exists at a container registry for example: [quay.io](https://quay.io)
-5. A `ServiceAccount` to enable access to perform the required operations in the Pipeline,
+4. User account exists at a container registry (e.g. [quay.io](https://quay.io))
+5. A ServiceAccount to enable access to perform the required operations in the Pipeline,
    we'll configure one in following section.
 
 ### One time setup:
@@ -34,8 +34,7 @@ kubectl create secret docker-registry container-registry --docker-server=<DOCKER
  - link `container-registry` secret created above in step 2
  - create cluster role `kn-deployer` to access the Knative resources
  - binds the ServiceAccount with cluster role `kn-deployer` in namespace `tkn-kn`
-
-  Save following YAML in for e.g. `kn_deployer.yaml` and apply using `kubectl apply -f kn_deployer.yaml`.
+ - Save following YAML in e.g. `kn_deployer.yaml` and apply using `kubectl apply -f kn_deployer.yaml`.
 
 ```yaml
 # Define a ServiceAccount named kn-deployer-account that has permission to
@@ -92,7 +91,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn
 
 ## Piplines:
 
-Let's create some Pipelines using `buildah` and `kn` task:
+Let's create some Pipelines using `buildah` and `kn` tasks:
 1. Create an image from git source and deploy to the Knative Service [pipeline](./build_deploy/README.md)
 2. Deploy a new Revision to the Knative Service [pipeline](./service_update/README.md)
 3. Perform traffic operations on the Knative Service [pipeline](./service_traffic/README.md)

--- a/kn/knative-dockerfile-deploy/README.md
+++ b/kn/knative-dockerfile-deploy/README.md
@@ -1,0 +1,98 @@
+# Git Source with Dockerfile to Knative Service
+
+This documents the example Pipeline to build the source code with a Dockerfile in
+the git repo and deploy it as Knative Service.
+It uses [buildah task](../../buildah/README.md) for building the source code and
+[kn task](../README.md) to create or update a Knative Service.
+
+## Prerequisites:
+
+1. Latest Tekton Pipelines [install](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)ed.
+2. `kubectl` CLI [install](https://kubernetes.io/docs/tasks/tools/install-kubectl/)ed.
+3. `tkn` CLI [install](https://github.com/tektoncd/cli#installing-tkn)ed.
+4. User account exists at a container registry for example: [quay.io](https://quay.io)
+5. A `ServiceAccount` to enable access to perform the required operations in the Pipeline,
+   we'll configure one in following section.
+
+### One time setup:
+
+1 - Create a sample namespace `tkn-kn`, we'll reference this namespace in the subsequent operations.
+```bash
+kubectl create namespace tkn-kn
+```
+
+2 - Create a `docker-registry` type secrets for pushing/pulling the built container images.
+```bash
+kubectl create secret docker-registry container-registry --docker-server=<DOCKER-REGISTRY> --docker-username=<USERNAME> --docker-password=<PASSWORD> --docker-email=<EMAIL>
+```
+#### Note:
+- If you are using `docker.io`: Push to (a new private repo at) `docker.io` via buildah and pull via `imagePullSecrets` does not work!
+  Please [create a new](https://hub.docker.com/repository/create) empty public repository for this tutorial and refer it in subsequent steps.
+- If you are using `quay.io`: Push to `quay.io` via buildah and pull via `imagePullSecrets` works well. [Get](https://quay.io/signin/) an account created at quay.
+
+3. Create a ServiceAccount `kn-deployer-account` and
+ - link `container-registry` secret created above in step 2
+ - create cluster role `kn-deployer` to access the Knative resources
+ - binds the ServiceAccount with cluster role `kn-deployer` in namespace `tkn-kn`
+
+  Save following YAML in for e.g. `kn_deployer.yaml` and apply using `kubectl apply -f kn_deployer.yaml`.
+
+```yaml
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kn-deployer-account
+  namespace: tkn-kn
+# Link the container registry secrets
+secrets:
+  - name: container-registry
+# To be able to pull the (private) image from the container registry
+imagePullSecrets:
+  - name: container-registry
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kn-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: kn-deployer-account
+  namespace: tkn-kn
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io
+```
+
+  - If you've used the same names for namespace and secrets as mentioned above, you can configure the ServiceAccount with YAML file in this repo using:
+```bash
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/kn_deployer.yaml
+```
+
+4. Install buildah task from tektoncd/atalog
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/buildah/buildah.yaml
+```
+
+5. Install the kn task from the tektoncd/atalog
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn.yaml
+```
+
+## Piplines:
+
+Let's create some Pipelines using `buildah` and `kn` task:
+1. Create an image from git source and deploy to the Knative Service [pipeline](./build_deploy/README.md)
+2. Deploy a new Revision to the Knative Service [pipeline](./service_update/README.md)
+3. Perform traffic operations on the Knative Service [pipeline](./service_traffic/README.md)

--- a/kn/knative-dockerfile-deploy/build_deploy/README.md
+++ b/kn/knative-dockerfile-deploy/build_deploy/README.md
@@ -3,7 +3,7 @@
 Let's create a container image from a git source having a Dockerfile and deploy it to a Knative Service.
 This Pipeline builds and push the git source using `buildah` and deploys the container as Knative Service using `kn`.
 
-## Pipline:
+## Pipeline:
 
 The following Pipeline definition refers:
  - `buildah` and `kn` tasks (we've installed these tasks in One time Setup section)

--- a/kn/knative-dockerfile-deploy/build_deploy/README.md
+++ b/kn/knative-dockerfile-deploy/build_deploy/README.md
@@ -113,7 +113,7 @@ kind: PipelineRun
 metadata:
   generateName: buildah-build-kn-create-
 spec:
-  serviceAccount: kn-deployer-account
+  serviceAccountName: kn-deployer-account
   pipelineRef:
     name: buildah-build-kn-create
   resources:

--- a/kn/knative-dockerfile-deploy/build_deploy/README.md
+++ b/kn/knative-dockerfile-deploy/build_deploy/README.md
@@ -1,0 +1,158 @@
+# Build and Deploy Pipeline
+
+Let's create a container image from a git source having a Dockerfile and deploy it to a Knative Service.
+This Pipeline builds and push the git source using `buildah` and deploys the container as Knative Service using `kn`.
+
+## Pipline:
+
+The following Pipeline definition refers:
+ - `buildah` and `kn` tasks (we've installed these tasks in One time Setup section)
+- Pipeline resources for git and resulting container image repository
+- Save the following YAML in a file e.g.: `build_deploy_pipeline.yaml` and create the Pipeline using
+  `kubectl create -f build_deploy_pipeline.yaml`
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: buildah-build-kn-create
+spec:
+  resources:
+  - name: source
+    type: git
+  - name: image
+    type: image
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: buildah-build
+    taskRef:
+      name: buildah
+    resources:
+      inputs:
+        - name: source
+          resource: source
+      outputs:
+        - name: image
+          resource: image
+  - name: kn-service-create
+    taskRef:
+      name: kn
+    runAfter:
+      - buildah-build
+    resources:
+      inputs:
+      - name: image
+        resource: image
+        from:
+          - buildah-build
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"
+```
+
+ - You can also create this Pipeline using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+```
+## PipelineResource
+
+Let's create Pipeline resources that we've referenced in the above Pipeline.
+
+### Note:
+ - Make sure the git repository has a Dockerfile at root of the repo.
+ - Make sure the container repository URL is correct and you have push access to.
+ - If you are using docker.io container registry, please [create a new](https://hub.docker.com/repository/create) empty repository in advance.
+
+Save the following YAML for Pipeline resources in a file e.g.: `resources.yaml` and make sure to update the values for the git and container repositories.
+Create the resource as `kubectl create -f resources.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: buildah-build-kn-create-source
+spec:
+  type: git
+  params:
+    - name: url
+      value: "https://github.com/navidshaikh/helloworld-go"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: buildah-build-kn-create-image
+spec:
+  type: image
+  params:
+    - name: url
+      value: "quay.io/navidshaikh/helloworld-go"
+```
+
+## PipelineRun:
+
+- Let's trigger the Pipeline we've created above referncing the resources via PipelineRun.
+- Note that we've referenced ServiceAccount `kn-deployer-account` in `kn` CLI arguments,
+  it tells `kn` which ServiceAccount to use while pulling the image from (private) container registry.
+- Also note that, we're giving creating service namely `hello` and asking to create Revision
+  `hello-v1`, we'll use this Revision name in subsequent Pipeline operations.
+
+Save the following YAML in a file e.g.: `pipeline_run.yaml` and create PipelineRun as
+`kubectl create -f pipeline_run.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: buildah-build-kn-create-
+spec:
+  serviceAccount: kn-deployer-account
+  pipelineRef:
+    name: buildah-build-kn-create
+  resources:
+    - name: source
+      resourceRef:
+        name: buildah-build-kn-create-source
+    - name: image
+      resourceRef:
+        name: buildah-build-kn-create-image
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "create"
+        - "hello"
+        - "--revision-name=hello-v1"
+        - "--image=$(inputs.resources.image.url)"
+        - "--env=TARGET=Tekton"
+        - "--service-account=kn-deployer-account"
+```
+
+ - You can also create this PipelineRun using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+```
+
+- We can monitor the logs of this PipelineRun using `tkn` CLI
+```bash
+tkn pr list
+tkn pr logs <pipelinerun-name> logs -f
+```
+
+- After the successful PipelineRun, we should have the source built, pushed to the repo and deployed as Knative Service. Let's check it:
+
+```bash
+kubectl get ksvc hello
+```
+
+## What's Next:
+- We've built a container image from git source, pushed it to a container registry, deployed a Knative Service using the image.
+- You can use other available `kn` options to configure the Service, just add them to `params.ARGS` field in above `pipeline_run.yaml`. Check the list of supported options in `kn` [here](https://github.com/knative/client/blob/master/docs/cmd/kn.md).
+- We've further pipeline examples showing [service update](../service_update/README.md) and [service traffic](../service_traffic/README.md) operations.

--- a/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: buildah-build-kn-create
+spec:
+  resources:
+  - name: source
+    type: git
+  - name: image
+    type: image
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: buildah-build
+    taskRef:
+      name: buildah
+    resources:
+      inputs:
+        - name: source
+          resource: source
+      outputs:
+        - name: image
+          resource: image
+  - name: kn-service-create
+    taskRef:
+      name: kn
+    runAfter:
+      - buildah-build
+    resources:
+      inputs:
+      - name: image
+        resource: image
+        from:
+          - buildah-build
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"

--- a/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: buildah-build-kn-create-
+spec:
+  serviceAccount: kn-deployer-account
+  pipelineRef:
+    name: buildah-build-kn-create
+  resources:
+    - name: source
+      resourceRef:
+        name: buildah-build-kn-create-source
+    - name: image
+      resourceRef:
+        name: buildah-build-kn-create-image
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "create"
+        - "hello"
+        - "--revision-name=hello-v1"
+        - "--image=$(inputs.resources.image.url)"
+        - "--env=TARGET=Tekton"
+        - "--service-account=kn-deployer-account"

--- a/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   generateName: buildah-build-kn-create-
 spec:
-  serviceAccount: kn-deployer-account
+  serviceAccountName: kn-deployer-account
   pipelineRef:
     name: buildah-build-kn-create
   resources:

--- a/kn/knative-dockerfile-deploy/build_deploy/resources.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/resources.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: buildah-build-kn-create-source
+spec:
+  type: git
+  params:
+    - name: url
+      value: "https://github.com/navidshaikh/helloworld-go"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: buildah-build-kn-create-image
+spec:
+  type: image
+  params:
+    - name: url
+      value: "quay.io/navidshaikh/helloworld-go"

--- a/kn/knative-dockerfile-deploy/kn_deployer.yaml
+++ b/kn/knative-dockerfile-deploy/kn_deployer.yaml
@@ -1,0 +1,35 @@
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kn-deployer-account
+  namespace: tkn-kn
+# Link the container registry secrets
+secrets:
+  - name: container-registry
+# To be able to pull the (private) image from the container registry
+imagePullSecrets:
+  - name: container-registry
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kn-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: kn-deployer-account
+  namespace: tkn-kn
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io

--- a/kn/knative-dockerfile-deploy/service_traffic/README.md
+++ b/kn/knative-dockerfile-deploy/service_traffic/README.md
@@ -64,8 +64,8 @@ spec:
         - "hello"
         - "--tag=hello-v1=v1"
         - "--tag=hello-v2=v2"
-        - "--traffic=v1=90"
-        - "--traffic=v2=10"
+        - "--traffic=v1=50"
+        - "--traffic=v2=50"
 ```
 - You can also create this PipelineRun using the YAML file present in this repo using
 ```

--- a/kn/knative-dockerfile-deploy/service_traffic/README.md
+++ b/kn/knative-dockerfile-deploy/service_traffic/README.md
@@ -53,7 +53,7 @@ kind: PipelineRun
 metadata:
   generateName: kn-service-traffic-splitting-
 spec:
-  serviceAccount: kn-deployer-account
+  serviceAccountName: kn-deployer-account
   pipelineRef:
     name: kn-service-traffic-splitting
   params:

--- a/kn/knative-dockerfile-deploy/service_traffic/README.md
+++ b/kn/knative-dockerfile-deploy/service_traffic/README.md
@@ -1,0 +1,85 @@
+# Set Traffic for Knative Service
+
+Let's perform traffic splitting on the Knative Service using Pipeline.
+If you followed the earlier two Pipeline examples, you already have a couple of Revisions available, that we'll reference in PipelineRun to
+configure the Service to route 50-50% traffic to each Revision.
+
+## Pipeline:
+
+- The following Pipline is focused only on performing traffic operations
+  on Service. It does not define/require any Pipeline resources.
+- Save the following YAML in a file say e.g.: `kn_service_traffic_pipeline.yaml` and create using
+ `kubectl create -f kn_service_traffic_pipeline.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: kn-service-traffic-splitting
+spec:
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-traffic-splitting
+    taskRef:
+      name: kn
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"
+```
+
+ - You can also create this Pipeline using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_pipeline.yaml
+```
+
+## PipelineRun:
+
+- Create the PipelineRun to trigger the Pipeline and provide the kn CLI arguments to perform the traffic splitting.
+- Note that, we're referencing Revisions `hello-v1` and `hello-v2` here, which we've created in earlier Pipeline examples.
+- Save the following YAML in a file e.g: `pipeline_run.yaml` and create using
+ `kubectl create -f pipeline_run.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-traffic-splitting-
+spec:
+  serviceAccount: kn-deployer-account
+  pipelineRef:
+    name: kn-service-traffic-splitting
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--tag=hello-v1=v1"
+        - "--tag=hello-v2=v2"
+        - "--traffic=v1=90"
+        - "--traffic=v2=10"
+```
+- You can also create this PipelineRun using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+```
+
+- Let's monitor the logs of the Pipeline run using `tkn`
+```bash
+tkn pr list
+tkn pr logs <pipelinerun-name> logs -f
+```
+
+- After the successful run of the Pipeline, we should have the Knative Service updated with mentioned traffic settings
+```bash
+kubectl get ksvc hello
+kubectl describe ksvc hello
+```

--- a/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: kn-service-traffic-splitting
+spec:
+  resources:
+  - name: image
+    type: image
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-traffic-splitting
+    taskRef:
+      name: kn
+    resources:
+      inputs:
+      - name: image
+        resource: image
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"

--- a/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-traffic-splitting-
+spec:
+  serviceAccount: kn-deployer-account
+  pipelineRef:
+    name: kn-service-traffic-splitting
+  resources:
+    - name: image
+      resourceRef:
+        name: kn-service-update-image
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--tag=hello-v1=v1"
+        - "--tag=hello-v2=v2"
+        - "--traffic=v1=90"
+        - "--traffic=v2=10"

--- a/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
@@ -18,5 +18,5 @@ spec:
         - "hello"
         - "--tag=hello-v1=v1"
         - "--tag=hello-v2=v2"
-        - "--traffic=v1=90"
-        - "--traffic=v2=10"
+        - "--traffic=v1=50"
+        - "--traffic=v2=50"

--- a/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   generateName: kn-service-traffic-splitting-
 spec:
-  serviceAccount: kn-deployer-account
+  serviceAccountName: kn-deployer-account
   pipelineRef:
     name: kn-service-traffic-splitting
   resources:

--- a/kn/knative-dockerfile-deploy/service_update/README.md
+++ b/kn/knative-dockerfile-deploy/service_update/README.md
@@ -1,0 +1,119 @@
+# Deploy new revision to a Knative Service
+
+Let's create a Pipeline which deploys a new Revision to the deployed Knative Service.
+A new Revision is created if you update the Configuration of the Service.
+
+## Pipeline:
+- The following Pipeline is generic `kn` Pipeline, which can update (or even create a new) Knative Service based to the parameters you provide.
+- Save the following YAML in a file say e.g.: `kn_service_update_pipeline.yaml` and create using `kubectl create -f kn_service_update_pipeline.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: kn-service-update
+spec:
+  resources:
+  - name: image
+    type: image
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-update
+    taskRef:
+      name: kn
+    resources:
+      inputs:
+      - name: image
+        resource: image
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"
+```
+
+ - You can also create this Pipeline using the YAML file present in this repo using 
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
+```
+
+## PipelineResource
+
+- If you wan't to deploy a new image to a Revision, let's create a PieplineResource for this Pipeline.
+- Note that in the below example, we're now referencing a different image,
+other than the one we created earlier using buildah.
+- Save the following YAML in a file say e.g.: `resources.yaml` and create using `kubectl create -f resources.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: kn-service-update-image
+spec:
+  type: image
+  params:
+    - name: url
+      value: "gcr.io/knative-samples/helloworld-go"
+```
+- You can use this PipelineResource using the YAML file present in this repo using 
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_update/resources.yaml
+```
+
+## PipelineRun
+
+- Create the PipelineRun to trigger the Pipeline and input the kn CLI
+parameters to deploy a new Revision to `hello` Service
+
+- Save the following YAML in a file e.g.: `pipeline_run.yaml` and create using `kubectl create -f pipeline_run.yaml`
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-update-
+spec:
+  serviceAccount: kn-deployer-account
+  pipelineRef:
+    name: kn-service-update
+  resources:
+    - name: image
+      resourceRef:
+        name: kn-service-update-image
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=$(inputs.resources.image.url)"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"
+```
+
+- You can also create this PipelineRun using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+```
+
+Let's monitor the logs of the Pipeline run using `tkn`
+```bash
+tkn pr list
+tkn pr logs <pipelinerun-name> logs -f
+```
+
+After the successful run of the Pipeline, we should have the Service updated, let's check
+```bash
+kubectl get ksvc hello
+```
+
+## What's Next:
+- We've updated the Knative Service and now we've two Revisions present, we can use this state to also perform
+  some traffic splitting operation on the Service, check out the [next Pipeline example](../service_traffic/README.md).

--- a/kn/knative-dockerfile-deploy/service_update/README.md
+++ b/kn/knative-dockerfile-deploy/service_update/README.md
@@ -79,7 +79,7 @@ kind: PipelineRun
 metadata:
   generateName: kn-service-update-
 spec:
-  serviceAccount: kn-deployer-account
+  serviceAccountName: kn-deployer-account
   pipelineRef:
     name: kn-service-update
   resources:

--- a/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: kn-service-update
+spec:
+  resources:
+  - name: image
+    type: image
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-update
+    taskRef:
+      name: kn
+    resources:
+      inputs:
+      - name: image
+        resource: image
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"

--- a/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   generateName: kn-service-update-
 spec:
-  serviceAccount: kn-deployer-account
+  serviceAccountName: kn-deployer-account
   pipelineRef:
     name: kn-service-update
   resources:

--- a/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-update-
+spec:
+  serviceAccount: kn-deployer-account
+  pipelineRef:
+    name: kn-service-update
+  resources:
+    - name: image
+      resourceRef:
+        name: kn-service-update-image
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=$(inputs.resources.image.url)"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"

--- a/kn/knative-dockerfile-deploy/service_update/resources.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/resources.yaml
@@ -1,0 +1,9 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: kn-service-update-image
+spec:
+  type: image
+  params:
+    - name: url
+      value: "gcr.io/knative-samples/helloworld-go"


### PR DESCRIPTION
# Changes
- Uses `buildah` task for Dockerfile-source at git to build and push
- Uses `kn` task to deploy as Knative Service
- Documents creating `docker-registry` type secrets, for push/pull
- Documents configuring `ServiceAccount` for deploying ksvc and linking the secrets to it
- Adds Pipelines for updating a ksvc as well as performing some traffic operations
- Links the example Pipelines from kn task README

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
