### PR TITLE
git-clone: Pass depth and sslVerify params to args

### DIFF
--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -40,12 +40,14 @@ spec:
     script: |
       CHECKOUT_DIR="$(workspaces.output.path)/$(inputs.params.subdirectory)"
       /ko-app/git-init \
-        -url $(inputs.params.url) \
-        -revision $(inputs.params.revision) \
+        -url "$(inputs.params.url)" \
+        -revision "$(inputs.params.revision)" \
         -path "$CHECKOUT_DIR" \
-        -submodules $(inputs.params.submodules)
+        -sslVerify "$(inputs.params.sslVerify)" \
+        -submodules "$(inputs.params.submodules)" \
+        -depth "$(inputs.params.depth)"
       cd $CHECKOUT_DIR
-      RESULT_SHA=$(git rev-parse HEAD | tr -d '\n')
+      RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
       EXIT_CODE="$?"
       if [ "$EXIT_CODE" != 0 ]
       then


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

I accidentally missed passing these two params to the flags of git-init.

This PR passes the params as expected.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
