### PR TITLE
Migrate GitResources to workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,20 @@ With the `Task` installed, you can define a `TaskRun` that runs that `Task`,
 being sure to provide values for required input parameters and resources:
 
 ```
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: example-run
 spec:
   taskRef:
     name: golang-build
-  inputs:
-    params:
-    - name: package
-      value: github.com/tektoncd/pipeline
-    resources:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/tektoncd/pipeline
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
 ```
 
 Next, create the `TaskRun` you defined:
@@ -73,7 +69,7 @@ You can check the status of the `TaskRun` using `kubectl`:
 
 ```
 $ kubectl get taskrun example-run -oyaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: example-run

--- a/buildah/README.md
+++ b/buildah/README.md
@@ -24,12 +24,12 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
   non-TLS registry) (_default:_ `true`)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
+
+## Resources
 
 ### Outputs
 
@@ -49,14 +49,11 @@ metadata:
 spec:
   taskRef:
     name: buildah
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/my-user/my-repo
     outputs:
     - name: image
       resourceSpec:

--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -17,10 +17,9 @@ spec:
   - name: TLSVERIFY
     description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
     default: "true"
+  workspaces:
+  - name: source
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
@@ -28,7 +27,7 @@ spec:
   steps:
   - name: build
     image: $(params.BUILDER_IMAGE)
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(resources.outputs.image.url)', '$(params.CONTEXT)']
     volumeMounts:
     - name: varlibcontainers
@@ -38,7 +37,7 @@ spec:
 
   - name: push
     image: $(params.BUILDER_IMAGE)
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
     volumeMounts:
     - name: varlibcontainers

--- a/buildah/tests/pre-apply-task-hook.sh
+++ b/buildah/tests/pre-apply-task-hook.sh
@@ -1,5 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Add an internal registry as sidecar to the task so we can upload it directly
-# from our tests withouth having to go to an external registry.
+# from our tests without having to go to an external registry.
 add_sidecar_registry ${TMPF}
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/buildah/tests/resources.yaml
+++ b/buildah/tests/resources.yaml
@@ -2,21 +2,20 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: nocode
-spec:
-  type: git
-  params:
-    - name: revision
-      value: master
-    - name: url
-      value: https://github.com/kelseyhightower/nocode
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
   name: image
 spec:
   type: image
   params:
     - name: url
       value: localhost:5000/nocode
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildah-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/buildah/tests/run.yaml
+++ b/buildah/tests/run.yaml
@@ -1,20 +1,56 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: Pipeline
 metadata:
-  name: buildah-run
+  name: buildah-test-pipeline
 spec:
-  taskRef:
-    name: buildah
+  workspaces:
+  - name: shared-workspace
   resources:
-    outputs:
-    - name: image
-      resourceRef:
-        name: image
-    inputs:
+  - name: build-image
+    type: image
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: buildah
+    taskRef:
+      name: buildah
+    runAfter:
+    - fetch-repository
+    workspaces:
     - name: source
-      resourceRef:
-        name: nocode
-  params:
-  - name: TLSVERIFY
-    value: "false"
+      workspace: shared-workspace
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    resources:
+      outputs:
+      - name: image
+        resource: build-image
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildah-test-pipeline-run
+spec:
+  pipelineRef:
+    name: buildah-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: buildah-source-pvc
+  resources:
+  - name: build-image
+    resourceRef:
+      name: image

--- a/buildkit-daemonless/README.md
+++ b/buildkit-daemonless/README.md
@@ -22,11 +22,11 @@ task.tekton.dev/buildkit-daemonless created
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_  `./Dockerfile`)
 * **BUILDKIT_IMAGE**: BuildKit image (_default:_`moby/buildkit:vX.Y.Z@sha256:...`)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the source to build.
+
+## Resources
 
 ### Outputs
 

--- a/buildkit-daemonless/buildkit-daemonless.yaml
+++ b/buildkit-daemonless/buildkit-daemonless.yaml
@@ -12,17 +12,16 @@ spec:
     # The image needs to be rootful because Tekton creates /builder/home/.docker/config.json owned by root:root with 0600
     # https://github.com/tektoncd/pipeline/issues/852
     default: "moby/buildkit:v0.6.2"
+  workspaces:
+  - name: source
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
   steps:
   - name: build-and-push
     image: $(params.BUILDKIT_IMAGE)
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     securityContext:
       privileged: true
     command: ["buildctl-daemonless.sh", "--debug",

--- a/buildkit/README.md
+++ b/buildkit/README.md
@@ -61,11 +61,11 @@ task.tekton.dev/buildkit created
 * **BUILDKIT_CLIENT_CERTS**: The name of Secret that contains `ca.pem`, `cert.pem`, `key.pem`
   for mTLS connection to BuildKit daemon (_default:_`buildkit-client-certs`)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the source to build.
+
+## Resources
 
 ### Outputs
 

--- a/buildkit/task.yaml
+++ b/buildkit/task.yaml
@@ -18,10 +18,9 @@ spec:
   - name: BUILDKIT_CLIENT_CERTS
     description: The name of Secret that contains ca.pem, cert.pem, key.pem for mTLS connection to BuildKit daemon
     default: "buildkit-client-certs"
+  workspaces:
+  - name: source
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
@@ -32,7 +31,7 @@ spec:
   steps:
   - name: build-and-push
     image: $(params.BUILDKIT_CLIENT_IMAGE)
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     volumeMounts:
     - name: certs
       readOnly: true

--- a/buildpacks/README.md
+++ b/buildpacks/README.md
@@ -38,19 +38,19 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 
 ## Resources
 
-### Inputs
-
-* **`source`**: A `git`-type `PipelineResource` specifying the location of the
-  source to build. See `SOURCE_SUBPATH` above if source is located within a subpath of this input.
-
 ### Outputs
 
 * **`image`**: An `image`-type `PipelineResource` specifying the image that should
   be built.
 
+## Workspaces
+
+The `source` workspace holds the source that will be used by buildpack
+to build and publish the container image.
+
 ## Usage
 
-This `TaskRun` will use the `buildpacks-v3` task to fetch source code from a Git repo, build the source code, then publish a container image.
+This `TaskRun` will use the `buildpacks-v3` task to build the source code, then publish a container image.
 
 ```
 apiVersion: tekton.dev/v1beta1
