### PR TITLE
Don't change Gradle home in jib-gradle

### DIFF
--- a/jib-gradle/jib-gradle.yaml
+++ b/jib-gradle/jib-gradle.yaml
@@ -42,7 +42,6 @@ spec:
       # Runs the Gradle Jib build.
       gradle jib \
         --stacktrace --console=plain \
-        -g gradle-user-home \
         --init-script=/tekton/home/init-script.gradle \
         -Duser.home=/tekton/home \
         -Dgradle.user.home=/tekton/home/.gradle \


### PR DESCRIPTION
@piyush-garg @hrishin 

# Changes

Reverting the Gradle home change introduced in #199.

As explained in #199, the change is in conflict with `-Dgradle.user.home=/tekton/home/.gradle`, and this actually breaks caching. I am certain that changing the Gradle home is not the right solution for #198.

@piyush-garg @hrishin I do not know what exactly the "security constraint" issue, but we should implement a proper fix after understanding the issue. Please reopen #198.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
