### PR TITLE
the removed line fails if a checkout hasn't yet happened

### DIFF
--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -60,7 +60,6 @@ spec:
 
       if [[ "$(params.deleteExisting)" == "true" ]] ; then
         cleandir
-        ls -lah "$CHECKOUT_DIR"
       fi
 
       /ko-app/git-init \


### PR DESCRIPTION

# Changes

(cherry picked from commit d5bf0f75112f524c3cf2125c4544b5631979723f)

This PR cherry-picks a bug fix from the master branch to the v1beta1 branch.  The `ls -lah` that used to appear in the git-clone Task could cause errors.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.