@@ -75,20 +75,18 @@ spec:
 #  - name: CACHE
 #    value: my-cache
   resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: <your git repo, e.g. "https://github.com/buildpacks/samples">
     outputs:
     - name: image
       resourceSpec:
         type: image
         params:
         - name: url
-          value: <your output image tag, e.g. "gcr.io/app-repo/app-image:app-tag">
+          value: <your output image tag,
+          e.g. "gcr.io/app-repo/app-image:app-tag">
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
 ```
 
 ### Example builders

--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -5,31 +5,31 @@ metadata:
   name: buildpacks-v3
 spec:
   params:
-    - name: BUILDER_IMAGE
-      description: The image on which builds will run (must include v3 lifecycle and compatible buildpacks).
-    - name: USE_CRED_HELPERS
-      description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
-      default: "false"
-    - name: CACHE
-      description: The name of the persistent app cache volume
-      default: empty-dir
-    - name: USER_ID
-      description: The user ID of the builder image user
-      default: "1000"
-    - name: GROUP_ID
-      description: The group ID of the builder image user
-      default: "1000"
-    - name: SOURCE_SUBPATH
-      description: A subpath within the `source` input where the source to build is located.
-      default: ""
+  - name: BUILDER_IMAGE
+    description: The image on which builds will run (must include v3 lifecycle and compatible buildpacks).
+  - name: USE_CRED_HELPERS
+    description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
+    default: "false"
+  - name: CACHE
+    description: The name of the persistent app cache volume
+    default: empty-dir
+  - name: USER_ID
+    description: The user ID of the builder image user
+    default: "1000"
+  - name: GROUP_ID
+    description: The group ID of the builder image user
+    default: "1000"
+  - name: SOURCE_SUBPATH
+    description: A subpath within the `source` input where the source to build is located.
+    default: ""
 
   resources:
-    inputs:
-      - name: source
-        type: git
     outputs:
-      - name: image
-        type: image
+    - name: image
+      type: image
+
+  workspaces:
+  - name: source
 
   stepTemplate:
     env:
@@ -47,7 +47,7 @@ spec:
           chown -R "$(params.USER_ID):$(params.GROUP_ID)" "/tekton/home" &&
           chown -R "$(params.USER_ID):$(params.GROUP_ID)" "/layers" &&
           chown -R "$(params.USER_ID):$(params.GROUP_ID)" "/cache" &&
-          chown -R "$(params.USER_ID):$(params.GROUP_ID)" "/workspace/source"
+          chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$(workspaces.source.path)"
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
@@ -61,7 +61,7 @@ spec:
       imagePullPolicy: Always
       command: ["/cnb/lifecycle/detector"]
       args:
-        - "-app=/workspace/source/$(params.SOURCE_SUBPATH)"
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
         - "-group=/layers/group.toml"
         - "-plan=/layers/plan.toml"
       volumeMounts:
@@ -103,7 +103,7 @@ spec:
       imagePullPolicy: Always
       command: ["/cnb/lifecycle/builder"]
       args:
-        - "-app=/workspace/source/$(params.SOURCE_SUBPATH)"
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
         - "-layers=/layers"
         - "-group=/layers/group.toml"
         - "-plan=/layers/plan.toml"
@@ -116,7 +116,7 @@ spec:
       imagePullPolicy: Always
       command: ["/cnb/lifecycle/exporter"]
       args:
-        - "-app=/workspace/source/$(params.SOURCE_SUBPATH)"
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
         - "-layers=/layers"
         - "-helpers=$(params.USE_CRED_HELPERS)"
         - "-group=/layers/group.toml"

--- a/buildpacks/tests/pre-apply-task-hook.sh
+++ b/buildpacks/tests/pre-apply-task-hook.sh
@@ -1,5 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Add an internal registry as sidecar to the task so we can upload it directly
-# from our tests withouth having to go to an external registry.
+# from our tests without having to go to an external registry.
 add_sidecar_registry ${TMPF}
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/buildpacks/tests/resources.yaml
+++ b/buildpacks/tests/resources.yaml
@@ -1,16 +1,3 @@
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: buildpacks-samples
-spec:
-  type: git
-  params:
-    - name: url
-      value: https://github.com/buildpacks/samples
-    - name: revision
-      value: master
----
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
@@ -20,6 +7,17 @@ spec:
   params:
     - name: url
       value: localhost:5000/buildpacks-app
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildpacks-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/buildpacks/tests/run.yaml
+++ b/buildpacks/tests/run.yaml
@@ -1,29 +1,65 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: Pipeline
 metadata:
-  name: buildpacks-run
+  name: buildpacks-test-pipeline
 spec:
-  taskRef:
-    name: buildpacks-v3
+  workspaces:
+  - name: shared-workspace
+  resources:
+  - name: build-image
+    type: image
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/buildpacks/samples
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: buildpacks-v3
+    taskRef:
+      name: buildpacks-v3
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: SOURCE_SUBPATH
+      value: apps/java-maven
+    - name: BUILDER_IMAGE
+      value: cnbs/sample-builder:alpine-p0.2
+    - name: CACHE
+      value: buildpacks-cache
+    resources:
+      outputs:
+      - name: image
+        resource: build-image
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildpacks-test-pipeline-run
+spec:
+  pipelineRef:
+    name: buildpacks-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: buildpacks-source-pvc
+  resources:
+  - name: build-image
+    resourceRef:
+      name: buildpacks-app-image
   podTemplate:
     volumes:
     - name: buildpacks-cache
       persistentVolumeClaim:
         claimName: buildpacks-cache-pvc
-  params:
-  - name: SOURCE_SUBPATH
-    value: apps/java-maven
-  - name: BUILDER_IMAGE
-    value: cnbs/sample-builder:alpine-p0.2
-  - name: CACHE
-    value: buildpacks-cache
-  resources:
-    inputs:
-    - name: source
-      resourceRef:
-        name: buildpacks-samples
-    outputs:
-    - name: image
-      resourceRef:
-        name: buildpacks-app-image

--- a/conftest/README.md
+++ b/conftest/README.md
@@ -30,16 +30,10 @@ metadata:
 spec:
   taskRef:
     name: conftest
-  resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: revision
-          value: master
-        - name: url
-          value: https://github.com/instrumenta/conftest.git
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   params:
   - name: files
     value: examples/kubernetes/deployment.yaml
@@ -69,9 +63,7 @@ container step-conftest has failed  : Error
 * **output**: Which output format to use (_default:_ `stdout`)
 * **args**: An array of additional arguments to pass to Conftest (_default `[]`_)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
@@ -90,16 +82,10 @@ metadata:
 spec:
   taskRef:
     name: helm-conftest
-  resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: revision
-          value: master
-        - name: url
-          value: https://github.com/helm/charts.git
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   params:
   - name: chart
     value: stable/mysql
@@ -114,9 +100,7 @@ spec:
 * **output**: Which output format to use (_default:_ `stdout`)
 * **args**: An array of additional arguments to pass to Conftest (_default `[]`)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.

--- a/conftest/conftest.yaml
+++ b/conftest/conftest.yaml
@@ -3,11 +3,8 @@ kind: Task
 metadata:
   name: conftest
 spec:
-  resources:
-    inputs:
-    - name: source
-      type: git
-      targetPath: source
+  workspaces:
+  - name: source
   params:
   - name: files
     type: string
@@ -21,7 +18,7 @@ spec:
 
   steps:
   - name: conftest
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     image: instrumenta/conftest:latest
     command:
       - conftest

--- a/conftest/helm-conftest.yaml
+++ b/conftest/helm-conftest.yaml
@@ -3,11 +3,8 @@ kind: Task
 metadata:
   name: helm-conftest
 spec:
-  resources:
-    inputs:
-    - name: source
-      type: git
-      targetPath: source
+  workspaces:
+  - name: source
   params:
   - name: chart
     default: "."
@@ -21,7 +18,7 @@ spec:
 
   steps:
   - name: helm-conftest
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     image: instrumenta/helm-conftest:latest
     command:
       - helm

--- a/gke-deploy/README.md
+++ b/gke-deploy/README.md
@@ -17,11 +17,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/gke-d
   See [here](https://github.com/GoogleCloudPlatform/cloud-builders/tree/master/gke-deploy#usage)
   for the arguments to `gke-deploy`.
 
-## Resources
+## Workspaces
 
-### Inputs
-
-* **source-repo**: The Git source repository that contains your application's Kubernetes configs.
+* **source**: The Git source repository that contains your application's Kubernetes configs.
 
 ## Usage
 
@@ -56,16 +54,10 @@ spec:
   serviceAccountName: workload-identity-sa  # <-- a SA configured with Workload Identity
   taskRef:
     name: gke-deploy
-  resources:
-    inputs:
-    - name: source-repo
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: [GIT_REPO_URL]
-        - name: revision
-          value: [GIT_REPO_REVISION]
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   params:
   - name: ARGS
     value:
@@ -95,11 +87,9 @@ This Pipeline builds, pushes, and deploys your application to a Google Kubernete
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/gke-deploy/build-push-gke-deploy.yaml
 ```
 
