### PR TITLE
Run jib-gradle as root

### DIFF
--- a/jib-gradle/jib-gradle.yaml
+++ b/jib-gradle/jib-gradle.yaml
@@ -61,6 +61,8 @@ spec:
     - name: $(inputs.params.CACHE)
       mountPath: /tekton/home/.cache
       subPath: jib-cache
+    securityContext:
+      runAsUser: 0
 
   volumes:
   - name: empty-dir-volume


### PR DESCRIPTION
This will fix the issue of task not
working on OpenShift as it needs root access and
by default on OpenShift pod run as nonroot

Fix #198 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
