### PR TITLE
Add optional input resource of type git

### DIFF
--- a/openshift-client/openshift-client-task.yaml
+++ b/openshift-client/openshift-client-task.yaml
@@ -1,9 +1,14 @@
+---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
   name: openshift-client
 spec:
   inputs:
+    resources:
+      - name: source
+        type: git
+        optional: true
     params:
       - name: SCRIPT
         description: The OpenShift CLI arguments to run
@@ -13,7 +18,7 @@ spec:
         description: The OpenShift CLI arguments to run
         type: array
         default:
-        - "help"
+          - "help"
   steps:
     - name: oc
       image: quay.io/openshift/origin-cli:latest


### PR DESCRIPTION

Fixes #239

Signed-off-by: Kamesh Sampath <ksampath@redhat.com>

# Changes

Added optional input resource could be used when need to apply manifest from sources

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
