### PR TITLE
Add Replace Tokens Task

### DIFF
--- a/replace-tokens/README.md
+++ b/replace-tokens/README.md
@@ -1,0 +1,136 @@
+# Replace Tokens
+
+This task can be used to replace tokens in a file. The supported file types are `YAML` and `JSON`. 
+The following task can be explained by taking an example of a `JSON` file :-
+
+config.json
+```
+{
+  "image": "$(image)",
+  "server": "$(server)",
+  "dbname": "$(dbname)",
+  "password": "$(dbpass)"
+}
+```
+token.json
+```
+{
+  "image": "ubuntu",
+  "server": "localhost:3306",
+  "dbname": "tektondb",
+  "dbpass": "tektonpass"
+}
+```
+After replacing the config.json becomes:-
+```
+{
+  "image": "ubuntu",
+  "server": "localhost:3306",
+  "dbname": "tektondb",
+  "password": "tektonpass"
+}
+```
+The above same can be done for the `YAML` file also.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/replace-tokens/replace-tokens.yaml
+```
+
+## Parameters
+
+- **inputFilePath**: The file path whose value needs to be replaced.
+
+## Resources
+
+* `Persistent Volume claim` to store the json file, in which token is replaced.
+* `ConfigMap` contains file `tokens.json` or `token.yaml` which stores the tokens and corresponding value that need to be replaced.
+* `Workspace` to mount file containing tokens and its corresponding value, and PVC to store the replaced file.
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: replace-tokens-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+```
+
+## Usage
+
+This task will use the input param `inputFilePath`, this is provided by the [git clone](https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml) task, which clones the target repository containing the json or yaml file to be replaced.
+
+ConfigMap is created from the `tokens.json` or `tokens.yaml` file, which contains tokens and its corresponding value that needs to be replaced. ConfigMap is mounted in the workspace, which is used in the task to access the `tokens.json` or `tokens.yaml` file.
+`ConfigMap` should be created using this file. Following `command` can be used to create congfigmap from the `file`.
+```
+kubectl create configmap tokens-configmap --from-file=tokens.json
+```
+or
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tokens-configmap
+data:
+  tokens.json: |
+    { "hello":"bye", "fortnite":"league of legends", "github":"tekton" }
+```
+
+Create the Pipeline and PipelineRun
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: replace-tokens-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: json-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/vinamra28/replace-tokens-plugin.git
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: replace-tokens
+      taskRef:
+        name: replace-tokens
+      params:
+        - name: inputFilePath
+          value: "./sample1.json"
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: token
+          workspace: json-workspace
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: replace-tokens-pipeline-run
+spec:
+  pipelineRef:
+    name: replace-tokens-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: replace-tokens-source-pvc
+    - name: json-workspace
+      configmap: 
+        name: tokens-configmap
+```

--- a/replace-tokens/replace-tokens.yaml
+++ b/replace-tokens/replace-tokens.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: replace-tokens
+spec:
+  workspaces:
+    - name: source
+    - name: token
+  params:
+    - name: inputFilePath
+      type: string
+      description: The file path whose value needs to be replaced
+  steps:
+    - name: replace-tokens
+      image: quay.io/vinamra2807/replace-tokens:latest
+      workingDir: $(workspaces.source.path)
+      args:
+        - --inputfile=$(params.inputFilePath)
+        - --tokensfile=$(workspaces.token.path)/tokens.json

--- a/replace-tokens/tests/configmap.yaml
+++ b/replace-tokens/tests/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tokens-configmap
+data:
+  tokens.json: |
+    { "name": "token-replace", "image": "ubuntu" }

--- a/replace-tokens/tests/pre-apply-task-hook.sh
+++ b/replace-tokens/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/replace-tokens/tests/resource.yaml
+++ b/replace-tokens/tests/resource.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: replace-tokens-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/replace-tokens/tests/run.yaml
+++ b/replace-tokens/tests/run.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: replace-tokens-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: json-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/vinamra28/replace-tokens-plugin.git
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: replace-tokens
+      taskRef:
+        name: replace-tokens
+      params:
+        - name: inputFilePath
+          value: "./sample.yaml"
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: token
+          workspace: json-workspace
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: replace-tokens-pipeline-run
+spec:
+  pipelineRef:
+    name: replace-tokens-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: replace-tokens-source-pvc
+    - name: json-workspace
+      configmap: 
+        name: tokens-configmap


### PR DESCRIPTION
# Changes
The Replace Tokens task can be used to replace the tokens in a `JSON` or `YAML` file. Provided there is a config.json or a yaml file in a git repository which contains some secret tokens can be replaced during a TaskRun by providing a tokens.json or tokens.yaml file as a part of ConfigMap. 

Link to the source code of the replace tokens :- https://github.com/vinamra28/replace-tokens-plugin

Signed-off-by: vinamra28 <vinjain@redhat.com>

Authors: @Divyansh42 @vinamra28 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
