### PR TITLE
don't run buildpacks prepare step as privileged

### DIFF
--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -55,8 +55,6 @@ spec:
           mountPath: /layers
         - name: $(inputs.params.CACHE)
           mountPath: /cache
-      securityContext:
-        privileged: true
 
     - name: detect
       image: $(inputs.params.BUILDER_IMAGE)


### PR DESCRIPTION
# Changes

Remove unnecessary privileged securityContext from buildpacks-v3 task `prepare` step.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
