### PR TITLE
Correct credential path of docker

### DIFF
--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -33,7 +33,7 @@ spec:
     # https://github.com/tektoncd/pipeline/pull/706
     env:
     - name: DOCKER_CONFIG
-      value: /builder/home/.docker
+      value: /tekton/home/.docker
     command:
     - /kaniko/executor
     - $(inputs.params.EXTRA_ARGS)


### PR DESCRIPTION
Follow the change in `pipeline`, change docker credential path to `/tekton/home/.docker`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