-## Resources
+## Workspaces
 
-### Inputs
-
-* **source-repo**: The Git repository that contains your application's Dockerfile and Kubernetes configs.
+* **source**: The Git repository that contains your application's Dockerfile and Kubernetes configs.
 
 ## Parameters
 
@@ -167,15 +157,10 @@ spec:
   pipelineRef:
     name: build-push-gke-deploy
   serviceAccountName: workload-identity-sa  # <-- a SA configured with Workload Identity
-  resources:
-  - name: source-repo
-    resourceSpec:
-      type: git
-      params:
-      - name: url
-        value: [GIT_REPO_URL]
-      - name: revision
-        value: [GIT_REPO_REVISION]
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   params:
   - name: pathToContext
     value: [PATH_TO_CONTEXT]

--- a/gke-deploy/build-push-gke-deploy.yaml
+++ b/gke-deploy/build-push-gke-deploy.yaml
@@ -3,10 +3,6 @@ kind: Task
 metadata:
   name: build-and-push
 spec:
-  resources:
-    inputs:
-    - name: source-repo
-      type: git
   params:
   - name: pathToContext
     description: The path to the build context relative to your source repo's root. This is used by Kaniko.
@@ -19,6 +15,8 @@ spec:
   - name: imageTag
     description: Tag to apply to the built image.
     default: latest
+  workspaces:
+  - name: source
   steps:
   - name: build-and-push
     image: gcr.io/kaniko-project/executor
@@ -27,17 +25,13 @@ spec:
     args:
     - --dockerfile=$(params.pathToDockerFile)
     - --destination=$(params.imageUrl):$(params.imageTag)
-    - --context=$(resources.resources.source-repo.path)/$(params.pathToContext)
+    - --context=$(workspaces.source.path)/$(params.pathToContext)
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: deploy-using-gke-deploy
 spec:
