### PR TITLE
Add GCS Tasks to replace the GCS PipelineResources

### DIFF
--- a/gcs/README.md
+++ b/gcs/README.md
@@ -1,0 +1,246 @@
+# Google Cloud Storage Tasks
+
+These `Tasks` are for copying to and from GCS buckets from Pipelines.
+
+These `Tasks` do a similar job to the `GCS` `PipelineResource` and
+are intended as its replacement. This is part of our plan to [offer replacement
+`Tasks` for Pipeline Resources](https://github.com/tektoncd/catalog/issues/95)
+as well as
+[document those replacements](https://github.com/tektoncd/pipeline/issues/1369).
+
+## `gcs-download`
+
+A `Task` that fetches files or directories from a GCS bucket and puts them
+on a Workspace.
+
+### Workspaces
+
+* **credentials**: A workspace that contains a service account key as a JSON file.
+    This workspace should be populated from a Secret in your TaskRuns and PipelineRuns.
+* **output**: A workspace for this Task to copy the files from GCS in to.
+
+### Parameters
+
+* **name**: The name of the file or directory that will be written to the output workspace. (_required_)
+* **location**: The address, including "gs://", of the bucket you'd like to copy from. (_required_)
+* **typeDir**: Set this to "true" if the object you are copying is a directory. (_default_: "false")
+* **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
+
+## `gcs-upload`
+
+A `Task` that uploads files or directories from a Workspace to a GCS bucket.
+
+### Workspaces
+
+* **credentials**: A workspace that contains a service account key as a JSON file.
+    This workspace should be populated from a Secret in your TaskRuns and PipelineRuns.
+* **source**: A workspace where files will be uploaded from.
+
+### Parameters
+
+* **name**: The path to files or directories relative to the source workspace that you'd like to upload. (_required_)
+* **location**: The address (including "gs://") where you'd like to upload files to. (_required_)
+* **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
+
+## `gcs-create-bucket`
+
+A `Task` that creates a new GCS bucket.
+
+### Workspaces
+
+* **credentials**: A workspace that contains a service account key as a JSON file.
+    This workspace should be populated from a Secret in your TaskRuns and PipelineRuns.
+
+### Parameters
+
+* **bucketName**: The name of the bucket (including "gs://") to create. (_required_)
+* **project**: The project with which your bucket will be associated. (_required_)
+* **storageClass**: The storage class for the new bucket. STANDARD, NEARLINE, COLDLINE, or ARCHIVE. (_default_: "STANDARD")
+* **region**: The region, dual-region, or multi-region for the new bucket. (_default_: "")
+* **uniformAccess**: Set this to "true" if the bucket should be created with bucket-level permissions instead of Access Control Lists. (_default_: "false")
+* **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
+
+## `gcs-delete-bucket`
+
+A `Task` that deletes a GCS bucket.
+
+### Workspaces
+
+* **credentials**: A workspace that contains a service account key as a JSON file.
+    This workspace should be populated from a Secret in your TaskRuns and PipelineRuns.
+
+### Parameters
+
+* **bucketName**: The name of the bucket (including "gs://") to create. (_required_)
+* **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
+
+## Usage
+
+### `gcs-download`
+
+This pipeline uses the gcs-download Task to fetch a directory.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cat-file
+spec:
+  workspaces:
+  - name: source
+    mountPath: /source
+  params:
+  - name: filePath
+    description: Path to file inside "source" to cat.
+    default: "README.md"
+  steps:
+  - name: cat-readme
+    image: ubuntu
+    script: cat "$(workspaces.source.path)/$(params.filePath)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cat-file
+spec:
+  workspaces:
+  - name: gcs-credentials
+    description: A secret containing a gcloud service account key JSON file.
+  - name: shared-workspace
+    description: The GCS location will be copied into this workspace.
+  tasks:
+  - name: copy-files
+    taskRef:
+      name: gcs-download
+    workspaces:
+    - name: credentials
+      workspace: gcs-credentials
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: name
+      value: foo
+    - name: location
+      value: gs://this-is-not-a-real-bucket
+    - name: typeDir
+      value: "true"
+  - name: print-readme
+    taskRef:
+      name: cat-readme
+    runAfter:
+    - copy-files # required to ensure copy occurs before cat
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: filePath
+      value: "foo/test.txt"
+```
+
+This pipeline can be used as the following `PipelineRun` does.
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: workspace-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: cat-file-pr
+spec:
+  pipelineRef:
+    name: cat-file
+  workspaces:
+  - name: gcs-credentials
+    secret:
+      secretName: my-gcs-credentials
+      defaultMode: 0400
+  - name: shared-workspace
+    persistentVolumeClaim:
+      claimName: workspace-pvc
+```
+
+### `gcs-upload`
+
+This TaskRun uses the gcs-upload Task to upload a file from a ConfigMap.
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test-input-data
+data:
+  test_file.txt: "Hello, world!"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: upload-configmap-file-to-gcs
+spec:
+  taskRef:
+    name: gcs-upload
+  workspaces:
+  - name: credentials
+    secret:
+      secretName: my-gcs-credentials
+      defaultMode: 0400
+  - name: source
+    configMap:
+      name: test-input-data
+```
+
+### `gcs-create-bucket`
+
+This TaskRun uses the gcs-create-bucket Task to create a new bucket in the singapore region.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: test-create-a-bucket
+spec:
+  taskRef:
+    name: gcs-create-bucket
+  workspaces:
+  - name: credentials
+    secret:
+      secretName: my-gcs-credentials
+      defaultMode: 0400
+  params:
+  - name: bucketName
+    value: gs://my-fancy-new-test-bucket-12345
+  - name: project
+    value: my-test-project
+  - name: region
+    value: ASIA-SOUTHEAST1
+```
+
+### `gcs-delete-bucket`
+
+This TaskRun uses the gcs-delete-bucket Task to delete the bucket created in the previous example.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: test-delete-a-bucket
+spec:
+  taskRef:
+    name: gcs-delete-bucket
+  workspaces:
+  - name: credentials
+    secret:
+      secretName: my-gcs-credentials
+      defaultMode: 0400
+  params:
+  - name: bucketName
+    value: gs://my-fancy-new-test-bucket-12345
+```

--- a/gcs/gcs-create-bucket.yaml
+++ b/gcs/gcs-create-bucket.yaml
@@ -1,0 +1,70 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-create-bucket
+spec:
+  workspaces:
+  - name: credentials
+    description: A secret with a service account key to use as GOOGLE_APPLICATION_CREDENTIALS.
+  params:
+  - name: bucketName
+    description: |
+      The name (including "gs://") of the bucket to create.
+    type: string
+  - name: project
+    description: |
+      The project with which your bucket will be associated.
+    type: string
+  - name: storageClass
+    description: |
+      The storage class for the new bucket. STANDARD, NEARLINE, COLDLINE, or ARCHIVE.
+    type: string
+    default: STANDARD
+  - name: region
+    description: |
+      The region, dual-region, or multi-region for the new bucket.
+    type: string
+    default: ""
+  - name: uniformAccess
+    description: |
+      Set this to "true" if the bucket should be created with bucket-level permissions instead of Access Control Lists.
+    type: string
+    default: "false"
+  - name: serviceAccountPath
+    description: |
+      The path inside the credentials workspace to the GOOGLE_APPLICATION_CREDENTIALS key file.
+    type: string
+    default: service_account.json
+  steps:
+  - name: create-bucket
+    image: google/cloud-sdk
+    script: |
+      #!/usr/bin/env bash
+      set -xe
+
+      CRED_PATH="$(workspaces.credentials.path)/$(params.serviceAccountPath)"
+
+      if [[ -f "$CRED_PATH" ]]; then
+        GOOGLE_APPLICATION_CREDENTIALS="$CRED_PATH"
+      fi
+
+      if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+        echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+        gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      fi
+
+      MB_PARAMS=()
+
+      if [[ "$(params.storageClass)" != "" ]] ; then
+        MB_PARAMS+=(-c "$(params.storageClass)")
+      fi
+
+      if [[ "$(params.region)" != "" ]] ; then
+        MB_PARAMS+=(-l "$(params.region)")
+      fi
+
+      if [[ "$(params.uniformAccess)" == "true" ]] ; then
+        MB_PARAMS+=(-b on)
+      fi
+
+      gsutil mb -p "$(params.project)" "${MB_PARAMS[@]}" "$(params.bucketName)"

--- a/gcs/gcs-delete-bucket.yaml
+++ b/gcs/gcs-delete-bucket.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-delete-bucket
+spec:
+  workspaces:
+  - name: credentials
+    description: A secret with a service account key to use as GOOGLE_APPLICATION_CREDENTIALS.
+  params:
+  - name: bucketName
+    description: |
+      The name (including "gs://") of the bucket to delete.
+    type: string
+  - name: serviceAccountPath
+    description: |
+      The path inside the credentials workspace to the GOOGLE_APPLICATION_CREDENTIALS key file.
+    type: string
+    default: service_account.json
+  steps:
+  - name: delete-bucket
+    image: google/cloud-sdk
+    script: |
+      #!/usr/bin/env bash
+      set -xe
+
+      CRED_PATH="$(workspaces.credentials.path)/$(params.serviceAccountPath)"
+
+      if [[ -f "$CRED_PATH" ]]; then
+        GOOGLE_APPLICATION_CREDENTIALS="$CRED_PATH"
+      fi
+
+      if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+        echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+        gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      fi
+
+      gsutil rm -r "$(params.bucketName)"

--- a/gcs/gcs-download.yaml
+++ b/gcs/gcs-download.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-download
+spec:
+  workspaces:
+  - name: credentials
+    description: A secret with a service account key to use as GOOGLE_APPLICATION_CREDENTIALS.
+  - name: output
+    description: The workspace where files will be copied to from GCS.
+  params:
+  - name: name
+    description: The name of the file or directory that will be written to the output workspace.
+    type: string
+  - name: location
+    description: The address (including "gs://") of the bucket you'd like to copy from.
+    type: string
+  - name: typeDir
+    description: Set this to "true" if the location you are copying from is a directory.
+    type: string
+    default: "false"
+  - name: serviceAccountPath
+    description: The path inside the credentials workspace to the GOOGLE_APPLICATION_CREDENTIALS key file.
+    type: string
+    default: service_account.json
+  steps:
+  - name: copy
+    image: google/cloud-sdk
+    script: |
+      #!/usr/bin/env bash
+      set -xe
+
+      CRED_PATH="$(workspaces.credentials.path)/$(params.serviceAccountPath)"
+      DESTINATION="$(workspaces.output.path)/$(params.name)"
+
+      if [[ -f "$CRED_PATH" ]]; then
+        GOOGLE_APPLICATION_CREDENTIALS="$CRED_PATH"
+      fi
+
+      if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+        echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+        gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      fi
+
+      if [[ "$(params.typeDir)" == "true" ]]; then
+        mkdir -p "$DESTINATION"
+        gsutil rsync -d -r "$(params.location)" "$DESTINATION"
+      else
+        gsutil cp $(params.location) "$DESTINATION"
+      fi

--- a/gcs/gcs-upload.yaml
+++ b/gcs/gcs-upload.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-upload
+spec:
+  workspaces:
+  - name: credentials
+    description: A secret with a service account key to use as GOOGLE_APPLICATION_CREDENTIALS.
+  - name: source
+    description: A workspace where files will be uploaded from.
+  params:
+  - name: path
+    description: The path to files or directories relative to the source workspace that you'd like to upload.
+    type: string
+  - name: location
+    description: The address (including "gs://") where you'd like to upload files to.
+    type: string
+  - name: serviceAccountPath
+    description: The path inside the credentials workspace to the GOOGLE_APPLICATION_CREDENTIALS key file.
+    type: string
+    default: service_account.json
+  steps:
+  - name: upload
+    image: google/cloud-sdk
+    script: |
+      #!/usr/bin/env bash
+      set -xe
+
+      CRED_PATH="$(workspaces.credentials.path)/$(params.serviceAccountPath)"
+      SOURCE="$(workspaces.source.path)/$(params.path)"
+
+      if [[ -f "$CRED_PATH" ]]; then
+        GOOGLE_APPLICATION_CREDENTIALS="$CRED_PATH"
+      fi
+
+      if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+        echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+        gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      fi
+
+      if [[ -d "$SOURCE" ]]; then
+        gsutil rsync -d -r "$SOURCE" "$(params.location)"
+      else
+        gsutil cp "$SOURCE" "$(params.location)"
+      fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We are providing tasks that mimic the behaviour of our existing
PipelineResources as part of the beta.

This Commit introduces two tasks to replace the GCS PipelineResource:
1. gcs-download fetches files and directories from GCS
2. gcs-upload uploads file and directories to GCS

Each of these tasks accepts a workspace for credentials that should
contain the service account json key and a workspace to download
onto or to upload from.

Additionally, two other Tasks are added here to help support testing
of the two above:

1. gcs-create-bucket creates a new GCS bucket
2. gcs-delete-bucket deletes a GCS bucket

As above credentials are provided via a credentials workspace.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
