### PR TITLE
Add a delete param to the git-clone task for reusing PVCs

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -35,20 +35,11 @@ as well as
 * **depth**: performs a shallow clone where only the most recent commit(s) will be fetched (_default_: 1)
 * **sslVerify**: defines if http.sslVerify should be set to true or false in the global git config (_default_: true)
 * **subdirectory**: subdirectory inside the "output" workspace to clone the git repo into (_default:_ src)
+* **deleteExisting**: clean out the contents of the repo's destination directory if it already exists before cloning the repo there (_default_: false)
 
 ### Results
 
 * **commit**: The precise commit SHA that was fetched by this Task
-
-### Notes On Usage
-
-Please ensure that the Workspace subdirectory you are cloning into is *empty*
-before giving the Workspace to this Task. The `git-init` binary that this task
-uses to perform a clone will error out if the directory you're cloning into is
-already a git repo. This problem can appear when you reuse a directory on a
-`PersistentVolumeClaim` as the "output" workspace multiple times. The current
-suggested workaround is to add a Task before git-clone that "cleans" the
-workspace first by running `rm -rf` on the directory if it exists.
 
 ## Usage
 

--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -31,6 +31,10 @@ spec:
       description: subdirectory inside the "output" workspace to clone the git repo into
       type: string
       default: "src"
+    - name: deleteExisting
+      description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
+      type: string
+      default: "false"
   results:
   - name: commit
     description: The precise commit SHA that was fetched by this Task
@@ -39,6 +43,27 @@ spec:
     image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
     script: |
       CHECKOUT_DIR="$(workspaces.output.path)/$(inputs.params.subdirectory)"
+
+      cleandir() {
+        # Delete any existing contents of the repo directory if it exists.
+        #
+        # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+        # or the root of a mounted volume.
+        if [[ -d "$CHECKOUT_DIR" ]] ; then
+          # Delete non-hidden files and directories
+          rm -rf "$CHECKOUT_DIR"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "$CHECKOUT_DIR"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "$CHECKOUT_DIR"/..?*
+        fi
+      }
+
+      if [[ "$(inputs.params.deleteExisting)" == "true" ]] ; then
+        cleandir
+        ls -lah "$CHECKOUT_DIR"
+      fi
+
       /ko-app/git-init \
         -url "$(inputs.params.url)" \
         -revision "$(inputs.params.revision)" \
@@ -46,7 +71,7 @@ spec:
         -sslVerify "$(inputs.params.sslVerify)" \
         -submodules "$(inputs.params.submodules)" \
         -depth "$(inputs.params.depth)"
-      cd $CHECKOUT_DIR
+      cd "$CHECKOUT_DIR"
       RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
       EXIT_CODE="$?"
       if [ "$EXIT_CODE" != 0 ]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

An implementation detail of the git-clone task in the catalog: it fails
if the directory it's cloning into is already a git repo. This behaviour
has been carried over from the GitResource. Prior to this commit the
advice for users was to manually delete the directory themselves before
running this Task.

This PR introduces a param that, when set to "true", will empty the
directory of any files and folders before performing the clone.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.