-  resources:
-    inputs:
-    - name: source-repo
-      type: git
   params:
   - name: pathToKubernetesConfigs
     description: The path to the Kubernetes configs to deploy, relative to your source repo's root.
@@ -53,14 +47,17 @@ spec:
   - name: clusterProject
     description: Project of target GKE cluster to deploy to.
     default: ""
+  workspaces:
+  - name: source
   steps:
   - name: deploy-using-gke-deploy
     image: gcr.io/cloud-builders/gke-deploy
+    workingDir: $(workspaces.source.path)
     command: ["/gke-deploy"]
     args:
     - "run"
     - "--image=$(params.imageUrl):$(params.imageTag)"
-    - "--filename=$(resources.inputs.source-repo.path)/$(params.pathToKubernetesConfigs)"
+    - "--filename=$(workspaces.source.path)/$(params.pathToKubernetesConfigs)"
     - "--cluster=$(params.clusterName)"
     - "--location=$(params.clusterLocation)"
     - "--project=$(params.clusterProject)"
@@ -71,9 +68,8 @@ kind: Pipeline
 metadata:
   name: build-push-gke-deploy
 spec:
-  resources:
-  - name: source-repo
-    type: git
+  workspaces:
+  - name: source
   params:
   - name: pathToContext
     type: string
@@ -114,10 +110,9 @@ spec:
       value: "$(params.imageUrl)"
     - name: imageTag
       value: "$(params.imageTag)"
-    resources:
-      inputs:
-      - name: source-repo
-        resource: source-repo
+    workspaces:
+    - name: source
+      workspace: source
   - name: deploy-using-gke-deploy
     taskRef:
       name: deploy-using-gke-deploy
@@ -136,7 +131,6 @@ spec:
       value: "$(params.clusterLocation)"
     - name: clusterProject
       value: "$(params.clusterProject)"
-    resources:
-      inputs:
-      - name: source-repo
-        resource: source-repo
+    workspaces:
+    - name: source
+      workspace: source

--- a/gke-deploy/gke-deploy.yaml
+++ b/gke-deploy/gke-deploy.yaml
@@ -3,10 +3,8 @@ kind: Task
 metadata:
   name: gke-deploy
 spec:
-  resources:
-    inputs:
-    - name: source-repo
-      type: git
+  workspaces:
+  - name: source
   params:
   - name: ARGS
     type: array
@@ -16,4 +14,5 @@ spec:
   - name: gke-deploy
     image: gcr.io/cloud-builders/gke-deploy
     command: ["/gke-deploy"]
+    workingDir: $(workspaces.source.path)
     args: ["$(params.ARGS)"]

--- a/golang/README.md
+++ b/golang/README.md
@@ -21,11 +21,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golan
 * **GOARCH**: architecture target (_default:_ amd64)
 * **GO111MODULE**: value of module support (_default:_ auto)
 
-### Resources
+### Workspaces
 
