### PR TITLE
Update openshift client task to use script mode

### DIFF
--- a/openshift-client/README.md
+++ b/openshift-client/README.md
@@ -24,11 +24,15 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/opens
 
 * **ARGS:** args to execute which are appended to `oc` e.g. `start-build myapp` (_default_: `help`)
 
+* **SCRIPT:** script of oc commands to execute  e.g. `oc get pod $1 -0 yaml` This will take the first value of ARGS as pod name (_default_: `oc $@`)
+
 ## Inputs `openshift-client-kubecfg`
 
 ### Parameters
 
 * **ARGS:** args to execute which are appended to `oc` e.g. `start-build myapp` (_default_: `help`)
+
+* **SCRIPT:** script of oc commands to execute  e.g. `oc get pod $1 -o yaml` This will take the first value of ARGS as pod name (_default_: `oc $@`)
 
 ### Resources
 
@@ -65,7 +69,6 @@ spec:
 ```
 
 The following `TaskRun` runs the commands against a different cluster than the one the `TaskRun` is running on. The cluster credentials are provided via a `PipelineResource` called `stage-cluster`.
-
 
 ```
 apiVersion: tekton.dev/v1alpha1

--- a/openshift-client/openshift-client-kubecfg-task.yaml
+++ b/openshift-client/openshift-client-kubecfg-task.yaml
@@ -8,6 +8,10 @@ spec:
       - name: cluster
         type: cluster
     params:
+      - name: SCRIPT
+        description: The OpenShift CLI arguments to run
+        type: string
+        default: "oc $@"
       - name: ARGS
         description: The OpenShift CLI arguments to run
         type: array
@@ -16,7 +20,7 @@ spec:
   steps:
     - name: oc
       image: quay.io/openshift/origin-cli:latest
-      command: ["/usr/bin/oc"]
+      script: "$(inputs.params.SCRIPT)"
       args:
         - "--kubeconfig /workspace/$(inputs.resources.cluster.name)/kubeconfig --context $(inputs.resources.cluster.name)"
         - "$(inputs.params.ARGS)"

--- a/openshift-client/openshift-client-task.yaml
+++ b/openshift-client/openshift-client-task.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   inputs:
     params:
+      - name: SCRIPT
+        description: The OpenShift CLI arguments to run
+        type: string
+        default: "oc $@"
       - name: ARGS
         description: The OpenShift CLI arguments to run
         type: array
@@ -13,6 +17,6 @@ spec:
   steps:
     - name: oc
       image: quay.io/openshift/origin-cli:latest
-      command: ["/usr/bin/oc"]
+      script: "$(inputs.params.SCRIPT)"
       args:
         - "$(inputs.params.ARGS)"


### PR DESCRIPTION
This will update openshift-client to be used in script mode

This will help to pass multiple commands or parametrized
commands in a single taskrun

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
