### PR TITLE
Github Enterprise support for github tasks

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -5,7 +5,7 @@ API](https://developer.github.com/v3/).
 
 ## GitHub token
 
-Most tasks would expect to have a secret set in the kubernetes secret `github-secret`
+Most tasks would expect to have a secret set in the kubernetes secret `github`
 with a GitHub token in the key `token`, you can easily create it on the
 command line with `kubectl` like this :
 
@@ -34,6 +34,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/githu
 
 * **REPO_FULL_NAME:**: The GitHub repository full name, _e.g:_ `tektoncd/catalog`
 * **GITHUB_HOST_URL:**: The GitHub host domain _default:_ `api.github.com`
+* **API_PATH_PREFIX:**: The GitHub Enterprise has a prefix for the API path. _e.g:_ `/api/v3`
 * **SHA:**: The commit SHA to set the status for _e.g_: `tektoncd/catalog`
 * **TARGET_URL:**: The target URL to associate with this status. This URL will
   be linked from the GitHub UI to allow users to easily see the source of the
@@ -92,6 +93,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/githu
 #### Parameters
 
 * **GITHUB_HOST_URL:**: The GitHub host domain (_default:_ `api.github.com`)
+* **API_PATH_PREFIX:**: The GitHub Enterprise has a prefix for the API path. _e.g:_ `/api/v3`
 * **REQUEST_URL:**: The GitHub pull request or issue url, _e.g:_
   `https://github.com/tektoncd/catalog/issues/46`
 * **COMMENT:**: The actual comment to add _e.g:_ `don't forget to eat your vegetables before commiting.`.
@@ -144,6 +146,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/githu
 #### Parameters
 
 * **GITHUB_HOST_URL:**: The GitHub host domain (_default:_ `api.github.com`)
+* **API_PATH_PREFIX:**: The GitHub Enterprise has a prefix for the API path. _e.g:_ `/api/v3`
 * **REQUEST_URL:**: The GitHub pull request or issue url, (_e.g:_
   `https://github.com/tektoncd/catalog/issues/46`)
 

--- a/github/add_comment.yaml
+++ b/github/add_comment.yaml
@@ -12,15 +12,24 @@ spec:
         description: |
           The GitHub host, adjust this if you run a GitHub enteprise.
         default: "api.github.com"
+        type: string
+
+      - name: API_PATH_PREFIX
+        description: |
+          The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+        default: ""
+        type: string
 
       - name: REQUEST_URL
         description: |
           The GitHub issue or pull request URL where we want to add a new
           comment.
+        type: string
 
       - name: COMMENT
         description: |
           The actual comment to add.
+        type: string
   steps:
     - name: add-comment
       env:
@@ -43,7 +52,7 @@ spec:
 
         # This will convert https://github.com/foo/bar/pull/202 to
         # api url path /repos/foo/issues/202
-        api_url = "/repos/" + "/".join(split_url[1:3]) + \
+        api_url = "$(inputs.params.API_PATH_PREFIX)" + "/repos/" + "/".join(split_url[1:3]) + \
                   "/issues/" + split_url[-1]
 
         # Trying to avoid quotes issue as much as possible by using triple

--- a/github/close_issue.yaml
+++ b/github/close_issue.yaml
@@ -12,11 +12,19 @@ spec:
         description: |
           The GitHub host, adjust this if you run a GitHub enteprise.
         default: "api.github.com"
+        type: string
+
+      - name: API_PATH_PREFIX
+        description: |
+          The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+        default: ""
+        type: string
 
       - name: REQUEST_URL
         description: |
           The GitHub issue or pull request URL where we want to add a new
           comment.
+        type: string
   steps:
     - name: close-issue
       env:
@@ -39,7 +47,7 @@ spec:
 
         # This will convert https://github.com/foo/bar/pull/202 to
         # api url path /repos/foo/issues/202
-        api_url = "/repos/" + "/".join(split_url[1:3]) + \
+        api_url = "$(inputs.params.API_PATH_PREFIX)" + "/repos/" + "/".join(split_url[1:3]) + \
                   "/issues/" + split_url[-1]
 
         # Trying to avoid quotes issue as much as possible by using triple

--- a/github/set_status.yaml
+++ b/github/set_status.yaml
@@ -13,35 +13,48 @@ spec:
         description: |
           The GitHub host, adjust this if you run a GitHub enteprise.
         default: "api.github.com"
+        type: string
+
+      - name: API_PATH_PREFIX
+        description: |
+          The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+        default: ""
+        type: string
 
       - name: REPO_FULL_NAME
         description: |
           The GitHub repository full name, i.e: tektoncd/catalog
+        type: string
 
       - name: SHA
         description: |
           Commit SHA to set the status for.
+        type: string
 
       - name: TARGET_URL
         description: |
           The target URL to associate with this status. This URL will be linked
           from the GitHub UI to allow users to easily see the source of the
           status.
+        type: string
 
       - name: DESCRIPTION
         description: |
           A short description of the status.
+        type: string
 
       - name: CONTEXT
         description: |
           The GitHub context, A string label to differentiate this status from
           the status of other systems. ie: "continuous-integration/tekton"
         default: "continuous-integration/tekton"
+        type: string
 
       - name: STATE
         description: |
           The state of the status. Can be one of the following `error`,
           `failure`, `pending`, or `success`.
+        type: string
   steps:
     - name: set-status
       env:
@@ -58,7 +71,7 @@ spec:
         import os
         import http.client
 
-        status_url = "/repos/$(inputs.params.REPO_FULL_NAME)/" + \
+        status_url = "$(inputs.params.API_PATH_PREFIX)" + "/repos/$(inputs.params.REPO_FULL_NAME)/" + \
             "statuses/$(inputs.params.SHA)"
 
         data = {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Three changes.

1. Add API_PATH_PREFIX parameter to each task. The Github Enterprise has `/api/v3` prefix between the host URL and the API path.
1. Correct github secret name in the README
1. Add `type: string` to all parameter definition.  This is not always necessary but useful sometimes.
 
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