-#### Inputs
-
-* **source**: A `git`-type `PipelineResource` specifying the location of the
+* **source**: A `git`-type `PipelineResource** specifying the location of the
   source to build.
 
 ## `golang-build`
@@ -40,9 +38,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golan
 * **GOARCH**: architecture target (_default:_ amd64)
 * **GO111MODULE**: value of module support (_default:_ auto)
 
-### Resources
-
-#### Inputs
+### Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
@@ -59,9 +55,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golan
 * **GOARCH**: architecture target (_default:_ amd64)
 * **GO111MODULE**: value of module support (_default:_ auto)
 
-### Resources
-
-#### Inputs
+### Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
@@ -82,14 +76,10 @@ metadata:
 spec:
   taskRef:
     name: golangci-lint
-  resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/tektoncd/pipeline
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   params:
   - name: package
     value: github.com/tektoncd/pipeline
@@ -110,14 +100,10 @@ metadata:
 spec:
   taskRef:
     name: golang-test
-  resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/tektoncd/pipeline
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   params:
   - name: package
     value: github.com/tektoncd/pipeline
@@ -139,14 +125,10 @@ metadata:
 spec:
   taskRef:
     name: golang-build
-  resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/tektoncd/pipeline
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   params:
   - name: package
     value: github.com/tektoncd/pipeline

--- a/golang/build.yaml
+++ b/golang/build.yaml
@@ -24,11 +24,9 @@ spec:
   - name: GO111MODULE
     description: "value of module support"
     default: auto
-  resources:
-    inputs:
-    - name: source
-      type: git
-      targetPath: src/$(params.package)
+  workspaces:
+  - name: source
+    mountPath: /workspace/src/$(params.package)
   steps:
   - name: build
     image: golang:$(params.version)

--- a/golang/lint.yaml
+++ b/golang/lint.yaml
@@ -21,11 +21,9 @@ spec:
   - name: GO111MODULE
     description: "value of module support"
     default: auto
-  resources:
-    inputs:
-    - name: source
-      type: git
-      targetPath: src/$(params.package)
+  workspaces:
+  - name: source
+    mountPath: /workspace/src/$(params.package)
   steps:
   - name: lint
     image: golangci/golangci-lint:$(params.version)

--- a/golang/tests.yaml
+++ b/golang/tests.yaml
@@ -24,11 +24,9 @@ spec:
   - name: GO111MODULE
     description: "value of module support"
     default: auto
-  resources:
-    inputs:
-    - name: source
-      type: git
-      targetPath: src/$(params.package)
+  workspaces:
+  - name: source
+    mountPath: /workspace/src/$(params.package)
   steps:
   - name: unit-test
     image: golang:$(params.version)

--- a/jib-gradle/README.md
+++ b/jib-gradle/README.md
@@ -16,12 +16,12 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/jib-g
 - **DIRECTORY**: The directory in the source repository where source should be found. (*default: .*)
 - **CACHE**: The name of the volume for caching Gradle artifacts, local Maven repository, and base image layers (*default: empty-dir-volume*)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
+
+## Resources
 
 ### Outputs
 
@@ -55,14 +55,11 @@ spec:
   params:
   - name: DIRECTORY
     value: ./examples/helloworld
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/my-user/my-repo
     outputs:
     - name: image
       resourceRef:

--- a/jib-gradle/jib-gradle.yaml
+++ b/jib-gradle/jib-gradle.yaml
@@ -13,10 +13,9 @@ spec:
   - name: INSECUREREGISTRY
     description: Whether to allow insecure registry
     default: "false"
+  workspaces:
+  - name: source
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
@@ -46,7 +45,7 @@ spec:
         -Dgradle.user.home=/tekton/home/.gradle \
         -Djib.allowInsecureRegistries=$(params.INSECUREREGISTRY) \
         -Djib.to.image=$(resources.outputs.image.url)
-    workingDir: /workspace/source/$(params.DIRECTORY)
+    workingDir: $(workspaces.source.path)/$(params.DIRECTORY)
     volumeMounts:
     - name: $(params.CACHE)
       mountPath: /tekton/home/.gradle/caches

--- a/jib-gradle/tests/pre-apply-task-hook.sh
+++ b/jib-gradle/tests/pre-apply-task-hook.sh
@@ -3,3 +3,6 @@
 # Add an internal registry as sidecar to the task so we can upload it directly
 # from our tests withouth having to go to an external registry.
 add_sidecar_registry ${TMPF}
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/jib-gradle/tests/resources.yaml
+++ b/jib-gradle/tests/resources.yaml
@@ -2,21 +2,20 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: console-java-simple
-spec:
-  type: git
-  params:
-    - name: revision
-      value: master
-    - name: url
-      value: https://github.com/che-samples/console-java-simple
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
   name: image
 spec:
   type: image
   params:
     - name: url
       value: localhost:5000/tekton-pipelines/console-java-simple
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jib-gradle-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/jib-gradle/tests/run.yaml
+++ b/jib-gradle/tests/run.yaml
@@ -1,20 +1,56 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: Pipeline
 metadata:
-  name: jib-gradle-run
+  name: jib-gradle-test-pipeline
 spec:
-  taskRef:
-    name: jib-gradle
+  workspaces:
+  - name: shared-workspace
   resources:
-    outputs:
-    - name: image
-      resourceRef:
-        name: image
-    inputs:
+  - name: build-image
+    type: image
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/che-samples/console-java-simple
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: jib-gradle
+    taskRef:
+      name: jib-gradle
+    runAfter:
+    - fetch-repository
+    workspaces:
     - name: source
-      resourceRef:
-        name: console-java-simple
-  params:
-  - name: INSECUREREGISTRY
-    value: "true"
+      workspace: shared-workspace
+    params:
+    - name: INSECUREREGISTRY
+      value: "true"
+    resources:
+      outputs:
+      - name: image
+        resource: build-image
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: jib-gradle-test-pipeline-run
+spec:
+  pipelineRef:
+    name: jib-gradle-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: jib-gradle-source-pvc
+  resources:
+  - name: build-image
+    resourceRef:
+      name: image

--- a/jib-maven/README.md
+++ b/jib-maven/README.md
@@ -13,14 +13,15 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/jib-m
 ## Parameters
 
 - **DIRECTORY**: The directory in the source repository where source should be found. (*default: .*)
-- **CACHE**: The name of the volume for caching Maven artifacts and base image layers (*default: empty-dir-volume*)
+- **CACHE**: The name of the volume for caching Maven artifacts and
+  base image layers (*default: empty-dir-volume*)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
+
+## Resources
 
 ### Outputs
 
@@ -54,14 +55,11 @@ spec:
   params:
   - name: DIRECTORY
     value: ./examples/helloworld
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   resources:
-    inputs
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/my-user/my-repo
     outputs:
     - name: image
       resourceRef:

--- a/jib-maven/jib-maven.yaml
+++ b/jib-maven/jib-maven.yaml
@@ -13,10 +13,9 @@ spec:
   - name: INSECUREREGISTRY
     description: Whether to allow insecure registry
     default: "false"
+  workspaces:
+  - name: source
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
@@ -31,7 +30,7 @@ spec:
     - -Duser.home=/tekton/home
     - -Djib.allowInsecureRegistries=$(params.INSECUREREGISTRY)
     - -Djib.to.image=$(resources.outputs.image.url)
-    workingDir: /workspace/source/$(params.DIRECTORY)
+    workingDir: $(workspaces.source.path)/$(params.DIRECTORY)
     volumeMounts:
     - name: $(params.CACHE)
       mountPath: /tekton/home/.m2

--- a/jib-maven/tests/pre-apply-task-hook.sh
+++ b/jib-maven/tests/pre-apply-task-hook.sh
@@ -3,3 +3,6 @@
 # Add an internal registry as sidecar to the task so we can upload it directly
 # from our tests withouth having to go to an external registry.
 add_sidecar_registry ${TMPF}
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/jib-maven/tests/resources.yaml
+++ b/jib-maven/tests/resources.yaml
@@ -2,21 +2,20 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: console-java-simple
-spec:
-  type: git
-  params:
-    - name: revision
-      value: master
-    - name: url
-      value: https://github.com/che-samples/console-java-simple
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
   name: image
 spec:
   type: image
   params:
     - name: url
       value: localhost:5000/tekton-pipelines/console-java-simple
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jib-maven-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/jib-maven/tests/run.yaml
+++ b/jib-maven/tests/run.yaml
@@ -1,20 +1,56 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: Pipeline
 metadata:
-  name: jib-maven-run
+  name: jib-maven-test-pipeline
 spec:
-  taskRef:
-    name: jib-maven
+  workspaces:
+  - name: shared-workspace
   resources:
-    outputs:
-    - name: image
-      resourceRef:
-        name: image
-    inputs:
+  - name: build-image
+    type: image
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/che-samples/console-java-simple
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: jib-maven
+    taskRef:
+      name: jib-maven
+    runAfter:
+    - fetch-repository
+    workspaces:
     - name: source
-      resourceRef:
-        name: console-java-simple
-  params:
-  - name: INSECUREREGISTRY
-    value: "true"
+      workspace: shared-workspace
+    params:
+    - name: INSECUREREGISTRY
+      value: "true"
+    resources:
+      outputs:
+      - name: image
+        resource: build-image
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: jib-maven-test-pipeline-run
+spec:
+  pipelineRef:
+    name: jib-maven-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: jib-maven-source-pvc
+  resources:
+  - name: build-image
+    resourceRef:
+      name: image

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -26,12 +26,12 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kanik
 * **CONTEXT**: The build context used by Kaniko (_default:_
   `./`)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
+
+## Resources
 
 ### Outputs
 
@@ -62,14 +62,11 @@ metadata:
 spec:
   taskRef:
     name: kaniko
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/my-user/my-repo
     outputs:
     - name: image
       resourceSpec:

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -15,17 +15,16 @@ spec:
   - name: BUILDER_IMAGE
     description: The image on which builds will run
     default: gcr.io/kaniko-project/executor:v0.13.0
+  workspaces:
+  - name: source
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
 
   steps:
   - name: build-and-push
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     image: $(params.BUILDER_IMAGE)
     # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
     # https://github.com/tektoncd/pipeline/pull/706

--- a/kaniko/tests/pre-apply-task-hook.sh
+++ b/kaniko/tests/pre-apply-task-hook.sh
@@ -3,3 +3,6 @@
 # Add an internal registry as sidecar to the task so we can upload it directly
 # from our tests withouth having to go to an external registry.
 add_sidecar_registry ${TMPF}
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/kaniko/tests/resources.yaml
+++ b/kaniko/tests/resources.yaml
@@ -2,21 +2,20 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: nocode
-spec:
-  type: git
-  params:
-    - name: revision
-      value: master
-    - name: url
-      value: https://github.com/kelseyhightower/nocode
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
   name: image
 spec:
   type: image
   params:
     - name: url
       value: localhost:5000/kaniko-nocode
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kaniko-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/kaniko/tests/run.yaml
+++ b/kaniko/tests/run.yaml
@@ -1,20 +1,56 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: Pipeline
 metadata:
-  name: kaniko-run
+  name: kaniko-test-pipeline
 spec:
-  taskRef:
-    name: kaniko
+  workspaces:
+  - name: shared-workspace
   resources:
-    outputs:
-    - name: image
-      resourceRef:
-        name: image
-    inputs:
+  - name: build-image
+    type: image
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: kaniko
+    taskRef:
+      name: kaniko
+    runAfter:
+    - fetch-repository
+    workspaces:
     - name: source
-      resourceRef:
-        name: nocode
-  params:
-  - name: EXTRA_ARGS
-    value: "--skip-tls-verify"
+      workspace: shared-workspace
+    params:
+    - name: EXTRA_ARGS
+      value: "--skip-tls-verify"
+    resources:
+      outputs:
+      - name: image
+        resource: build-image
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: kaniko-test-pipeline-run
+spec:
+  pipelineRef:
+    name: kaniko-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: kaniko-source-pvc
+  resources:
+  - name: build-image
+    resourceRef:
+      name: image

--- a/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
@@ -3,9 +3,9 @@ kind: Pipeline
 metadata:
   name: buildah-build-kn-create
 spec:
-  resources:
+  workspaces:
   - name: source
-    type: git
+  resources:
   - name: image
     type: image
   params:
@@ -14,14 +14,32 @@ spec:
     description: Arguments to pass to kn CLI
     default:
       - "help"
+  - name: GIT_URL
+    type: string
+    description: Git url to clone
   tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: source
+    params:
+    - name: url
+      value: $(params.GIT_URL)
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
   - name: buildah-build
     taskRef:
       name: buildah
+    runAfter:
+      - fetch-repository
+    workspaces:
+    - name: source
+      workspace: source
     resources:
-      inputs:
-        - name: source
-          resource: source
       outputs:
         - name: image
           resource: image

--- a/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
@@ -7,13 +7,12 @@ spec:
   pipelineRef:
     name: buildah-build-kn-create
   resources:
-    - name: source
-      resourceRef:
-        name: buildah-build-kn-create-source
     - name: image
       resourceRef:
         name: buildah-build-kn-create-image
   params:
+    - name: GIT_URL
+      value: "https://github.com/navidshaikh/helloworld-go"
     - name: ARGS
       value:
         - "service"

--- a/kn/knative-dockerfile-deploy/build_deploy/resources.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/resources.yaml
@@ -1,12 +1,3 @@
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: buildah-build-kn-create-source
-spec:
-  type: git
-  params:
-    - name: url
-      value: "https://github.com/navidshaikh/helloworld-go"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource

--- a/kubeval/README.md
+++ b/kubeval/README.md
@@ -23,16 +23,10 @@ metadata:
 spec:
   taskRef:
     name: kubeval
-  resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: revision
-          value: master
-        - name: url
-          value: https://github.com/instrumenta/conftest.git
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
 ```
 
 By default the task will recursively scan the provided repository for YAML files and validate them against the Kubernetes schemas. You can change the default behavious, targetting particular directories, files or Kubernetes versions, using the parameters.
