### PR TITLE
Test GCS Tasks

### DIFF
--- a/gcs/sample/gcs-sample.yaml
+++ b/gcs/sample/gcs-sample.yaml
@@ -1,0 +1,124 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: gcs-triggertemplate
+spec:
+  params:
+    - name: pvc-name
+    - name: project-name
+    - name: secret-name
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        name: gcs-pr-$(uid)
+      spec:
+        workspaces:
+        - name: data
+          persistentVolumeClaim:
+            claimName: $(params.pvc-name)
+        - name: credentials
+          secret:
+            secretName: $(params.secret-name)
+        pipelineSpec:
+          workspaces:
+          - name: data
+          - name: credentials
+          tasks:
+          - name: gcs-create-bucket
+            taskRef:
+              name: gcs-create-bucket
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            params:
+            - name: bucketName
+              value: gs://tekton-test-bucket-$(uid)
+            - name: project
+              value: $(params.project-name)
+          - name: create-data
+            runAfter: [gcs-create-bucket]
+            taskSpec:
+              workspaces:
+              - name: data
+              steps:
+              - name: write-data
+                image: ubuntu
+                script: |
+                  #!/usr/bin/env bash
+                  set -xe
+                  mkdir -p $(workspaces.data.path)/$(uid)/test_data/
+                  echo "Test data $(uid)" > $(workspaces.data.path)/$(uid)/test_data/test.txt
+            workspaces:
+            - name: data
+              workspace: data
+          - name: gcs-upload
+            taskRef:
+              name: gcs-upload
+            runAfter: [create-data]
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            - name: source
+              workspace: data
+            params:
+            - name: path
+              value: $(uid)
+            - name: location
+              value: gs://tekton-test-bucket-$(uid)
+            - name: serviceAccountPath
+              value: service_account.json
+          - name: gcs-download
+            taskRef:
+              name: gcs-download
+            runAfter: [gcs-upload]
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            - name: output
+              workspace: data
+            params:
+            - name: path
+              value: download-$(uid)
+            - name: location
+              value: gs://tekton-test-bucket-$(uid)
+            - name: typeDir
+              value: "true"
+            - name: serviceAccountPath
+              value: service_account.json
+          - name: verify-data
+            runAfter: [gcs-download]
+            workspaces:
+            - name: data
+              workspace: data
+            taskSpec:
+              workspaces:
+              - name: data
+              steps:
+              - image: ubuntu
+                script: |
+                  #!/usr/bin/env bash
+                  set -xe
+                  cat $(workspaces.data.path)/download-$(uid)/test_data/test.txt | grep "Test data $(uid)"
+          - name: delete-bucket
+            taskRef:
+              name: gcs-delete-bucket
+            runAfter: [gcs-download]
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            params:
+            - name: bucketName
+              value: gs://tekton-test-bucket-$(uid)
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gcs-test-storage
+spec:
+  resources:
+    requests:
+      storage: 16Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tasks in the catalog don't currently have a uniform approach to testing. It would be good if the catalog provided some kind of blessed path and supporting infrastructure so that Tasks can be exercised as part of PRs.

This commit includes a test for the GCS tasks that utilizes triggers to kick off a pipelinerun. There are still some decisions to be made around how service account generation might work, how the needed infra gets spun up, and how the triggers get _triggered_ in the first place, but this demonstrates the general idea.

author: @bobcatfish 
coauthor: @sbwsg

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
