### PR TITLE
Change to ${OW_ACTION_CODE} for new Tekton version

### DIFF
--- a/openwhisk/openwhisk.yaml
+++ b/openwhisk/openwhisk.yaml
@@ -69,7 +69,7 @@ spec:
               ENV __OW_RUNTIME_DEBUG "$(inputs.params.OW_RUNTIME_DEBUG)"
               ENV __OW_RUNTIME_PLATFORM "$(inputs.params.OW_RUNTIME_PLATFORM)"
               ENV __OW_ACTION_NAME "$(inputs.params.OW_ACTION_NAME)"
-              ENV __OW_ACTION_CODE "$(OW_ACTION_CODE)"
+              ENV __OW_ACTION_CODE "${OW_ACTION_CODE}"
               ENV __OW_ACTION_MAIN "$(inputs.params.OW_ACTION_MAIN)"
               ENV __OW_ACTION_BINARY "$(inputs.params.OW_ACTION_BINARY)"
               ENV __OW_HTTP_METHODS "$(inputs.params.OW_HTTP_METHODS)"


### PR DESCRIPTION
When using the latest Tekton pipeline version. It reports an error when executing this task:
`bash: line 15: OW_ACTION_CODE: command not found`

It because this line: `              ENV __OW_ACTION_CODE "$(OW_ACTION_CODE)"`

When running this code, bash thinks it is a command not a variable.

So change it to `ENV __OW_ACTION_CODE "${OW_ACTION_CODE}"`

Then the task can be run correctly

Pls review

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