@@ -43,9 +37,7 @@ By default the task will recursively scan the provided repository for YAML files
 * **output**: Which output format to use (_default:_ `stdout`)
 * **args**: An arrag of additional arguments to pass to Kubeval (_defaultt `[]`)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.

--- a/kubeval/kubeval.yaml
+++ b/kubeval/kubeval.yaml
@@ -3,11 +3,8 @@ kind: Task
 metadata:
   name: kubeval
 spec:
-  resources:
-    inputs:
-    - name: source
-      type: git
-      targetPath: source
+  workspaces:
+  - name: source
   params:
   - name: files
     default: "."
@@ -19,7 +16,7 @@ spec:
 
   steps:
   - name: kubeval
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     image: garethr/kubeval:latest
     command:
       - kubeval

--- a/makisu/README.md
+++ b/makisu/README.md
@@ -51,12 +51,12 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/makis
 * **REGISTRY_SECRET**: Secret containing information about the used regsitry (_default:_
   `docker-registry-config`)
 
-## Resources
-
-### Inputs
+## Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
+
+## Resources
 
 ### Outputs
 
@@ -80,14 +80,11 @@ metadata:
 spec:
   taskRef:
     name: makisu
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   resource:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/my-user/my-repo
     outputs:
     - name: image
       resourceSpec:
