### PR TITLE
Create OWNERS from jib team

### DIFF
--- a/jib-gradle/OWNERS
+++ b/jib-gradle/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- loosebazooka
+- chanseokoh
+- briandealwis
+
+reviewers:
+- loosebazooka
+- chanseokoh
+- briandealwis

--- a/jib-maven/OWNERS
+++ b/jib-maven/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- loosebazooka
+- chanseokoh
+- briandealwis
+
+reviewers:
+- loosebazooka
+- chanseokoh
+- briandealwis


### PR DESCRIPTION
Add OWNERS to jib catalog entries (https://github.com/GoogleContainerTools/jib)

With guidance from @bobcatfish 
