### PR TITLE
Add Jib Gradle catalog / fix Docker config issue for Jib Maven

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,7 +56,7 @@ test resources (`PipelineResource`) and a yaml files to run the tasks
 
 Sometime you may need to be able to launch some scripts before applying the
 tested task or the other yaml files. Some may pre-setup something on the
-`Namespace` or have to do something externally or sometime you may even want to do
+`Namespace` or have to do something externally or sometimes you may even want to do
 some manipulation of the main `Task`.
 
 For example on the *image builders* tasks like `kaniko` or `jib` we want to

--- a/jib-gradle/README.md
+++ b/jib-gradle/README.md
@@ -1,0 +1,75 @@
+# Jib Gradle
+
+This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google's [Jib](https://github.com/GoogleContainerTools/jib) tool.
+
+Jib works with [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin) and [Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin) projects, and this template is for Gradle projects.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/jib-gradle/jib-gradle.yaml
+```
+
+## Inputs
+
+### Parameters
+
+- **DIRECTORY**: The directory in the source repository where source should be found. (*default: .*)
+- **CACHE**: The name of the volume for caching Gradle artifacts, local Maven repository, and base image layers (*default: empty-dir-volume*)
+
+### Resources
+
+* **source**: A `git`-type `PipelineResource` specifying the location of the
+  source to build.
+
+## Outputs
+
+### Resources
+
+* **image**: The Docker image name to apply to the newly built image.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Jib (Gradle)
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: example-image
+spec:
+  type: image
+  params:
+  - name: url
+    value: gcr.io/tekton-task-project/my-image
+```
+
+```
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: example-jib-gradle
+spec:
+  taskRef:
+    name: jib-gradle
+  inputs:
+    params:
+    - name: DIRECTORY
+      value: ./examples/helloworld
+    resources:
+    - name: source
+      resourceSpec:
+        type: git
+        params:
+        - name: url
+          value: https://github.com/my-user/my-repo
+  outputs:
+    resources:
+    - name: image
+      resourceRef:
+        name: example-image
+```
+
+If you would like to customize the container, configure the `jib-gradle-plugin` in your `build.gradle`. 
+See [setup instructions for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#setup) for more information.

--- a/jib-gradle/jib-gradle.yaml
+++ b/jib-gradle/jib-gradle.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: jib-gradle
+spec:
+  inputs:
+    params:
+    - name: DIRECTORY
+      description: The directory containing the app, relative to the source repository root
+      default: .
+    - name: CACHE
+      description: The name of the volume for caching Gradle artifacts, local Maven repository, and base image layers
+      default: empty-dir-volume
+    - name: INSECUREREGISTRY
+      description: Whether to allow insecure registry
+      default: "false"
+    resources:
+    - name: source
+      type: git
+  outputs:
+    resources:
+    - name: image
+      type: image
+  steps:
+  - name: build-and-push
+    image: gcr.io/cloud-builders/gradle
+    command: ["sh", "-c"]
+    args:
+      - |
+        # Adds Gradle init script that applies the Jib Gradle plugin.
+        echo "initscript {
+                repositories { maven { url 'https://plugins.gradle.org/m2' } }
+                dependencies { classpath 'gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:+' }
+              }
+              rootProject {
+                afterEvaluate {
+                  if (!project.plugins.hasPlugin('com.google.cloud.tools.jib')) {
+                    project.apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
+                  }
+                }
+              }" > /tekton/home/init-script.gradle
+        # Runs the Gradle Jib build.
+        gradle jib \
+          --stacktrace --console=plain \
+          --init-script=/tekton/home/init-script.gradle \
+          -Duser.home=/tekton/home \
+          -Dgradle.user.home=/tekton/home/.gradle \
+          -Djib.allowInsecureRegistries=$(inputs.params.INSECUREREGISTRY) \
+          -Djib.to.image=$(outputs.resources.image.url)
+    workingDir: /workspace/source/$(inputs.params.DIRECTORY)
+    volumeMounts:
+    - name: $(inputs.params.CACHE)
+      mountPath: /tekton/home/.gradle/caches
+      subPath: gradle-caches
+    - name: $(inputs.params.CACHE)
+      mountPath: /tekton/home/.gradle/wrapper
+      subPath: gradle-wrapper
+    - name: $(inputs.params.CACHE)
+      mountPath: /tekton/home/.m2
+      subPath: m2-cache
+    - name: $(inputs.params.CACHE)
+      mountPath: /tekton/home/.cache
+      subPath: jib-cache
+
+  volumes:
+  - name: empty-dir-volume
+    emptyDir: {}

--- a/jib-gradle/jib-gradle.yaml
+++ b/jib-gradle/jib-gradle.yaml
@@ -24,29 +24,29 @@ spec:
   steps:
   - name: build-and-push
     image: gcr.io/cloud-builders/gradle