@@ -114,14 +111,11 @@ spec:
     value: eu.gcr.io
   - name: REGISTRY_SECRET
     value: gcr-registry-config
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/my-user/my-repo
     outputs:
     - name: image
       resourceSpec:

--- a/makisu/makisu.yaml
+++ b/makisu/makisu.yaml
@@ -13,19 +13,16 @@ spec:
   - name: REGISTRY_SECRET
     description: Secret containing information about the used regsitry.
     default: docker-registry-config
-
+  workspaces:
+  - name: source
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
-
   steps:
   - name: build-and-push
     image: gcr.io/makisu-project/makisu:v0.1.10
-    workingDir: /workspace/source
+    workingDir: $(workspaces.source.path)
     command:
     - /makisu-internal/makisu
     - build

--- a/maven/maven.yaml
+++ b/maven/maven.yaml
@@ -13,11 +13,8 @@ spec:
     description: The Maven bucketrepo- mirror
     type: string
     default: ""
-  resources:
-    inputs:
-    - name: source
-      targetPath: /
-      type: git
+  workspaces:
+  - name: source
   steps:
     - name: mvn-settings
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
@@ -52,6 +49,7 @@ spec:
           mountPath: /.m2
     - name: mvn-goals
       image: gcr.io/cloud-builders/mvn
+      workingDir: $(workspaces.source.path)
       command:
         - /usr/bin/mvn
       args:

--- a/maven/tests/pre-apply-task-hook.sh
+++ b/maven/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/maven/tests/resources.yaml
+++ b/maven/tests/resources.yaml
@@ -1,14 +1,3 @@
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: maven-resource-petclinic
-spec:
-  type: git
-  params:
-    - name: revision
-      value: master
-    - name: url
-      value: https://github.com/spring-projects/spring-petclinic
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/maven/tests/resources.yaml
+++ b/maven/tests/resources.yaml
@@ -9,3 +9,14 @@ spec:
       value: master
     - name: url
       value: https://github.com/spring-projects/spring-petclinic
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: maven-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/maven/tests/run.yaml
+++ b/maven/tests/run.yaml
@@ -1,12 +1,42 @@
+---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: Pipeline
 metadata:
-  name: maven-run
+  name: maven-test-pipeline
 spec:
-  resources:
-    inputs:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/spring-projects/spring-petclinic
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: maven
+    taskRef:
+      name: maven
+    runAfter:
+    - fetch-repository
+    workspaces:
     - name: source
-      resourceRef:
-        name: maven-resource-petclinic
-  taskRef:
-    name: maven
+      workspace: shared-workspace
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: maven-test-pipeline-run
+spec:
+  pipelineRef:
+    name: maven-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: maven-source-pvc

--- a/s2i/README.md
+++ b/s2i/README.md
@@ -22,14 +22,14 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/s2i/s
 * **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
   non-TLS registry) (_default:_ `true`)
 
-## Resources
-
-### Inputs
+# Workspaces
 
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
 
-## Outputs
+## Resources
+
+### Outputs
 
 * **image**: An `image`-type `PipelineResource` specify the image that should
   be built.
@@ -76,14 +76,11 @@ spec:
   params:
   - name: BUILDER_IMAGE
     value: docker.io/centos/nodejs-8-centos7
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
   resources:
-    inputs:
-    - name: source
-      resourceSpec:
-        type: git
-        params:
-        - name: url
-          value: https://github.com/sclorg/nodejs-ex
     outputs:
     - name: image
       resourceSpec:

--- a/s2i/s2i.yaml
+++ b/s2i/s2i.yaml
@@ -16,14 +16,14 @@ spec:
     description: Log level when running the S2I binary
     default: '0'
   resources:
-    inputs:
-    - name: source
-      type: git
     outputs:
     - name: image
       type: image
+  workspaces:
+  - name: source
   steps:
-  - command:
+  - name: generate
+    command:
     - /usr/local/bin/s2i
     - --loglevel=$(params.LOGLEVEL)
     - build
@@ -32,12 +32,12 @@ spec:
     - --as-dockerfile
     - /gen-source/Dockerfile.gen
     image: quay.io/openshift-pipeline/s2i:nightly
-    name: generate
     volumeMounts:
     - mountPath: /gen-source
       name: gen-source
-    workingDir: /workspace/source
-  - command:
+    workingDir: $(workspaces.source.path)
+  - name: build
+    command:
     - buildah
     - bud
     - --tls-verify=$(params.TLSVERIFY)
