### PR TITLE
Fix script in Maven Task and settings.xml mounting

### DIFF
--- a/maven/README.md
+++ b/maven/README.md
@@ -17,13 +17,13 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/maven
 - **PROXY_USER**: Username to login to the proxy server (to be inserted into ~/.m2/settings.xml)
 - **PROXY_PASSWORD**: Password to login to the proxy server (to be inserted into ~/.m2/settings.xml)
 - **PROXY_HOST**: Hostname of the proxy server (to be inserted into ~/.m2/settings.xml)
-- **NON_PROXY_HOST**: Non proxy hosts to be reached directly bypassing the proxy (to be inserted into ~/.m2/settings.xml)
+- **PROXY_NON_PROXY_HOSTS**: Non proxy hosts to be reached directly bypassing the proxy (to be inserted into ~/.m2/settings.xml)
 - **PROXY_PORT**: Port number on which the proxy port listens (to be inserted into ~/.m2/settings.xml)
 - **PROXY_PROTOCOL**: http or https protocol whichever is applicable (to be inserted into ~/.m2/settings.xml)
 
 ### Resources
 
-* **source**: `git`-type `PipelineResource` specifying the location of the source to build.
+* **source**: `git`-type `PipelineResource` specifying the location of the source to build. 
 
 ## Usage
 
@@ -58,6 +58,9 @@ spec:
         name: maven-resource-petclinic
   taskRef:
     name: maven
+  workspaces:
+    - name: maven-settings
+      emptyDir: {}
 ```
 ---
 
@@ -85,7 +88,7 @@ spec:
       value: "yourusername"
     - name: PROXY_PASSWORD
       value: "yourpassword"
-    - name: NON_PROXY_HOST
+    - name: PROXY_NON_PROXY_HOSTS
       value: "www.google.com|*.example.com"
     - name: PROXY_PROTOCOL
       value: "https"
@@ -100,115 +103,46 @@ Following steps demostrate the use of a ConfigMap to mount a custom `settings.xm
 
 1. create configmap
 ```
-oc create configmap `maven-settings-cm` --from-flie settings.xml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-maven-settings
+data:
+  settings.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <settings>
+      <mirrors>
+        <mirror>
+          <id>maven.org</id>
+          <name>Default mirror</name>
+          <url>http://repo1.maven.org/maven2</url>
+          <mirrorOf>central</mirrorOf>
+        </mirror>
+      </mirrors>
+    </settings>
+
+```
+or 
+```
+oc create configmap custom-maven-settings --from-file=settings.xml
 ```
 