-    command: ["sh", "-c"]
-    args:
-      - |
-        # Adds Gradle init script that applies the Jib Gradle plugin.
-        echo "initscript {
-                repositories { maven { url 'https://plugins.gradle.org/m2' } }
-                dependencies { classpath 'gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:+' }
-              }
-              rootProject {
-                afterEvaluate {
-                  if (!project.plugins.hasPlugin('com.google.cloud.tools.jib')) {
-                    project.apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
-                  }
+    script: |
+      #!/bin/sh
+      set -o errexit
+      # Adds Gradle init script that applies the Jib Gradle plugin.
+      echo "initscript {
+              repositories { maven { url 'https://plugins.gradle.org/m2' } }
+              dependencies { classpath 'gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:+' }
+            }
+            rootProject {
+              afterEvaluate {
+                if (!project.plugins.hasPlugin('com.google.cloud.tools.jib')) {
+                  project.apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
                 }
-              }" > /tekton/home/init-script.gradle
-        # Runs the Gradle Jib build.
-        gradle jib \
-          --stacktrace --console=plain \
-          --init-script=/tekton/home/init-script.gradle \
-          -Duser.home=/tekton/home \
-          -Dgradle.user.home=/tekton/home/.gradle \
-          -Djib.allowInsecureRegistries=$(inputs.params.INSECUREREGISTRY) \
-          -Djib.to.image=$(outputs.resources.image.url)
+              }
+            }" > /tekton/home/init-script.gradle
+      # Runs the Gradle Jib build.
+      gradle jib \
+        --stacktrace --console=plain \
+        --init-script=/tekton/home/init-script.gradle \
+        -Duser.home=/tekton/home \
+        -Dgradle.user.home=/tekton/home/.gradle \
+        -Djib.allowInsecureRegistries=$(inputs.params.INSECUREREGISTRY) \
+        -Djib.to.image=$(outputs.resources.image.url)
     workingDir: /workspace/source/$(inputs.params.DIRECTORY)
     volumeMounts:
     - name: $(inputs.params.CACHE)

--- a/jib-gradle/tests/pre-apply-task-hook.sh
+++ b/jib-gradle/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests withouth having to go to an external registry.
+add_sidecar_registry ${TMPF}

--- a/jib-gradle/tests/resources.yaml
+++ b/jib-gradle/tests/resources.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: console-java-simple
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/che-samples/console-java-simple
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: image
+spec:
+  type: image
+  params:
+    - name: url
+      value: localhost:5000/tekton-pipelines/console-java-simple

--- a/jib-gradle/tests/run.yaml
+++ b/jib-gradle/tests/run.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: jib-gradle-run
+spec:
+  taskRef:
+    name: jib-gradle
+  outputs:
+    resources:
+      - name: image
+        resourceRef:
+          name: image
+  inputs:
+    resources:
+      - name: source
+        resourceRef:
+          name: console-java-simple
+    params:
+      - name: INSECUREREGISTRY
+        value: "true"

--- a/jib-maven/jib-maven.yaml
+++ b/jib-maven/jib-maven.yaml
@@ -12,7 +12,7 @@ spec:
       description: The name of the volume for caching Maven artifacts and base image layers
       default: empty-dir-volume
     - name: INSECUREREGISTRY
-      description: Wether to allow insecure registry
+      description: Whether to allow insecure registry
       default: "false"
     resources:
     - name: source
@@ -26,18 +26,19 @@ spec:
     image: gcr.io/cloud-builders/mvn
     command:
     - mvn
+    - -B
     - compile
     - com.google.cloud.tools:jib-maven-plugin:build
-    - -Duser.home=/builder/home
+    - -Duser.home=/tekton/home
     - -Djib.allowInsecureRegistries=$(inputs.params.INSECUREREGISTRY)
-    - -Dimage=$(outputs.resources.image.url)
+    - -Djib.to.image=$(outputs.resources.image.url)
     workingDir: /workspace/source/$(inputs.params.DIRECTORY)
     volumeMounts:
     - name: $(inputs.params.CACHE)
-      mountPath: /builder/home/.m2
+      mountPath: /tekton/home/.m2
       subPath: m2-cache
     - name: $(inputs.params.CACHE)
-      mountPath: /builder/home/.cache
+      mountPath: /tekton/home/.cache
       subPath: jib-cache
 
   volumes:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add Jib Gradle catalog / fix Docker config issue for Jib Maven

- Add Jib Gradle catalog: counterpart of Jib Maven.
- Change the user home inside JVM from `/builder/home` to `/tekton/home` in Jib Maven
   - See: https://github.com/tektoncd/pipeline/issues/2013#issuecomment-585908031
- Run Jib Maven in batch mode (`mvn -B ...`)

(@GoogleContainerTools/java-tools-build FYI)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
