### PR TITLE
Rewrite git-clone as shell script

### DIFF
--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -40,42 +40,78 @@ spec:
     description: The precise commit SHA that was fetched by this Task
   steps:
   - name: clone
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    image: alpine/git:latest
     script: |
+      #!/usr/bin/env sh
+      # Most errors handling are handled by the set -eux
+      set -eux
       CHECKOUT_DIR="$(workspaces.output.path)/$(inputs.params.subdirectory)"
+      URL="$(inputs.params.url)"
+      REVISION="$(inputs.params.revision)"
+      SUBMODULES="$(inputs.params.submodules)"
+      SSLVERIFY="$(inputs.params.sslVerify)"
+      DEPTH="$(inputs.params.depth)"
 
-      cleandir() {
-        # Delete any existing contents of the repo directory if it exists.
-        #
-        # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
-        # or the root of a mounted volume.
-        if [[ -d "$CHECKOUT_DIR" ]] ; then
-          # Delete non-hidden files and directories
-          rm -rf "$CHECKOUT_DIR"/*
-          # Delete files and directories starting with . but excluding ..
-          rm -rf "$CHECKOUT_DIR"/.[!.]*
-          # Delete files and directories starting with .. plus any other character
-          rm -rf "$CHECKOUT_DIR"/..?*
-        fi
+      [[ "$(inputs.params.deleteExisting)" == "true" && -d ${CHECKOUT_DIR} ]] && {
+        find ${CHECKOUT_DIR}/|grep -v "^${CHECKOUT_DIR}/$"|xargs  rm -rf
       }
 
-      if [[ "$(inputs.params.deleteExisting)" == "true" ]] ; then
-        cleandir
-      fi
+      # https://git.io/JvBCV
+      ensureHomeEnv() {
+          local realhomedir=$(getent passwd $(whoami)|cut -f6 -d:)
+          if [[ ! -d ${realhomedir} ]];then
+              mkdir -p ${realhomedir}
+          fi
 
-      /ko-app/git-init \
-        -url "$(inputs.params.url)" \
-        -revision "$(inputs.params.revision)" \
-        -path "$CHECKOUT_DIR" \
-        -sslVerify "$(inputs.params.sslVerify)" \
-        -submodules "$(inputs.params.submodules)" \
-        -depth "$(inputs.params.depth)"
-      cd "$CHECKOUT_DIR"
-      RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
-      EXIT_CODE="$?"
-      if [ "$EXIT_CODE" != 0 ]
-      then
-        exit $EXIT_CODE
-      fi
-      # Make sure we don't add a trailing newline to the result!
-      echo -n "$RESULT_SHA" > $(results.commit.path)
+          if [[ ${realhomedir} == ${HOME} ]];then
+              return
+          fi
+
+          if [[ ! -e ${realhomedir}/.ssh && -w ${realhomedir}/.ssh ]];then
+              ln -svf ${HOME}/.ssh ${realhomedir}/.ssh
+          fi
+      }
+
+      # https://git.io/JvBCr
+      fetch() {
+          local revision=${REVISION:-master}
+          [[ -n ${CHECKOUT_DIR} ]] && {
+            mkdir -p ${CHECKOUT_DIR}
+            cd ${CHECKOUT_DIR}
+          }
+
+          git init .
+
+          trimmedURL=$(echo ${URL}|sed -e 's/^[ ]*//' -e 's/[ ]*$//')
+          git remote add origin ${trimmedURL}
+
+          git config http.sslVerify ${SSLVERIFY}
+
+          fetchArgs="fetch"
+          if [[ ${DEPTH} > 0 ]];then
+              fetchArgs="${fetchArgs} --tags  --depth=${DEPTH}"
+          fi
+
+          # Translating original go code from https://git.io/JvEtG
+          # original comment: Fetch can fail if an old commitid was used so try
+          # git pull, performing regardless of error as no guarantee that the
+          # same error is returned by all git servers gitlab, github etc...
+          if git ${fetchArgs} && git reset --hard ${revision};then
+             true
+          else
+              git reset --hard FETCH_HEAD
+          fi
+
+          if [[ ${SUBMODULES} == "true" || ${SUBMODULES} == "yes" ]];then
+              git submodule init
+              git submodule update --recursive
+              git submodule status
+          fi
+
+          echo "Successfully cloned ${trimmedURL} @ ${revision} in path $(readlink -f .)"
+      }
+
+      ensureHomeEnv
+      fetch
+
+      git rev-parse HEAD | tr -d '\n' > "$(results.commit.path)"

--- a/git/tests/run.yaml
+++ b/git/tests/run.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-clone-run-noargs
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-clone-run-tag
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: revision
+        value: 1.0.0
+
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-submodules
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/githubtraining/example-dependency
+      - name: submodules
+        value: "false"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-depth-2
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: depth
+        value: "2"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-clone-run-sslverify-none
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: sslVerify
+        value: "false"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-clone-run-subdirectory
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: "hellomoto"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-clone-run-delete-existing
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: deleteExisting
+        value: "true"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -75,7 +75,7 @@ function show_failure() {
     echo "--- TR Dump"
     kubectl get -n ${tns} tr -o yaml
     echo "--- Container Logs"
-    kubectl get pod -o name -n ${tns}|xargs kubectl logs --all-containers -n ${tns}
+    kubectl get pod -o name -n ${tns}|sed 's,.*/,,'|xargs kubectl logs --all-containers -n ${tns}
     exit 1
 
 }


### PR DESCRIPTION
We are rewritting git-clone as a 'pure' bourne shell script with no dependence
on the git-init image.

I have rewritten almost word by word the go code from here https://git.io/JvBCr

Error handling are handled by shell's set -e so if any command fails it will
just exit 1,

There is some bugs in go code submodules which is done always so i have handled
this differently to properly be conditional to the parameter.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._