### PR TITLE
Extract the builder image as a common parameter

### DIFF
--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -13,6 +13,9 @@ spec:
       default: ./
     - name: EXTRA_ARGS
       default: ""
+    - name: BUILDER_IMAGE
+      description: The image on which builds will run
+      default: gcr.io/kaniko-project/executor:v0.13.0
     resources:
     - name: source
       type: git
@@ -25,7 +28,7 @@ spec:
   steps:
   - name: build-and-push
     workingdir: /workspace/source
-    image: gcr.io/kaniko-project/executor:v0.13.0
+    image: $(inputs.params.BUILDER_IMAGE)
     # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
     # https://github.com/tektoncd/pipeline/pull/706
     env:


### PR DESCRIPTION
Hi all,
Right now, the kaniko builder image is hard code in the steps.

As other build tasks (As buildpacks an example: https://github.com/tektoncd/catalog/blob/master/buildpacks/buildpacks-v3.yaml#L8), it is better to extract the build image as a common parameter `BUILDER_IMAGE` so that users can set it by themselves.

Please review. Thanks!

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
