### PR TITLE
Fix jib-gradle task

### DIFF
--- a/jib-gradle/jib-gradle.yaml
+++ b/jib-gradle/jib-gradle.yaml
@@ -42,6 +42,7 @@ spec:
       # Runs the Gradle Jib build.
       gradle jib \
         --stacktrace --console=plain \
+        -g gradle-user-home \
         --init-script=/tekton/home/init-script.gradle \
         -Duser.home=/tekton/home \
         -Dgradle.user.home=/tekton/home/.gradle \


### PR DESCRIPTION
This wil fix the issue jib gradle task
gettng failed on security constrained
environments like OpenShift

Fix #198

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
