### PR TITLE
Pin git-clone to the 0.11.0 version of git-init

### DIFF
--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -39,7 +39,7 @@ spec:
     description: The precise commit SHA that was fetched by this Task
   steps:
   - name: clone
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.11.0
     script: |
       CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

One of the disadvantages of using a binary built from tekton's repo as the image
of a catalog task is that changes to the binary may introduce or remove behaviour
that don't then get added or removed in the catalog task.

The git-init binary is getting a new flag, `-refspec`, that won't be available until
we cut the next pipelines release. If we use the ":latest" image tag then this flag
will silently get added to git-clone tasks but there won't be params or docs
associated with it in the catalog.

I think it would be much better if we could add this change
immediately in the `git-clone` task, independently of `git-init` in pipelines. For the time being let's pin the version of the `git-init` image used and then add the feature explicitly to the git-clone task when the new version of pipelines and the git-init image are released.

This PR pins the version of git-init used to the digest currently tagged as `:latest`.

The `-refspec` flag is being added here: https://github.com/tektoncd/pipeline/pull/2320

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
