### PR TITLE
Add 2020 roadmap 🛣️

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Each `Task` is provided in a separate directory along with a README.md and a
 Kubernetes manifest, so you can choose which `Task`s to install on your
 cluster. A directory can hold more than one task (e.g. [`golang`](golang)).
 
+_See [our project roadmap](roadmap.md)._
+
+
 ## `Task` Kinds
 
 There are two kinds of `Task`s:
@@ -100,3 +103,5 @@ This project is still under active development, so you might run into
 [issues](https://github.com/tektoncd/catalog/issues). If you do,
 please don't be shy about letting us know, or better yet, contribute a
 fix or feature. Its folder structure is not yet set in stone either.
+
+_See [our project roadmap](roadmap.md)._

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,21 @@
+# Tekton Catalog Roadmap
+
+This doc describes the roadmap for [the Tekton Catalog](https://github.com/tektoncd/catalog).
+
+The catalog is a key piece of
+[Tekton's mission](https://github.com/tektoncd/community/blob/master/roadmap.md#mission-and-vision).
+In 2019 we got a solid start on a catalog of reusable `Tasks` and in 2020 we want to keep this momentum
+going and make the catalog even more useful by adding:
+
+* [Component versioning](https://github.com/tektoncd/pipeline/issues/1839)
+* Clear indications of which versions of Tekton Pipelines (and Triggers) a component
+  is compatible with
+* A clear story around ownership of components
+* [Support for custom catalogs](https://docs.google.com/document/d/1O8VHZ-7tNuuRjPNjPfdo8bD--WDrkcz-lbtJ3P8Wugs/edit#)
+* Support for more components, e.g. `Pipelines` and `TriggerTemplates` in
+  addition to `Tasks`
+* Increased confidence in component quality through:
+  * Clear testing requriements
+  * Support for testing components that depend on external services
+* Increased documentation and examples
+* Well defined Tekton API conformance


### PR DESCRIPTION
# Changes

In https://github.com/tektoncd/community/pull/77 we started on a roadmap
for 2020 for all of Tekton but folks pointed out it makes more sense to
let each project's own roadmap live in the repo with them.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