@@ -48,7 +48,6 @@ spec:
     - $(resources.outputs.image.url)
     - .
     image: quay.io/buildah/stable
-    name: build
     securityContext:
       privileged: true
     volumeMounts:
@@ -57,14 +56,14 @@ spec:
     - mountPath: /gen-source
       name: gen-source
     workingDir: /gen-source
-  - command:
+  - name: push
+    command:
     - buildah
     - push
     - --tls-verify=$(params.TLSVERIFY)
     - $(resources.outputs.image.url)
     - docker://$(resources.outputs.image.url)
     image: quay.io/buildah/stable
-    name: push
     securityContext:
       privileged: true
     volumeMounts:

--- a/s2i/tests/pre-apply-task-hook.sh
+++ b/s2i/tests/pre-apply-task-hook.sh
@@ -1,5 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Add an internal registry as sidecar to the task so we can upload it directly
 # from our tests withouth having to go to an external registry.
 add_sidecar_registry ${TMPF}
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/s2i/tests/resources.yaml
+++ b/s2i/tests/resources.yaml
@@ -2,21 +2,20 @@
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
-  name: django-s2i-example
-spec:
-  type: git
-  params:
-    - name: revision
-      value: master
-    - name: url
-      value: https://github.com/sclorg/django-ex
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
   name: image
 spec:
   type: image
   params:
     - name: url
       value: localhost:5000/python-example-tekton
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s2i-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/s2i/tests/run.yaml
+++ b/s2i/tests/run.yaml
@@ -1,24 +1,60 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: TaskRun
+kind: Pipeline
 metadata:
-  name: s2i-run
+  name: s2i-test-pipeline
 spec:
-  taskRef:
-    name: s2i
+  workspaces:
+  - name: shared-workspace
   resources:
-    outputs:
-    - name: image
-      resourceRef:
-        name: image
-    inputs:
+  - name: build-image
+    type: image
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/sclorg/django-ex
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: s2i
+    taskRef:
+      name: s2i
+    runAfter:
+    - fetch-repository
+    workspaces:
     - name: source
-      resourceRef:
-        name: django-s2i-example
-  params:
-  - name: BUILDER_IMAGE
-    value: centos/python-36-centos7
-  - name: TLSVERIFY
-    value: "false"
-  - name: LOGLEVEL
-    value: "10"
+      workspace: shared-workspace
+    params:
+    - name: BUILDER_IMAGE
+      value: centos/python-36-centos7
+    - name: TLSVERIFY
+      value: "false"
+    - name: LOGLEVEL
+      value: "10"
+    resources:
+      outputs:
+      - name: image
+        resource: build-image
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: s2i-test-pipeline-run
+spec:
+  pipelineRef:
+    name: s2i-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: s2i-source-pvc
+  resources:
+  - name: build-image
+    resourceRef:
+      name: image

--- a/terraform-cli/README.md
+++ b/terraform-cli/README.md
@@ -18,11 +18,10 @@ This task currently works only on kubernetes 1.6+ support for a task that works 
 * **ARGS:** args to execute which are appended to `terraform` e.g. `init` (_default_: `--help`)
 * **terraform-secret:** the name of the secret containing the authentication information for the chosen provider (_default_: `terraform-creds`)
 
-## Resources
-
-## Inputs
+## Workspaces
 
 * **source:** A `git`-type `PipelineResource` specifying the location of the terraform HCL or JSON files
+
 
 ## Terraform-Secret
 
@@ -74,13 +73,15 @@ kind: Pipeline
 metadata:
   name: terraform-cli-example
 spec:
-  resources:
-  - name: terraform-file
-    type: git
+  workspaces:
+  - name: source
   tasks:
   - name: terraform
     taskRef:
       name: terraform-cli
+    workspaces:
+    - name: source
+      workspace: source
     params:
      - name: terraform-secret
        value: "terraform-secret"
@@ -88,8 +89,4 @@ spec:
        value:
          - apply
          - "-auto-approve"
-    resources:
-      inputs:
-        - name: source
-          resource: terraform-file
 ```

--- a/terraform-cli/terraform-cli-task.yaml
+++ b/terraform-cli/terraform-cli-task.yaml
@@ -4,10 +4,8 @@ kind: Task
 metadata:
   name: terraform-cli
 spec:
-  resources:
-    inputs:
-    - name: source
-      type: git
+  workspaces:
+  - name: source
   params:
   - name: ARGS
     description: The terraform cli commands to tun
@@ -21,7 +19,7 @@ spec:
   steps:
     - name: init
       image: quay.io/rcmendes/terraform-cli:latest
-      workingDir: /workspace/source
+      workingDir: $(workspaces.source.path)
       command: ["/usr/local/bin/terraform"]
       args:
         - "init"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -72,8 +72,14 @@ function show_failure() {
     local testname=$1 tns=$2
 
     echo "FAILED: ${testname} task has failed to comeback properly" ;
-    echo "--- TR Dump"
-    kubectl get -n ${tns} tr -o yaml
+    echo "--- Task Dump"
+    kubectl get -n ${tns} task -o yaml
+    echo "--- Pipeline Dump"
+    kubectl get -n ${tns} pipeline -o yaml
+    echo "--- PipelineRun Dump"
+    kubectl get -n ${tns} pipelinerun -o yaml
+    echo "--- TaskRun Dump"
+    kubectl get -n ${tns} taskrun -o yaml
     echo "--- Container Logs"
     kubectl get pod -o name -n ${tns}|xargs kubectl logs --all-containers -n ${tns}
     exit 1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Tekton Authors
 #


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This migrates use of `GitResources` to workspace in the catalog. 

I know the integration tests will fail because the PVC will be empty… we need to setup something to populate the PVC before running the task :stuck_out_tongue_closed_eyes: 

/cc @chmouel @bobcatfish @sbwsg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
