### PR TITLE
Use serviceAccountName instead of serviceAccount 💺

### DIFF
--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -77,7 +77,7 @@ kind: TaskRun
 metadata:
   generateName: auth-check-
 spec:
-  serviceAccount: workload-identity-sa  # <-- a SA configured with Workload Identity
+  serviceAccountName: workload-identity-sa  # <-- a SA configured with Workload Identity
   taskRef:
     name: gcloud
   inputs:
@@ -101,7 +101,7 @@ kind: TaskRun
 metadata:
   generateName: run-deploy
 spec:
-  serviceAccount: workload-identity-sa  # <-- a SA configured with Workload Identity
+  serviceAccountName: workload-identity-sa  # <-- a SA configured with Workload Identity
   taskRef:
     name: gcloud
   inputs:
@@ -132,7 +132,7 @@ kind: TaskRun
 metadata:
   generateName: run-deploy
 spec:
-  serviceAccount: workload-identity-sa  # <-- a SA configured with Workload Identity
+  serviceAccountName: workload-identity-sa  # <-- a SA configured with Workload Identity
   taskRef:
     name: gcloud
   inputs:

--- a/kn/README.md
+++ b/kn/README.md
@@ -56,7 +56,7 @@ kind: TaskRun
 metadata:
   generateName: kn-create-
 spec:
-  serviceAccount: kn-deployer-account  # <-- run as the authorized SA
+  serviceAccountName: kn-deployer-account  # <-- run as the authorized SA
   taskRef:
     name: kn
   inputs:
@@ -91,7 +91,7 @@ kind: TaskRun
 metadata:
   generateName: kn-update-
 spec:
-  serviceAccount: kn-deployer-account  # <-- run as the authorized SA
+  serviceAccountName: kn-deployer-account  # <-- run as the authorized SA
   taskRef:
     name: kn
   inputs:

--- a/openwhisk/runtimes/javascript/README.md
+++ b/openwhisk/runtimes/javascript/README.md
@@ -256,7 +256,7 @@ kubectl apply -f service.yaml
 service.serving.knative.dev/nodejs-helloworld created
 ```
 
-### Run HelloWorld 
+### Run HelloWorld
 
 ```bash
 curl -H "Host: nodejs-helloworld.default.example.com" -X POST http://${IP_ADDRESS}
@@ -267,10 +267,10 @@ curl -H "Host: nodejs-helloworld.default.example.com" -X POST http://${IP_ADDRES
 
 ## Example 2: Actions with JSON in / JSON out Interface
 
-### Build HelloWorld with JSON Payload as Parameters 
+### Build HelloWorld with JSON Payload as Parameters
 #### Configure taskrun.yaml
 
-Now, let's update the OpenWhisk Task parameter ```OW_ACTION_CODE``` to ```function main(params) {return {payload: 'Hello ' + params.name + ' from ' + params.place + '!'};}``` 
+Now, let's update the OpenWhisk Task parameter ```OW_ACTION_CODE``` to ```function main(params) {return {payload: 'Hello ' + params.name + ' from ' + params.place + '!'};}```
 
 <details>
     <summary>taskrun.yaml.tmpl contents</summary>
@@ -339,7 +339,7 @@ spec:
 ```bash
 kubectl apply -f taskrun.yaml
 pipelineresource.tekton.dev/openwhisk-nodejs-runtime-git unchanged
-pipelineresource.tekton.dev/openwhisk-nodejs-helloworld-with-params-image created 
+pipelineresource.tekton.dev/openwhisk-nodejs-helloworld-with-params-image created
 taskrun.tekton.dev/openwhisk-nodejs-helloworld-with-params created
 ```
 
@@ -354,7 +354,7 @@ Service URL:
 http://nodejs-helloworld-with-params.default.example.com
 ```
 
-### Run HelloWorld 
+### Run HelloWorld
 
 ```bash
 curl -H "Host: nodejs-helloworld-with-params.default.example.com" -H "Content-Type: application/json" -d '{"value":{"name": "Jill", "place": "OK"}}' http://${IP_ADDRESS}
@@ -473,7 +473,7 @@ error building image: parsing dockerfile: Dockerfile parse error line 43: unknow
 
 #### Configure taskrun.yaml
 