-1. modify Maven Task (mount config map to `maven-settings` step in Task definition. also add `maven-settings-cm` to volumes).
+2. create TaskRun
 ```
 apiVersion: tekton.dev/v1alpha1
-kind: Task
+kind: TaskRun
 metadata:
-  name: maven
+  name: maven-run
 spec:
   inputs:
-    params:
-    - name: GOALS
-      description: The Maven goals to run
-      type: array
-      default:
-      - "package"
-    - name: MAVEN_MIRROR_URL
-      description: The Maven bucketrepo- mirror
-      type: string
-      default: ""
-    - name: PROXY_USER
-      description: The username for the proxy server
-      type: string
-      default: "testuser"
-    - name: PROXY_PASSWORD
-      description: The password for the proxy server
-      type: string
-      default: "testpassword"
-    - name: PROXY_PORT
-      description: Port number for the proxy server
-      type: string
-      default: "80"
-    - name: PROXY_HOST
-      description: Proxy server Host
-      type: string
-      default: ""
-    - name: NON_PROXY_HOST
-      description: Non proxy server host
-      type: string
-      default: ""
-    - name: PROXY_PROTOCOL
-      description: Protocol for the proxy ie http or https
-      type: string
-      default: "http"
     resources:
-    - name: source
-      targetPath: /
-      type: git
-  steps:
-    - name: mvn-settings
-      image: registry.access.redhat.com/ubi8/ubi-minimal:latest
-      workingDir: /.m2
-      script: |
-        #!/usr/bin/env bash
-        
-        [[ -f /.m2/settings.xml ]] && \
-        echo 'using already existing /.m2/settings.xml' && \
-        cat /.m2/settings.xml && exit 0
-
-        [[ -n '$(inputs.params.MAVEN_MIRROR_URL)' ]] && \
-        cat > /.m2/settings.xml <<EOF
-        <settings>
-          <mirrors>
-            <mirror>
-              <id>mirror.default</id>
-              <name>mirror.default</name>
-              <url>$(inputs.params.MAVEN_MIRROR_URL)</url>
-              <mirrorOf>*</mirrorOf>
-            </mirror>
-          </mirrors>
-          <proxies>
-            <proxy>
-              <id>proxy.default</id>
-              <active>true</active>
-              <protocol>$(inputs.params.PROXY_PROTOCOL)</protocol>
-              <username>$(inputs.params.PROXY_USER)</username>
-              <password>$(inputs.params.PROXY_PASSWORD)</password>
-              <host>$(inputs.params.PROXY_HOST)</host>
-              <port>$(inputs.params.PROXY_PORT)</port>
-              <nonProxyHosts>$(inputs.params.NON_PROXY_HOST)</nonProxyHosts>
-            </proxy>
-          </proxies>
-        </settings>
-        EOF
-
-        [[ -f /.m2/settings.xml ]] && cat /.m2/settings.xml
-        [[ -f /.m2/settings.xml ]] || echo skipping settings
-      volumeMounts:
-        - name: m2-repository
-          mountPath: /.m2
-        - name: maven-configmap
-          mountPath: /.m2/settings.xml
-          subPath: settings.xml
-    - name: mvn-goals
-      image: gcr.io/cloud-builders/mvn
-      command:
-        - /usr/bin/mvn
-      args:
-        - "$(inputs.params.GOALS)"
-      volumeMounts:
-        - name: m2-repository
-          mountPath: /.m2
-  volumes:
-    - name: m2-repository
-      emptyDir: {}
-    - name: maven-configmap
+      - name: source
+        resourceRef:
+          name: maven-resource-petclinic
+    taskRef:
+      name: maven
+    workspaces:
+    - name: maven-settings
       configMap:
-        name: maven-settings-cm
+        name: custom-maven-settings
 ```
-1. create TaskRun
- 

--- a/maven/maven.yaml
+++ b/maven/maven.yaml
@@ -3,10 +3,12 @@ kind: Task
 metadata:
   name: maven
 spec:
+  workspaces:
+    - name: maven-settings
   inputs:
     params:
       - name: GOALS
-        description: The Maven goals to run
+        description: maven goals to run
         type: array
         default:
           - "package"
@@ -17,20 +19,20 @@ spec:
       - name: PROXY_USER
         description: The username for the proxy server
         type: string
-        default: "testuser"
+        default: ""
       - name: PROXY_PASSWORD
         description: The password for the proxy server
         type: string
-        default: "testpassword"
+        default: ""
       - name: PROXY_PORT
         description: Port number for the proxy server
         type: string
-        default: "80"
+        default: ""
       - name: PROXY_HOST
         description: Proxy server Host
         type: string
         default: ""
-      - name: NON_PROXY_HOST
+      - name: PROXY_NON_PROXY_HOSTS
         description: Non proxy server host
         type: string
         default: ""
@@ -40,59 +42,69 @@ spec:
         default: "http"
     resources:
       - name: source
-        targetPath: /
         type: git
+        targetPath: /
   steps:
     - name: mvn-settings
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
-      workingDir: /.m2
       script: |
         #!/usr/bin/env bash
 
-        [[ -f /.m2/settings.xml ]] && \
-        echo 'using existing /.m2/settings.xml' && \
-        cat /.m2/settings.xml && exit 0
+        [[ -f $(workspaces.maven-settings.path)/settings.xml ]] && \
+        echo 'using existing $(workspaces.maven-settings.path)/settings.xml' && \
+        cat $(workspaces.maven-settings.path)/settings.xml && exit 0
 
-        [[ -n '$(inputs.params.MAVEN_MIRROR_URL)' ]] && \
-        cat > /.m2/settings.xml <<EOF
+        cat > $(workspaces.maven-settings.path)/settings.xml <<EOF
         <settings>
           <mirrors>
-            <mirror>
-              <id>mirror.default</id>
-              <name>mirror.default</name>
-              <url>$(inputs.params.MAVEN_MIRROR_URL)</url>
-              <mirrorOf>*</mirrorOf>
-            </mirror>
+            <!-- The mirrors added here are generated from environment variables. Don't change. -->
+            <!-- ### mirrors from ENV ### -->
           </mirrors>
           <proxies>
