### PR TITLE
Default kn image to the latest released version

### DIFF
--- a/kn/kn.yaml
+++ b/kn/kn.yaml
@@ -7,7 +7,7 @@ spec:
     params:
     - name: kn-image
       description: kn CLI container image to run this task
-      default: gcr.io/knative-releases/knative.dev/client/cmd/kn:v0.10.0
+      default: gcr.io/knative-releases/knative.dev/client/cmd/kn:latest
     - name: ARGS
       type: array
       description: kn CLI arguments to run


### PR DESCRIPTION
# Changes
- Use `latest` tag for kn image at https://gcr.io/knative-releases/knative.dev/client/cmd/kn
 which points to the latest released version of kn.
- User can still parameterize the kn image to use, for example nightly build of kn image
 at https://gcr.io/knative-nightly/knative.dev/client/cmd/kn:latest

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