-Now, let's update the OpenWhisk Task parameter ```OW_PROJECT_URL``` to ```https://github.com/tektoncd/catalog/blob/openwhisk/openwhisk/runtimes/javascript/examples/04-zip/action.zip?raw=true```
+Now, let's update the OpenWhisk Task parameter ```OW_PROJECT_URL``` to ```https://github.com/tektoncd/catalog/raw/master/openwhisk/runtimes/javascript/examples/04-zip/action.zip```
 
 <details>
     <summary>taskrun.yaml.tmpl contents</summary>
@@ -529,7 +529,7 @@ spec:
             - name: OW_ACTION_CODE
               value: ""
             - name: OW_PROJECT_URL
-              value: "https://github.com/tektoncd/catalog/blob/openwhisk/openwhisk/runtimes/javascript/examples/04-zip/action.zip?raw=true"
+              value: "https://github.com/tektoncd/catalog/raw/master/openwhisk/runtimes/javascript/examples/04-zip/action.zip"
     outputs:
         resources:
             - name: runtime-image
@@ -569,4 +569,3 @@ curl -H "Host: nodejs-zip.default.example.com" -X POST http://${IP_ADDRESS}
 curl -H "Host: nodejs-zip.default.example.com" -H "Content-Type: application/json" -d '{"value":{"name": "Bob", "place": "NY"}}' http://${IP_ADDRESS}
 {"payload":"Hello, Bob from NY!"}
 ```
-

--- a/openwhisk/runtimes/javascript/README.md
+++ b/openwhisk/runtimes/javascript/README.md
@@ -115,7 +115,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-helloworld
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: task-openwhisk
     trigger:
@@ -308,7 +308,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-helloworld-with-params
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: task-openwhisk
     trigger:
@@ -408,7 +408,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-raw-github
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: openwhisk
     trigger:
@@ -511,7 +511,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-zip
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: openwhisk
     trigger:

--- a/openwhisk/runtimes/javascript/examples/01-helloworld/taskrun-helloworld.yaml.tmpl
+++ b/openwhisk/runtimes/javascript/examples/01-helloworld/taskrun-helloworld.yaml.tmpl
@@ -30,7 +30,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-helloworld
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: openwhisk
     trigger:

--- a/openwhisk/runtimes/javascript/examples/02-json-in-json-out/taskrun-helloworld-with-params.yaml.tmpl
+++ b/openwhisk/runtimes/javascript/examples/02-json-in-json-out/taskrun-helloworld-with-params.yaml.tmpl
@@ -30,7 +30,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-helloworld-with-params
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: openwhisk
     trigger:

--- a/openwhisk/runtimes/javascript/examples/03-github/taskrun-raw-github.yaml.tmpl
+++ b/openwhisk/runtimes/javascript/examples/03-github/taskrun-raw-github.yaml.tmpl
@@ -30,7 +30,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-raw-github
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: openwhisk
     trigger:

--- a/openwhisk/runtimes/javascript/examples/04-zip/taskrun-zip.yaml.tmpl
+++ b/openwhisk/runtimes/javascript/examples/04-zip/taskrun-zip.yaml.tmpl
@@ -30,7 +30,7 @@ kind: TaskRun
 metadata:
     name: openwhisk-nodejs-zip
 spec:
-    serviceAccount: openwhisk-runtime-builder
+    serviceAccountName: openwhisk-runtime-builder
     taskRef:
         name: openwhisk
     trigger:

--- a/s2i/README.md
+++ b/s2i/README.md
@@ -73,7 +73,7 @@ metadata:
   name: s2i-nodejs-taskrun
 spec:
   # Use service account with git and image repo credentials
-  serviceAccount: pipeline
+  serviceAccountName: pipeline
   taskRef:
     name: s2i
   inputs:

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -24,6 +24,7 @@
 # Markdown linting failures don't show up properly in Gubernator resulting
 # in a net-negative contributor experience.
 export DISABLE_MD_LINTING=1
+export DISABLE_MD_LINK_CHECK=1
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`serviceAccount` is deprecated and now invalid (starting from 0.9.0),
so removing it from the examples.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @chmouel @bobcatfish @ImJasonH 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