-            <proxy>
-              <id>proxy.default</id>
-              <active>true</active>
-              <protocol>$(inputs.params.PROXY_PROTOCOL)</protocol>
-              <username>$(inputs.params.PROXY_USER)</username>
-              <password>$(inputs.params.PROXY_PASSWORD)</password>
-              <host>$(inputs.params.PROXY_HOST)</host>
-              <port>$(inputs.params.PROXY_PORT)</port>
-              <nonProxyHosts>$(inputs.params.NON_PROXY_HOST)</nonProxyHosts>
-            </proxy>
+            <!-- The proxies added here are generated from environment variables. Don't change. -->
+            <!-- ### HTTP proxy from ENV ### -->
           </proxies>
         </settings>
         EOF
 
-        [[ -f /.m2/settings.xml ]] && cat /.m2/settings.xml
-        [[ -f /.m2/settings.xml ]] || echo skipping settings
-      volumeMounts:
-        - name: m2-repository
-          mountPath: /.m2
+        xml=""
+        if [ -n "$(inputs.params.PROXY_HOST)" -a -n "$(inputs.params.PROXY_PORT)" ]; then
+          xml="<proxy>\
+            <id>genproxy</id>\
+            <active>true</active>\
+            <protocol>$(inputs.params.PROXY_PROTOCOL)</protocol>\
+            <host>$(inputs.params.PROXY_HOST)</host>\
+            <port>$(inputs.params.PROXY_PORT)</port>"
+          if [ -n "$(inputs.params.PROXY_USER)" -a -n "$(inputs.params.PROXY_PASSWORD)" ]; then
+            xml="$xml\
+                <username>$(inputs.params.PROXY_USER)</username>\
+                <password>$(inputs.params.PROXY_PASSWORD)</password>"
+          fi
+          if [ -n "$(inputs.params.PROXY_NON_PROXY_HOSTS)" ]; then
+            xml="$xml\
+                <nonProxyHosts>$(inputs.params.PROXY_NON_PROXY_HOSTS)</nonProxyHosts>"
+          fi
+          xml="$xml\
+              </proxy>"
+          sed -i "s|<!-- ### HTTP proxy from ENV ### -->|$xml|" $(workspaces.maven-settings.path)/settings.xml
+        fi
+
+        if [ -n "$(inputs.params.MAVEN_MIRROR_URL)" ]; then
+          xml="    <mirror>\
+            <id>mirror.default</id>\
+            <url>$(inputs.params.MAVEN_MIRROR_URL)</url>\
+            <mirrorOf>central</mirrorOf>\
+          </mirror>"
+          sed -i "s|<!-- ### mirrors from ENV ### -->|$xml|" $(workspaces.maven-settings.path)/settings.xml
+        fi
+
+        [[ -f $(workspaces.maven-settings.path)/settings.xml ]] && cat $(workspaces.maven-settings.path)/settings.xml
+        [[ -f $(workspaces.maven-settings.path)/settings.xml ]] || echo skipping settings
+
     - name: mvn-goals
       image: gcr.io/cloud-builders/mvn
-      command:
-        - /usr/bin/mvn
+      command: ["/usr/bin/mvn"]
       args:
+        - -s
+        - $(workspaces.maven-settings.path)/settings.xml
         - "$(inputs.params.GOALS)"
-      volumeMounts:
-        - name: m2-repository
-          mountPath: /.m2
-  volumes:
-    - name: m2-repository
-      emptyDir: {}

--- a/maven/tests/run.yaml
+++ b/maven/tests/run.yaml
@@ -5,8 +5,11 @@ metadata:
 spec:
   inputs:
     resources:
-    - name: source
-      resourceRef:
-        name: maven-resource-petclinic
+      - name: source
+        resourceRef:
+          name: maven-resource-petclinic
   taskRef:
     name: maven
+  workspaces:
+    - name: maven-settings
+      emptyDir: {}


### PR DESCRIPTION
Earlier settings.xml used to get created but wasn't consumed by maven during the runtime.
Now after the fix, if we provide wrong configuration in the parameters, the maven goals
fail. Also improved the script in maven-settings Task Step.

Ref: #158 

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
