### PR TITLE
Use golang instead of bazel in catalog README 📎

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,16 @@ There are two kinds of `Task`s:
 First, install a `Task` onto your cluster:
 
 ```
-$ kubectl apply -f bazel.yaml
-task.tekton.dev/bazel created
+$ kubectl apply -f golang/build.yaml
+task.tekton.dev/golang-build created
 ```
 
 You can see which `Task`s are installed using `kubectl` as well:
 
 ```
 $ kubectl get tasks
-NAME    AGE
-bazel   3s
-```
-
-*OR*
-
-```
-$ kubectl get clustertasks
-NAME            AGE
-cluster-bazel   3s
+NAME           AGE
+golang-build   3s
 ```
 
 With the `Task` installed, you can define a `TaskRun` that runs that `Task`,
@@ -56,18 +48,18 @@ metadata:
   name: example-run
 spec:
   taskRef:
-    name: bazel
+    name: golang-build
   inputs:
     params:
-    - name: TARGET
-      value: //path/to/image:publish
+    - name: package
+      value: github.com/tektoncd/pipeline
     resources:
     - name: source
       resourceSpec:
         type: git
         params:
         - name: url
-          value: https://github.com/my-user/my-repo
+          value: https://github.com/tektoncd/pipeline
 ```
 
 Next, create the `TaskRun` you defined:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
We don't have a `bazel` task in the catalog. Switch to use
`golang-build` with `tektoncd/pipeline` as source.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sbwsg @chmouel @bobcatfish 

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
