### PR TITLE
Remove duplicate word from maven/README

### DIFF
--- a/maven/README.md
+++ b/maven/README.md
@@ -19,7 +19,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/maven
 
 ## Usage
 
-This TaskRun runs runs a Maven build
+This TaskRun runs a Maven build
 
 ### With Defaults
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The word 'run' exists twice in line 21 of maven/README.md
This commit removes one of them

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
