### PR TITLE
Remove Default for ARGS and Update Image Tag to 2.0.78 for Azure CLI

### DIFF
--- a/azure-cli/README.md
+++ b/azure-cli/README.md
@@ -18,7 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/azure
 
   You can use a specific version of the `az` CLI by specifying the `az-image` param with the `mcr.microsoft.com/azure-cli` image tagged with the specific version of the CLI you would like to use (i.e. version 2.0.70 = `mcr.microsoft.com/azure-cli:2.0.70`). A full list of available version tags can be found under the [Full Tag Listing](https://hub.docker.com/_/microsoft-azure-cli) section of the `az` Docker Hub.
 
-* **ARGS**: The arguments to pass to `az` CLI.  _default_: `["help"]`
+* **ARGS**: The arguments to pass to `az` CLI. This parameter is required to run this task. 
 
 ## Usage
 

--- a/azure-cli/azure_cli.yaml
+++ b/azure-cli/azure_cli.yaml
@@ -7,11 +7,10 @@ spec:
     params:
     - name: az-image
       description: Azure CLI container image to run this task
-      default: mcr.microsoft.com/azure-cli:2.0.77
+      default: mcr.microsoft.com/azure-cli:2.0.78
     - name: ARGS
       type: array
       description: Azure CLI arguments to run
-      default: ["help"]
   steps:
   - name: az
     image: "$(inputs.params.az-image)"

--- a/tkn/README.md
+++ b/tkn/README.md
@@ -16,4 +16,4 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/tkn/t
 name      | description                                 | default
 --------- | ------------------------------------------- | -------
 tkn-image | `tkn` CLI container image to run this task. | gcr.io/tekton-releases/dogfooding/tkn
-ARGS      | The arguments to pass to the `tkn` CLI.     | `["help"]`
+ARGS      | The arguments to pass to the `tkn` CLI.     | No default. Required.


### PR DESCRIPTION
This pull request introduces the following changes:
* Updates the default image for the azure-cli task to the latest version of `az`, which is 2.0.78
* Removes the default for `ARGS` parameter, making it a required parameter
* Updates the `tkn` task README to reflect that `ARGS` does not have a default and is required

# Changes

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
