### PR TITLE
Fix script in Maven Task and settings.xml mounting

### DIFF
--- a/jib-gradle/jib-gradle.yaml
+++ b/jib-gradle/jib-gradle.yaml
@@ -61,6 +61,8 @@ spec:
     - name: $(inputs.params.CACHE)
       mountPath: /tekton/home/.cache
       subPath: jib-cache
+    securityContext:
+      runAsUser: 0
 
   volumes:
   - name: empty-dir-volume

--- a/maven/README.md
+++ b/maven/README.md
@@ -13,7 +13,13 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/maven
 ### Parameters
 
 - **GOALS**: Maven `goals` to be executed
-- **MAVEN_MIRROR_URL**: Maven mirror url (to be inserted into ~/.m2/settings.xml)
+- **MAVEN_MIRROR_URL**: Maven mirror url (to be inserted into ~/.m2/settings.xml)   
+- **PROXY_USER**: Username to login to the proxy server (to be inserted into ~/.m2/settings.xml)
+- **PROXY_PASSWORD**: Password to login to the proxy server (to be inserted into ~/.m2/settings.xml)
+- **PROXY_HOST**: Hostname of the proxy server (to be inserted into ~/.m2/settings.xml)
+- **NON_PROXY_HOST**: Non proxy hosts to be reached directly bypassing the proxy (to be inserted into ~/.m2/settings.xml)
+- **PROXY_PORT**: Port number on which the proxy port listens (to be inserted into ~/.m2/settings.xml)
+- **PROXY_PROTOCOL**: http or https protocol whichever is applicable (to be inserted into ~/.m2/settings.xml)
 
 ### Resources
 
@@ -71,6 +77,18 @@ spec:
     params:
     - name: MAVEN_MIRROR_URL
       value: "http://localhost:8080/bucketrepo/"
