### PR TITLE
Fix running s2i binary as user

### DIFF
--- a/s2i/Dockerfile
+++ b/s2i/Dockerfile
@@ -7,6 +7,7 @@ RUN yum -y update && yum clean all &&  rm -rf /var/cache/yum
 # in the image so wedon't have to install extra packages)
 RUN mkdir -p /usr/local/bin && \
     curl -L $(curl -L -s "https://api.github.com/repos/openshift/source-to-image/releases/latest"| python -c "import sys, json;x=json.load(sys.stdin);print([ r['browser_download_url'] for r in x['assets'] if 'linux-amd64' in r['name']][0])") -o /tmp/s2i.tgz && \
-    tar xz -f/tmp/s2i.tgz -C /usr/local/bin/
+    tar xz -f/tmp/s2i.tgz -C /usr/local/bin/ && \
+	chmod -R 0755 /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/s2i"]


### PR DESCRIPTION
When building the dockerfile we were creating directory as root
unreadable by normal user, let's make sure it's readable/executable by
everyone.

/cc @sthaha

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._