### PR TITLE
Add Github set-status and add-comment tasks

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -5,9 +5,9 @@ API](https://developer.github.com/v3/).
 
 ## GitHub token
 
-Most tasks would expect to have a secret set in the github secret `github-secret`
-with a GitHub token in the key `secretToken`, you can easily create it on the
-command line :
+Most tasks would expect to have a secret set in the kubernetes secret `github-secret`
+with a GitHub token in the key `token`, you can easily create it on the
+command line with `kubectl` like this :
 
 ```
 kubectl create secret generic github --from-literal token="MY_TOKEN"
@@ -73,4 +73,55 @@ spec:
         value: pending
       - name: TARGET_URL
         value: https://tekon/dashboard/taskrun/log
+```
+
+## Add a comment to an issue or a pull request
+
+The `github-add-comment` task let you add a comment to a pull request or an
+issue.
+
+### Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/github/add_comment.yaml
+```
+
+### Inputs
+
+#### Parameters
+
+* **GITHUB_HOST_URL:**: The GitHub host domain (_default:_ `api.github.com`)
+* **REQUEST_NAME:**: The GitHub pull request or issue url, e.g:
+  _https://github.com/tektoncd/catalog/issues/46_
+* **COMMENT:**: The actual comment to add (_default_: `don't forget to eat your vegetables before commiting.`)
+
+## Usage
+
+This TaskRun runs the Task to add a comment to an issue
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: github-add-comment
+  name: github-add-comment-to-pr-22
+spec:
+  taskRef:
+    kind: Task
+    name: github-add-comment
+  inputs:
+    params:
+      - name: REQUEST_URL
+        value: https://github.com/chmouel/scratchpad/pull/46
+      - name: COMMENT
+        value: |
+            The cat went here and there
+            And the moon spun round like a top,
+            And the nearest kin of the moon,
+            The creeping cat, looked up.
+            Black Minnaloushe stared at the moon,
+            For, wander and wail as he would,
+            The pure cold light in the sky
+            Troubled his animal blood.
 ```

--- a/github/README.md
+++ b/github/README.md
@@ -1,0 +1,76 @@
+# GitHub
+
+A collection of tasks to help working with the [GitHub
+API](https://developer.github.com/v3/).
+
+## GitHub token
+
+Most tasks would expect to have a secret set in the github secret `github-secret`
+with a GitHub token in the key `secretToken`, you can easily create it on the
+command line :
+
+```
+kubectl create secret generic github --from-literal token="MY_TOKEN"
+```
+
+## Set Status on a Commit/PR
+
+The `github-set-status` task allows external services to mark GtiHUB commits
+with an `error`, `failure`, `pending`, or `success` state, which is then
+reflected in pull requests involving those commits.
+
+Statuses include as well a `description` and a `target_url`, to give the user
+informations about the CI statuses or a direct link to the full log.
+
+### Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/github/set_status.yaml
+```
+
+### Inputs
+
+#### Parameters
+
+* **REPO_FULL_NAME:**: The GitHub repository full name, e.g: _tektoncd/catalog_
+* **GITHUB_HOST_URL:**: The GitHub host domain (_default:_ `api.github.com`)
+* **SHA:**: The commit SHA to set the status for i.e: _tektoncd/catalog_
+* **TARGET_URL:**: The target URL to associate with this status. This URL will
+  be linked from the GitHub UI to allow users to easily see the source of the
+  status. For example you can link to a
+  [dashboard](https://github.com/tektoncd/dahsboard) URL so users can follow a
+  Pipeline/Task run.
+* **DESCRIPTION:**: A short description of the status. e.g: _"Building your PR"_
+* **CONTEXT:** The GitHub context, A string label to differentiate this status
+  from the status of other systems. e.g: `"continuous-integration/tekton"`
+* **STATE:** The state of the status. Can be one of the following `error`,
+  `failure`, `pending`, or `success`.
+
+## Usage
+
+This TaskRun runs the Task to set a successfull status on a commit
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: github-set-status
+  name: github-set-status-run-on-commit-bd93
+spec:
+  taskRef:
+    kind: Task
+    name: github-set-status
+  inputs:
+    params:
+      - name: REPO_FULL_NAME
+        value: tektoncd/catalog
+      - name: SHA
+        value: bd93869b489258cef567ccf85e7ef6bc0d6949ea
+      - name: DESCRIPTION
+        value: "Build has started"
+      - name: STATE
+        value: pending
+      - name: TARGET_URL
+        value: https://tekon/dashboard/taskrun/log
+```

--- a/github/add_comment.yaml
+++ b/github/add_comment.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: github-add-comment
+  description: |
+    This Task will add a comment to a pull request or an issue.
+spec:
+  inputs:
+    params:
+      - name: GITHUB_HOST_URL
+        description: |
+          The GitHub host, adjust this if you run a GitHub enteprise.
+        default: "api.github.com"
+
+      - name: REQUEST_URL
+        description: |
+          The GitHub issue or pull request URL where we want to add a new
+          comment.
+
+      - name: COMMENT
+        description: |
+          The actual comment to add.
+  steps:
+    - name: add-comment
+      env:
+        - name: GITHUBTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github
+              key: token
+
+      image: registry.access.redhat.com/ubi8/ubi:latest
+      script: |
+        #!/usr/libexec/platform-python
+        import json
+        import os
+        import http.client
+        import urllib.parse
+
+        split_url = urllib.parse.urlparse(
+            "$(inputs.params.REQUEST_URL)").path.split("/")
+
+        # This will convert https://github.com/foo/bar/pull/202 to
+        # api url path /repos/foo/issues/202
+        api_url = "/repos/" + "/".join(split_url[1:3]) + \
+                  "/issues/" + split_url[-1]
+
+        # Trying to avoid quotes issue as much as possible by using triple
+        # quotes
+        comment = """$(inputs.params.COMMENT)"""
+        data = {
+            "body": comment,
+        }
+
+        print("Sending this data to GitHub: ")
+        print(data)
+
+        conn = http.client.HTTPSConnection("$(inputs.params.GITHUB_HOST_URL)")
+        r = conn.request(
+            "POST",
+            api_url + "/comments",
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
+            })
+        resp = conn.getresponse()
+        if not str(resp.status).startswith("2"):
+            print("Error: %d" % (resp.status))
+            print(resp.read())
+        else:
+          print("a GitHub comment has been added to "
+                "$(inputs.params.REQUEST_URL)")

--- a/github/set_status.yaml
+++ b/github/set_status.yaml
@@ -34,7 +34,7 @@ spec:
 
       - name: CONTEXT
         description: |
-          The GitHUB context, A string label to differentiate this status from
+          The GitHub context, A string label to differentiate this status from
           the status of other systems. ie: "continuous-integration/tekton"
         default: "continuous-integration/tekton"
 
@@ -67,7 +67,7 @@ spec:
             "description": "$(inputs.params.DESCRIPTION)",
             "context": "$(inputs.params.CONTEXT)"
         }
-        print("Sending this data to GitHUB: ")
+        print("Sending this data to GitHub: ")
         print(data)
 
         conn = http.client.HTTPSConnection("$(inputs.params.GITHUB_HOST_URL)")

--- a/github/set_status.yaml
+++ b/github/set_status.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: github-set-status
+  description: |
+    This task will set the CI as running and add a link to the openshift console
+    viewer url.
+spec:
+  inputs:
+    params:
+      - name: GITHUB_HOST_URL
+        description: |
+          The GitHub host, adjust this if you run a GitHub enteprise.
+        default: "api.github.com"
+
+      - name: REPO_FULL_NAME
+        description: |
+          The GitHub repository full name, i.e: tektoncd/catalog
+
+      - name: SHA
+        description: |
+          Commit SHA to set the status for.
+
+      - name: TARGET_URL
+        description: |
+          The target URL to associate with this status. This URL will be linked
+          from the GitHub UI to allow users to easily see the source of the
+          status.
+
+      - name: DESCRIPTION
+        description: |
+          A short description of the status.
+
+      - name: CONTEXT
+        description: |
+          The GitHUB context, A string label to differentiate this status from
+          the status of other systems. ie: "continuous-integration/tekton"
+        default: "continuous-integration/tekton"
+
+      - name: STATE
+        description: |
+          The state of the status. Can be one of the following `error`,
+          `failure`, `pending`, or `success`.
+  steps:
+    - name: set-status
+      env:
+        - name: GITHUBTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github
+              key: token
+
+      image: registry.access.redhat.com/ubi8/ubi:latest
+      script: |
+        #!/usr/libexec/platform-python
+        import json
+        import os
+        import http.client
+
+        status_url = "/repos/$(inputs.params.REPO_FULL_NAME)/" + \
+            "statuses/$(inputs.params.SHA)"
+
+        data = {
+            "state": "$(inputs.params.STATE)",
+            "target_url": "$(inputs.params.TARGET_URL)",
+            "description": "$(inputs.params.DESCRIPTION)",
+            "context": "$(inputs.params.CONTEXT)"
+        }
+        print("Sending this data to GitHUB: ")
+        print(data)
+
+        conn = http.client.HTTPSConnection("$(inputs.params.GITHUB_HOST_URL)")
+        r = conn.request(
+            "POST",
+            status_url,
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
+            })
+        resp = conn.getresponse()
+        if not str(resp.status).startswith("2"):
+            print("Error: %d" % (resp.status))
+            print(resp.read())
+        else:
+          print("GitHub status '$(inputs.params.STATE)' has been set on "
+                "$(inputs.params.REPO_FULL_NAME)#$(inputs.params.SHA) ")


### PR DESCRIPTION
Add a github directory with for now only two tasks (more to follow)  allowing to do
different github actions with the API.

I have made those tasks in _pure_ python to be able to use a minimal image and
not have to build one with `hub` or other tools.

The `github-set-status` task allows external services to mark GtiHUB commits
with an `error`, `failure`, `pending`, or `success` state, which is then
reflected in pull requests involving those commits.

The `github-set-status` task allows external services to mark GtiHUB commits
with an `error`, `failure`, `pending`, or `success` state, which is then
reflected in pull requests involving those commits.

The `github-add-comment` task let you add a comment to a pull request or an
xissue.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._