+    - name: PROXY_HOST
+      value: "proxy.somewhere.com"
+    - name: PROXY_PORT
+      value: "8080"
+    - name: PROXY_USER
+      value: "yourusername"
+    - name: PROXY_PASSWORD
+      value: "yourpassword"
+    - name: NON_PROXY_HOST
+      value: "www.google.com|*.example.com"
+    - name: PROXY_PROTOCOL
+      value: "https"
   taskRef:
     name: maven
 ```
@@ -103,6 +121,30 @@ spec:
       description: The Maven bucketrepo- mirror
       type: string
       default: ""
+    - name: PROXY_USER
+      description: The username for the proxy server
+      type: string
+      default: "testuser"
+    - name: PROXY_PASSWORD
+      description: The password for the proxy server
+      type: string
+      default: "testpassword"
+    - name: PROXY_PORT
+      description: Port number for the proxy server
+      type: string
+      default: "80"
+    - name: PROXY_HOST
+      description: Proxy server Host
+      type: string
+      default: ""
+    - name: NON_PROXY_HOST
+      description: Non proxy server host
+      type: string
+      default: ""
+    - name: PROXY_PROTOCOL
+      description: Protocol for the proxy ie http or https
+      type: string
+      default: "http"
     resources:
     - name: source
       targetPath: /
@@ -111,11 +153,9 @@ spec:
     - name: mvn-settings
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
       workingDir: /.m2
-      command:
-        - '/bin/bash'
-        - '-c'
-      args:
-      - |-
+      script: |
+        #!/usr/bin/env bash
+        
         [[ -f /.m2/settings.xml ]] && \
         echo 'using already existing /.m2/settings.xml' && \
         cat /.m2/settings.xml && exit 0
@@ -131,6 +171,18 @@ spec:
               <mirrorOf>*</mirrorOf>
             </mirror>
           </mirrors>
+          <proxies>
+            <proxy>
+              <id>proxy.default</id>
+              <active>true</active>
+              <protocol>$(inputs.params.PROXY_PROTOCOL)</protocol>
+              <username>$(inputs.params.PROXY_USER)</username>
+              <password>$(inputs.params.PROXY_PASSWORD)</password>
+              <host>$(inputs.params.PROXY_HOST)</host>
+              <port>$(inputs.params.PROXY_PORT)</port>
+              <nonProxyHosts>$(inputs.params.NON_PROXY_HOST)</nonProxyHosts>
+            </proxy>
+          </proxies>
         </settings>
         EOF
 

--- a/maven/maven.yaml
+++ b/maven/maven.yaml
@@ -5,48 +5,82 @@ metadata:
 spec:
   inputs:
     params:
-    - name: GOALS
-      description: The Maven goals to run
-      type: array
-      default:
-      - "package"
-    - name: MAVEN_MIRROR_URL
-      description: The Maven bucketrepo- mirror
-      type: string
-      default: ""
+      - name: GOALS
+        description: The Maven goals to run
+        type: array
+        default:
+          - "package"
+      - name: MAVEN_MIRROR_URL
+        description: The Maven bucketrepo- mirror
+        type: string
+        default: ""
+      - name: PROXY_USER
+        description: The username for the proxy server
+        type: string
+        default: "testuser"
+      - name: PROXY_PASSWORD
+        description: The password for the proxy server
+        type: string
+        default: "testpassword"
+      - name: PROXY_PORT
+        description: Port number for the proxy server
+        type: string
+        default: "80"
+      - name: PROXY_HOST
+        description: Proxy server Host
+        type: string
+        default: ""
+      - name: NON_PROXY_HOST
+        description: Non proxy server host
+        type: string
+        default: ""
+      - name: PROXY_PROTOCOL
+        description: Protocol for the proxy ie http or https
+        type: string
+        default: "http"
     resources:
-    - name: source
-      targetPath: /
-      type: git
+      - name: source
+        targetPath: /
+        type: git
   steps:
     - name: mvn-settings
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
       workingDir: /.m2
-      command:
-        - '/bin/bash'
-        - '-c'
-      args:
-        - |-
-          [[ -f /.m2/settings.xml ]] && \
-          echo 'using existing /.m2/settings.xml' && \
-          cat /.m2/settings.xml && exit 0
+      script: |
+        #!/usr/bin/env bash
 
-          [[ -n '$(inputs.params.MAVEN_MIRROR_URL)' ]] && \
-          cat > /.m2/settings.xml <<EOF
-          <settings>
-            <mirrors>
-              <mirror>
-                <id>mirror.default</id>
-                <name>mirror.default</name>
-                <url>$(inputs.params.MAVEN_MIRROR_URL)</url>
-                <mirrorOf>*</mirrorOf>
-              </mirror>
-            </mirrors>
-          </settings>
-          EOF
+        [[ -f /.m2/settings.xml ]] && \
+        echo 'using existing /.m2/settings.xml' && \
+        cat /.m2/settings.xml && exit 0
 
-          [[ -f /.m2/settings.xml ]] && cat /.m2/settings.xml
-          [[ -f /.m2/settings.xml ]] || echo skipping settings
+        [[ -n '$(inputs.params.MAVEN_MIRROR_URL)' ]] && \
+        cat > /.m2/settings.xml <<EOF
+        <settings>
+          <mirrors>
+            <mirror>
+              <id>mirror.default</id>
+              <name>mirror.default</name>
+              <url>$(inputs.params.MAVEN_MIRROR_URL)</url>
+              <mirrorOf>*</mirrorOf>
+            </mirror>
+          </mirrors>
+          <proxies>
+            <proxy>
+              <id>proxy.default</id>
+              <active>true</active>
+              <protocol>$(inputs.params.PROXY_PROTOCOL)</protocol>
+              <username>$(inputs.params.PROXY_USER)</username>
+              <password>$(inputs.params.PROXY_PASSWORD)</password>
+              <host>$(inputs.params.PROXY_HOST)</host>
+              <port>$(inputs.params.PROXY_PORT)</port>
+              <nonProxyHosts>$(inputs.params.NON_PROXY_HOST)</nonProxyHosts>
+            </proxy>
+          </proxies>
+        </settings>
+        EOF
+
+        [[ -f /.m2/settings.xml ]] && cat /.m2/settings.xml
+        [[ -f /.m2/settings.xml ]] || echo skipping settings
       volumeMounts:
         - name: m2-repository
           mountPath: /.m2

--- a/maven/maven.yaml
+++ b/maven/maven.yaml
@@ -17,20 +17,20 @@ spec:
       - name: PROXY_USER
         description: The username for the proxy server
         type: string
-        default: "testuser"
+        default: ""
       - name: PROXY_PASSWORD
         description: The password for the proxy server
         type: string
-        default: "testpassword"
+        default: ""
       - name: PROXY_PORT
         description: Port number for the proxy server
         type: string
-        default: "80"
+        default: ""
       - name: PROXY_HOST
         description: Proxy server Host
         type: string
         default: ""
-      - name: NON_PROXY_HOST
+      - name: HTTP_PROXY_NONPROXYHOSTS
         description: Non proxy server host
         type: string
         default: ""
@@ -53,43 +53,68 @@ spec:
         echo 'using existing /.m2/settings.xml' && \
         cat /.m2/settings.xml && exit 0
 
-        [[ -n '$(inputs.params.MAVEN_MIRROR_URL)' ]] && \
         cat > /.m2/settings.xml <<EOF
         <settings>
           <mirrors>
-            <mirror>
-              <id>mirror.default</id>
-              <name>mirror.default</name>
-              <url>$(inputs.params.MAVEN_MIRROR_URL)</url>
-              <mirrorOf>*</mirrorOf>
-            </mirror>
+            <!-- ### configured mirrors ### -->
           </mirrors>
           <proxies>
-            <proxy>
-              <id>proxy.default</id>
-              <active>true</active>
-              <protocol>$(inputs.params.PROXY_PROTOCOL)</protocol>
-              <username>$(inputs.params.PROXY_USER)</username>
-              <password>$(inputs.params.PROXY_PASSWORD)</password>
-              <host>$(inputs.params.PROXY_HOST)</host>
-              <port>$(inputs.params.PROXY_PORT)</port>
-              <nonProxyHosts>$(inputs.params.NON_PROXY_HOST)</nonProxyHosts>
-            </proxy>
+            <!-- ### configured http proxy ### -->
           </proxies>
         </settings>
         EOF
 
+        if [ -n "$(inputs.params.PROXY_HOST)" -a -n "$(inputs.params.PROXY_PORT)" ]; then
+          xml="<proxy>\
+            <id>genproxy</id>\
+            <active>true</active>\
+            <protocol>$(inputs.params.PROXY_PROTOCOL)</protocol>\
+            <host>$(inputs.params.PROXY_HOST)</host>\
+            <port>$(inputs.params.PROXY_PORT)</port>"
+          if [ -n "$(inputs.params.PROXY_USER)" -a -n "$(inputs.params.PROXY_PASSWORD)" ]; then
+            xml="$xml\
+                <username>$(inputs.params.PROXY_USER)</username>\
+                <password>$(inputs.params.PROXY_PASSWORD)</password>"
+          fi
+          if [ -n "$(inputs.params.HTTP_PROXY_NONPROXYHOSTS)" ]; then
+            xml="$xml\
+                <nonProxyHosts>$(inputs.params.HTTP_PROXY_NONPROXYHOSTS)</nonProxyHosts>"
+          fi
+          xml="$xml\
+              </proxy>"
+          sed -i "s|<!-- ### configured http proxy ### -->|$xml|" /.m2/settings.xml
+        fi
+
+        if [ -n "$(inputs.params.MAVEN_MIRROR_URL)" ]; then
+          xml="    <mirror>\
+            <id>mirror.default</id>\
+            <url>$(inputs.params.MAVEN_MIRROR_URL)</url>\
+            <mirrorOf>external:*</mirrorOf>\
+          </mirror>"
+          sed -i "s|<!-- ### configured mirrors ### -->|$xml|" /.m2/settings.xml
+        fi
+
         [[ -f /.m2/settings.xml ]] && cat /.m2/settings.xml
         [[ -f /.m2/settings.xml ]] || echo skipping settings
+
       volumeMounts:
         - name: m2-repository
           mountPath: /.m2
+
     - name: mvn-goals
       image: gcr.io/cloud-builders/mvn
-      command:
-        - /usr/bin/mvn
       args:
         - "$(inputs.params.GOALS)"
+      script: |
+        #!/bin/bash
+
+        if [[ -f "/.m2/settings.xml" ]]
+        then
+          mvn ${@} --settings /.m2/settings.xml
+        else
+          mvn ${@}
+        fi
+
       volumeMounts:
         - name: m2-repository
           mountPath: /.m2

--- a/maven/tests/run.yaml
+++ b/maven/tests/run.yaml
@@ -5,8 +5,15 @@ metadata:
 spec:
   inputs:
     resources:
-    - name: source
-      resourceRef:
-        name: maven-resource-petclinic
+      - name: source
+        resourceRef:
+          name: maven-resource-petclinic
+    params:
+      - name: MAVEN_MIRROR_URL
+        value: "http://downloads.planetmirror.com/pub/maven2"
+      - name: PROXY_HOST
+        value: "proxy.somewhere.com"
+      - name: PROXY_PORT
+        value: "8080"
   taskRef:
     name: maven

--- a/maven/tests/run.yaml
+++ b/maven/tests/run.yaml
@@ -8,12 +8,5 @@ spec:
       - name: source
         resourceRef:
           name: maven-resource-petclinic
-    params:
-      - name: MAVEN_MIRROR_URL
-        value: "http://downloads.planetmirror.com/pub/maven2"
-      - name: PROXY_HOST
-        value: "proxy.somewhere.com"
-      - name: PROXY_PORT
-        value: "8080"
   taskRef:
     name: maven


### PR DESCRIPTION
Earlier settings.xml used to get created but wasn't consumed by maven during the runtime.
Now after the fix, if we provide wrong configuration in the parameters, the maven goals
fail. Also improved the script in maven-settings Task Step.

Ref: #158

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
