### PR TITLE
Add Pipelines version info to the git-clone README

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -5,6 +5,8 @@ in your Pipeline.
 
 ## `git-clone`
 
+**Please Note: this Task is only compatible with Tekton Pipelines versions 0.11-rc1 and greater!**
+
 This `Task` has two required inputs:
 
 1. The URL of a git repo to clone provided with the `url` param.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The version of the `git-clone` task on the master branch of the catalog is only compatible with 0.11-rc1 and above because I modified it to start using Task Results.  We've got stuff in the works related to versioning of the catalog but at the very least this version info should be documented.

This PR adds version information to the README so that at least we have this documented somewhere.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)