### PR TITLE
Force using v0.11.0-rc2 yaml for the v1beta1 branch

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
+
 # FIXME(vdemeester) Remove once 0.11 is released
 export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.11.0-rc2/release.yaml
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# FIXME(vdemeester) Remove once 0.11 is released
+export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.11.0-rc2/release.yaml
+
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh
 


### PR DESCRIPTION
# Changes

Otherwise, 0.10.2 is picked up, and `v1beta1` is not present…

/cc @chmouel @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
