### PR TITLE
Add batch merge and refspec support to git task

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -31,6 +31,7 @@ as well as
 
 * **url**: git url to clone (_required_)
 * **revision**: git revision to checkout (branch, tag, sha, ref…) (_default:_ master)
+* **refspec**: git refspec to fetch before checking out revision (_default_:refs/heads/master:refs/heads/master)
 * **submodules**: defines if the resource should initialize and fetch the submodules (_default_: true)
 * **depth**: performs a shallow clone where only the most recent commit(s) will be fetched (_default_: 1)
 * **sslVerify**: defines if http.sslVerify should be set to true or false in the global git config (_default_: true)
@@ -135,3 +136,48 @@ spec:
     persistentVolumeClaim:
       claimName: workspace-pvc
 ```
+
+## `git-batch-merge`
+
+This task takes a set of refspecs, fetches them and performs git operations
+(cherry-pick or merge) to apply them in order on the given base revision (default master).
+The resulting commit SHA will not match across taskruns, but the git tree SHA should
+match. This can be useful for batch testing changes, for example, when you want to
+batch up your PRs into a single merge by taking the HEAD of the branch you want to merge
+to, and adding all the PRs to it. This concept is used in tools such as [Tide][tide] to
+batch test PR's, and [Zuul CI Gating][zuul-ci], to perform speculative execution of
+PR's/change requests individually
+
+This `Task` has four required inputs:
+
+1. The URL of a git repo to clone provided with the `url` param.
+1. A space separated string of refs `BatchedRefs` to fetch and batch over the given `revision`
+1. Merge `mode` to use while batching (merge, merge-resolve, merge-squash, cherry-pick)
+1. A Workspace called `output`.
+
+There are 4 additional parameters in addition to the ones mentioned above for the git-clone task:
+* **batchedRefs**: space separated git [refnames][git-ref] to fetch and batch on top of revision using the given mode
+    (must be a valid refs, no commit SHA's).
+* **mode**: Batch mode to select (_default_: merge) <br>
+  &nbsp;&nbsp;`merge`: corresponds to git merge -s recursive. This is the default mode used by github <br>
+  &nbsp;&nbsp;`cherry-pick`: corresponds to git cherry-pick <br>
+  See [git-merge][git-merge] and [git-cherry-pick][git-cherry-pick]
+* **gitUserName**: git user name to use for creating the batched commit (First Last)
+    (_default_: GitBatch Task). See [git-user-config][git-user-config]
+* **gitUserEmail**: git user email to use for creating the batched commit (First.Last@domain.com)
+  (_default_: GitBatch.Task@tekton.dev). See [git-user-config][git-user-config]
+
+### Results
+
+* **commit**: The precise commit SHA that was fetched by this Task
+* **tree**: The [git tree][git-tree] object SHA that was created after batch merging the refs on HEAD.
+
+### Usage
+
+[git-ref]: https://git-scm.com/book/en/v2/Git-Internals-Git-References
+[git-merge]: https://git-scm.com/docs/git-merge
+[git-cherry-pick]: https://git-scm.com/docs/git-cherry-pick
+[git-user-config]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-username
+[git-tree]: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+[tide]: https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/README.md
+[zuul-ci]: https://zuul-ci.org/docs/zuul/discussion/gating.html

--- a/git/git-batch-merge.yaml
+++ b/git/git-batch-merge.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: git-clone
+  name: git-batch-merge
 spec:
   workspaces:
     - name: output
@@ -11,12 +11,28 @@ spec:
       description: git url to clone
       type: string
     - name: revision
-      description: git revision to checkout (branch, tag, sha, ref…)
+      description: base git revision to checkout (branch, tag, sha, ref…)
       type: string
       default: master
     - name: refspec
-      description: (optional) git refspec to fetch before checking out revision
-      default: ""
+      description: base git refspec to fetch before checking out revision
+      type: string
+      default: "refs/heads/master:refs/heads/master"
+    - name: batchedRefs
+      description: git refs to fetch and batch on top of revision using the given mode (must be a valid refname, no commit SHA's)
+      type: string
+    - name: gitUserName
+      description: git user name to use for creating the batched commit (First Last)
+      type: string
+      default: GitBatch Task
+    - name: gitUserEmail
+      description: git user email to use for creating the batched commit (First.Last@domain.com)
+      type: string
+      default: GitBatch.Task@tekton.dev
+    - name: mode
+      description: git operation to perform while batching (choose from merge, cherry-pick)
+      type: string
+      default: merge
     - name: submodules
       description: defines if the resource should initialize and fetch the submodules
       type: string
@@ -32,14 +48,16 @@ spec:
     - name: subdirectory
       description: subdirectory inside the "output" workspace to clone the git repo into
       type: string
-      default: ""
+      default: "src"
     - name: deleteExisting
       description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
       type: string
       default: "false"
   results:
     - name: commit
-      description: The precise commit SHA that was fetched by this Task
+      description: The final commit SHA that was obtained after batching all provided refs onto revision
+    - name: tree
+      description: The git tree SHA that was obtained after batching all provided refs onto revision.
   steps:
     - name: clone
       image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.0
@@ -65,20 +83,40 @@ spec:
           cleandir
         fi
 
+        p="$(params.batchedRefs)"
+        refs="$(params.refspec)"
+        for ref in $p; do
+          refs="$refs $ref:refs/batch/$ref"
+        done
+
         /ko-app/git-init \
           -url "$(params.url)" \
           -revision "$(params.revision)" \
-          -refspec "$(params.refspec)" \
+          -refspec "$refs" \
           -path "$CHECKOUT_DIR" \
           -sslVerify="$(params.sslVerify)" \
           -submodules="$(params.submodules)" \
           -depth "$(params.depth)"
-        cd "$CHECKOUT_DIR"
-        RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
-        EXIT_CODE="$?"
-        if [ "$EXIT_CODE" != 0 ]
-        then
-          exit $EXIT_CODE
+
+        git -C $CHECKOUT_DIR config user.name "$(params.gitUserName)"
+        git -C $CHECKOUT_DIR config user.email "$(params.gitUserEmail)"
+
+        mode="$(params.mode)"
+        if [[ $mode == "merge" ]]; then
+          for ref in $p; do
+             git -C $CHECKOUT_DIR merge --quiet --allow-unrelated-histories refs/batch/$ref
+          done
+        elif [[ $mode == "cherry-pick" ]]; then
+          for ref in $p; do
+             git -C $CHECKOUT_DIR cherry-pick --allow-empty --keep-redundant-commits refs/batch/$ref
+          done
+        else
+            echo "unsupported mode $mode"
+            exit 1
         fi
+
+        RESULT_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD)"
+        TREE_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD^{tree})"
         # Make sure we don't add a trailing newline to the result!
-        echo -n "$RESULT_SHA" > $(results.commit.path)
+        echo -n "$(echo $RESULT_SHA | tr -d '\n')" > $(results.commit.path)
+        echo -n "$(echo $TREE_SHA | tr -d '\n')" > $(results.tree.path)

--- a/git/tests/run.yaml
+++ b/git/tests/run.yaml
@@ -116,3 +116,41 @@ spec:
         value: https://github.com/kelseyhightower/nocode
       - name: deleteExisting
         value: "true"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-batch-merge-test-mode-merge
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-batch-merge
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: mode
+        value: "merge"
+      - name: batchedRefs
+        value: "refs/pull/4014/head refs/pull/3894/head"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-batch-merge-test-mode-merge-cherry-pick
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-batch-merge
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: mode
+        value: "cherry-pick"
+      - name: batchedRefs
+        value: "refs/pull/4014/head refs/pull/3894/head"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add refspec support to git task corresponding to https://github.com/tektoncd/pipeline/pull/2320

Add a new batch merge task (https://github.com/tektoncd/pipeline/issues/508) that re-uses
the git-init container and subsequently performs the requested batch merge mode on top of
the checked out revision

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [?] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.