### PR TITLE
Port ImageResource to params and results

### DIFF
--- a/buildah/README.md
+++ b/buildah/README.md
@@ -15,6 +15,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 
 ## Parameters
 
+* **IMAGE**: The name (reference) of the image to build.
 * **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
   note below.  (_default:_ quay.io/buildah/stable:v1.11.0)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
@@ -29,13 +30,6 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
 
-## Resources
-
-### Outputs
-
-* **image**: An `image`-type `PipelineResource` specify the image that should
-  be built.
-
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container
@@ -49,18 +43,13 @@ metadata:
 spec:
   taskRef:
     name: buildah
+  params:
+  - name: IMAGE
+    value: gcr.io/my-repo/my-image
   workspaces:
   - name: source
     persistentVolumeClaim:
       claimName: my-source
-  resources:
-    outputs:
-    - name: image
-      resourceSpec:
-        type: image
-        params:
-        - name: url
-          value: gcr.io/my-repo/my-image
 ```
 
 In this example, the Git repo being built is expected to have a `Dockerfile` at

--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -5,6 +5,8 @@ metadata:
   name: buildah
 spec:
   params:
+  - name: IMAGE
+    description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
     default: quay.io/buildah/stable:v1.11.0
@@ -19,16 +21,12 @@ spec:
     default: "true"
   workspaces:
   - name: source
-  resources:
-    outputs:
-    - name: image
-      type: image
 
   steps:
   - name: build
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
-    command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(resources.outputs.image.url)', '$(params.CONTEXT)']
+    command: ['buildah', 'bud', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(params.IMAGE)', '$(params.CONTEXT)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
@@ -38,7 +36,7 @@ spec:
   - name: push
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
-    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
+    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers

--- a/buildah/tests/resources.yaml
+++ b/buildah/tests/resources.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: image
-spec:
-  type: image
-  params:
-    - name: url
-      value: localhost:5000/nocode
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/buildah/tests/run.yaml
+++ b/buildah/tests/run.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   workspaces:
   - name: shared-workspace
-  resources:
-  - name: build-image
-    type: image
   tasks:
   - name: fetch-repository
     taskRef:
@@ -32,12 +29,10 @@ spec:
     - name: source
       workspace: shared-workspace
     params:
+    - name: IMAGE
+      value: localhost:5000/nocode
     - name: TLSVERIFY
       value: "false"
-    resources:
-      outputs:
-      - name: image
-        resource: build-image
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -50,7 +45,3 @@ spec:
   - name: shared-workspace
     persistentvolumeclaim:
       claimName: buildah-source-pvc
-  resources:
-  - name: build-image
-    resourceRef:
-      name: image

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -20,6 +20,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kanik
 
 ## Parameters
 
+* **IMAGE**: The name (reference) of the image to build.
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 
@@ -31,12 +32,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kanik
 * **source**: A `git`-type `PipelineResource` specifying the location of the
   source to build.
 
-## Resources
+## Results
 
-### Outputs
-
-* **image**: An `image`-type `PipelineResource` specifying the image that should
-  be built.
+* **digest**: The digest of the image just built.
 
 ## ServiceAccount
 

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kaniko
 spec:
   params:
+  - name: IMAGE
+    description: Name (reference) of the image to build.
   - name: DOCKERFILE
     description: Path to the Dockerfile to build.
     default: ./Dockerfile
@@ -14,13 +16,12 @@ spec:
     default: ""
   - name: BUILDER_IMAGE
     description: The image on which builds will run
-    default: gcr.io/kaniko-project/executor:v0.13.0
+    default: gcr.io/kaniko-project/executor:latest
   workspaces:
   - name: source
-  resources:
-    outputs:
-    - name: image
-      type: image
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
 
   steps:
   - name: build-and-push
@@ -35,7 +36,21 @@ spec:
     - /kaniko/executor
     - $(params.EXTRA_ARGS)
     - --dockerfile=$(params.DOCKERFILE)
-    - --context=/workspace/source/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
-    - --destination=$(resources.outputs.image.url)
+    - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
+    - --destination=$(params.IMAGE)
+    - --oci-layout-path=$(workspaces.source.path)/image-digest
     securityContext:
       runAsUser: 0
+  - name: write-digest
+    workingDir: $(workspaces.source.path)
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.11.0-rc2
+    # output of imagedigestexport [{"name":"image","digest":"sha256:eed29..660"}]
+    command: ["/ko-app/imagedigestexporter"]
+    args:
+    - -images=[{"name":"$(params.IMAGE)","type":"image","url":"$(params.IMAGE)","digest":"","OutputImageDir":"$(workspaces.source.path)/image-digest"}]
+    - -terminationMessagePath=image-digested
+  - name: digest-to-results
+    workingDir: $(workspaces.source.path)
+    image: stedolan/jq
+    script: |
+      cat image-digested | jq '.[0].digest' | tee /tekton/results/IMAGE_DIGEST

--- a/kaniko/tests/resources.yaml
+++ b/kaniko/tests/resources.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: image
-spec:
-  type: image
-  params:
-    - name: url
-      value: localhost:5000/kaniko-nocode
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kaniko/tests/run.yaml
+++ b/kaniko/tests/run.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   workspaces:
   - name: shared-workspace
-  resources:
-  - name: build-image
-    type: image
+  params:
+  - name: image
+    description: reference of the image to build
   tasks:
   - name: fetch-repository
     taskRef:
@@ -32,12 +32,10 @@ spec:
     - name: source
       workspace: shared-workspace
     params:
+    - name: IMAGE
+      value: $(params.image)
     - name: EXTRA_ARGS
       value: "--skip-tls-verify"
-    resources:
-      outputs:
-      - name: image
-        resource: build-image
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -46,11 +44,10 @@ metadata:
 spec:
   pipelineRef:
     name: kaniko-test-pipeline
+  params:
+  - name: image
+    value: localhost:5000/kaniko-nocode
   workspaces:
   - name: shared-workspace
     persistentvolumeclaim:
       claimName: kaniko-source-pvc
-  resources:
-  - name: build-image
-    resourceRef:
-      name: image


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This starts the work on using `params` for specifying the image reference, and result (when supported) to store the digest.

The `kaniko` is an example with the `results`.

Depends on tektoncd/pipeline#2212

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
