### PR TITLE
Add a kubeconfig-creator Task to access cluster

### DIFF
--- a/kubeconfig-creator/README.md
+++ b/kubeconfig-creator/README.md
@@ -1,0 +1,127 @@
+# Kubeconfig Creator Task
+
+This `Task` do a similar job to the [Cluster](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md#cluster-resource) 
+`PipelineResource` and
+are intended as its replacement. This is part of our plan to [offer replacement
+`tasks` for Pipeline Resources](https://github.com/tektoncd/catalog/issues/95)
+as well as
+[document those replacements](https://github.com/tektoncd/pipeline/issues/1369).
+
+This task creates a [kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+file that can be used to configure access to the different clusters.
+A common use case for this task is to deploy your `application/function` on different clusters.
+
+The task will use the [kubeconfigwriter](https://github.com/tektoncd/pipeline/blob/master/cmd/kubeconfigwriter/main.go) 
+image and the provided parameters to create a `kubeconfig` file that can be used by other tasks
+in the pipeline to access the target cluster. The kubeconfig will be placed at 
+`/workspace/<workspace-name>/kubeconfig`.
+
+This task provides users variety of ways to authenticate:
+- Authenticate using tokens.
+- Authenticate using client key and client certificates.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kubeconfig-creator/kubeconfig-creator.yaml
+```
+
+## Workspace
+
+* **output**: A workspace that stores the generated kubeconfig file, such that it can be used in the other tasks to access the cluster.
+
+
+## Parameters
+
+* **Name**: Name of the `cluster`.
+* **URL**: Address of the target cluster (_e.g.:_ 
+  `https://hostname:port`)
+* **Username**: Username for basic authentication to the cluster
+(_default:_ `""`)
+* **Password**: Password for basic authentication to the cluster
+(_default:_ `""`)
+* **Cadata**: Contains PEM-encoded certificate authority certificates
+(_default:_ `""`)
+* **ClientKeyData**: Contains PEM-encoded data from a client key file for TLS
+(_default:_ `""`)
+* **ClientCertificateData**: Contains PEM-encoded data from a client cert file for TLS 
+(_default:_ `""`)
+* **Namespace**: Default namespace to use on unspecified requests
+(_default:_ `""`)
+* **Token**: Bearer token for authentication to the cluster
+(_default:_ `""`)
+* **Insecure**:  If true, skips the validity check for the server's certificate. 
+This will make your HTTPS connections insecure
+(_default:_ `false`)
+
+
+## Usage
+
+This [example](../kubeconfig-creator/example) task uses a 
+`shared workspace` with [`PVC`](https://kubernetes.io/docs/concepts/storage/persistent-volumes) 
+to store the `kubeconfig` in the `output` directory. 
+Kubeconfig file is stored at `/workspace/<workspace-name>/kubeconfig`.
+
+Task can be used with the other task in the pipeline to authenticate the cluster.
+In this example, pipeline has a task `kubeconfig-creator` that generates a 
+`kubeconfig file` for the cluster and the `test-task` uses that kubeconfig file and verifiy whether the
+application has an access to the cluster or not by using some `kubectl/oc` commands.
+
+Required `params` can be passed in the pipeline as follows:
+
+```
+params:
+  - name: name
+    value: cluster-bot
+  - name: username
+    value: admin
+  - name: url
+    value: https://api.ci-ln-13f81c2-d5d6b.origin-ci-int-aws.dev.rhcloud.com:6443
+  - name: cadata
+    value: LS0tLS1C....
+  - name: clientCertificateData
+    value: LS0tLS1C....
+  - name: clientKeyData
+    value: LS0tLS1C....
+```
+[This](../kubeconfig-creator/example/pipeline.yaml) can be referred for the pipeline example.
+
+
+`Test-task` uses shared-workspace to fetch the kubeconfig file from the
+`input` named workspace and uses `oc` commands to check whether
+ the `cluster` is configured or not.
+
+```
+steps:
+  - name: get
+    image: quay.io/openshift/origin-cli:latest
+    script: |
+      export KUBECONFIG="$(workspaces.input.path)/$(inputs.params.filename)"
+      #
+      # check that the cluster is configured
+      oc get pods
+```
+
+Workspace with `PVC` is used, as shown below.
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kubeconfig-pvc
+spec:
+  resources:
+    requests:
+      storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+   ```
+
+ Finally, PipelineRun is used to execute the tasks in the pipeline and get the results.
+ Reference for sample PipelineRun can be found [here](../kubeconfig-creator/example/pipelinerun.yaml).
+ 
+***NOTE***
+
+- Since only one `authentication` technique is allowed per user, either a `token` or a `password` should be provided, if both are provided, the password will be ignored.
+
+- `clientKeyData` and `clientCertificateData` are only required if `token` or `password` is not provided for authentication to cluster.

--- a/kubeconfig-creator/example/pers-vol.yaml
+++ b/kubeconfig-creator/example/pers-vol.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kubeconfig-pvc
+spec:
+  resources:
+    requests:
+      storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/kubeconfig-creator/example/pipeline.yaml
+++ b/kubeconfig-creator/example/pipeline.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kubeconfig-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: kubeconfig-creator
+      taskRef:
+        name: kubeconfig-creator
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: name
+          value: cluster-bot
+        - name: username
+          value: kubeadmin
+        - name: url
+          value: https://api.ci-ln-...
+        - name: cadata
+          value: LS0tLS...
+        - name: clientKeyData
+          value: LS0tLS...
+        - name: clientCertificateData
+          value: LS0tLS...
+    - name: authentication-test
+      taskRef:
+        name: authentication-test
+      workspaces:
+        - name: input
+          workspace: shared-workspace
+      params:
+        - name: filename
+          value: kubeconfig
+      runAfter:
+        - kubeconfig-creator

--- a/kubeconfig-creator/example/pipelinerun.yaml
+++ b/kubeconfig-creator/example/pipelinerun.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: kubeconfig-test-pipeline-run
+spec:
+  pipelineRef:
+    name: kubeconfig-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: kubeconfig-pvc

--- a/kubeconfig-creator/example/test-task.yaml
+++ b/kubeconfig-creator/example/test-task.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: authentication-test
+spec:
+  params:
+    - name: filename
+      description: kubeconfig file name
+      type: string
+  workspaces:
+    - name: input
+      readOnly: true
+  steps:
+    - name: get
+      image: quay.io/openshift/origin-cli:latest
+      script: |
+
+        export KUBECONFIG="$(workspaces.input.path)/$(inputs.params.filename)"
+        #
+        # check that the cluster is configured
+        oc get pods

--- a/kubeconfig-creator/kubeconfig-creator.yaml
+++ b/kubeconfig-creator/kubeconfig-creator.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kubeconfig-creator
+spec:
+  params:
+    - name: name
+      description: name of the cluster
+      type: string
+    - name: url
+      description: address of the cluster
+      type: string
+    - name: username
+      description: username for basic authentication to the cluster
+      type: string
+    - name: password
+      description: password for basic authentication to the cluster
+      type: string
+      default: ""
+    - name: cadata
+      description: contains PEM-encoded certificate authority certificates
+      type: string
+      default: ""
+    - name: clientKeyData
+      description: contains PEM-encoded data from a client key file for TLS
+      type: string
+      default: ""
+    - name: clientCertificateData
+      description: contains PEM-encoded data from a client cert file for TLS
+      type: string
+      default: ""
+    - name: namespace
+      description: default namespace to use on unspecified requests
+      type: string
+      default: ""
+    - name: token
+      description: bearer token for authentication to the cluster
+      type: string
+      default: ""
+    - name: insecure
+      description: to indicate server should be accessed without verifying the TLS certificate
+      type: string
+      default: "false"
+  workspaces:
+    - name: output
+  steps:
+    - name: write
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:latest
+      command: ["/ko-app/kubeconfigwriter"]
+      args:
+        # passing the required json in the form of string to generate the kubeconfig file.
+        #
+        - -clusterConfig
+        - '{
+              "name":"$(params.name)",
+              "url":"$(params.url)",
+              "username":"$(params.username)",
+              "password":"$(params.password)",
+              "cadata":"$(params.cadata)",
+              "clientKeyData":"$(params.clientKeyData)",
+              "clientCertificateData":"$(params.clientCertificateData)",
+              "namespace":"$(params.namespace)",
+              "token":"$(params.token)",
+              "Insecure":$(params.insecure)
+            }'
+        # path to the destination directory, where kubeconfig file will be stored.
+        - -destinationDir
+        - '$(workspaces.output.path)'


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is a part of documenting and providing task in the catalog that would help user not using PipelineResource for accesing the target cluster.
This task will be help in creating the `kubeconfig` file by providing the required cluster `credentials` to the task as a `param`.

Ref:#95

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
