### PR TITLE
Handle TaskRun as well as PipelineRun tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ the task and then every yaml files that you have in that `tests/` directory.
 
 Usually in these other yaml files you would have a yaml file for the
 test resources (`PipelineResource`) and a yaml files to run the tasks
-(`TaskRun`).
+(`TaskRun or PipelineRun`).
 
 Sometime you may need to be able to launch some scripts before applying the
 tested task or the other yaml files. Some may pre-setup something on the

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -123,6 +123,18 @@ function test_task_creation() {
 
             status=$(kubectl get -n ${tns} pipelinerun --output=jsonpath='{.items[*].status.conditions[*].status}')
             reason=$(kubectl get -n ${tns} pipelinerun --output=jsonpath='{.items[*].status.conditions[*].reason}')
+
+            if [[ -z ${status} && -z ${reason} ]];then
+                status=$(kubectl get -n ${tns} taskrun --output=jsonpath='{.items[*].status.conditions[*].status}')
+                reason=$(kubectl get -n ${tns} taskrun --output=jsonpath='{.items[*].status.conditions[*].reason}')
+            fi
+
+            if [[ -z ${status} || -z ${reason} ]];then
+                echo -n "FAILS: Could not find a created taskrun or pipelinerun in ${tns}"
+                show_failure ${testname} ${tns}
+                exit
+            fi
+
             [[ ${status} == *ERROR || ${reason} == *Failed || ${reason} == CouldntGetTask || ${reason} == CouldntGetPipeline ]] && show_failure ${testname} ${tns}
             [[ ${status} == True ]] && {
                 echo -n "SUCCESS: ${testname} pipelinerun has successfully executed: " ;


### PR DESCRIPTION
Allow test Taskruns 

We were only running the PipelineRuns type of test but let allow the Taskruns too

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [?] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
