### PR TITLE
Azure CLI Task

### DIFF
--- a/azure-cli/README.md
+++ b/azure-cli/README.md
@@ -1,0 +1,41 @@
+# `az`
+
+This task performs operations on Microsoft Azure resources using `az`.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/azure-cli/azure_cli.yaml
+```
+
+## Inputs
+
+### Parameters
+
+* **az-image**: `az` CLI container image to run this task.
+
+  _default_: `mcr.microsoft.com/azure-cli:2.0.77`
+
+  You can use a specific version of the `az` CLI by specifying the `az-image` param with the `mcr.microsoft.com/azure-cli` image tagged with the specific version of the CLI you would like to use (i.e. version 2.0.70 = `mcr.microsoft.com/azure-cli:2.0.70`). A full list of available version tags can be found under the [Full Tag Listing](https://hub.docker.com/_/microsoft-azure-cli) section of the `az` Docker Hub.
+
+* **ARGS**: The arguments to pass to `az` CLI.  _default_: `["help"]`
+
+## Usage
+
+### Running the Task
+
+After creating the task, you should now be able to execute `az` commands by specifying the command you would like to run as the `ARGS` param. The `ARGS` param takes an array of `az` subcommands that will be executed as part of this task.
+
+### Examples
+
+Run `az ad --help` using `az`. Start the task using the Tekton CLI (`tkn`):
+
+```shell
+tkn task start az -p ARGS=ad,--help
+```
+
+Specify a different `az-image` to use with the `az` task:
+
+```shell
+tkn task start az -p az-image=mcr.microsoft.com/azure-cli:2.0.70
+```

--- a/azure-cli/azure_cli.yaml
+++ b/azure-cli/azure_cli.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: az
+spec:
+  inputs:
+    params:
+    - name: az-image
+      description: Azure CLI container image to run this task
+      default: mcr.microsoft.com/azure-cli:2.0.77
+    - name: ARGS
+      type: array
+      description: Azure CLI arguments to run
+      default: ["help"]
+  steps:
+  - name: az
+    image: "$(inputs.params.az-image)"
+    command: ["az"]
+    args: ["$(inputs.params.ARGS)"]


### PR DESCRIPTION
Closes #147 

This pull request adds a task to execute azure cli (`az`) commands. It uses the [official Microsoft Azure CLI image](https://hub.docker.com/_/microsoft-azure-cli). The default image used is `mcr.microsoft.com/azure-cli:2.0.77`, which is the most recent release of `az`.

Future work on this task will be centered around documenting best authentication approaches using `az` from a task.

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
