### PR TITLE
git-clone: fix git-init flags

### DIFF
--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -66,9 +66,9 @@ spec:
         -url "$(params.url)" \
         -revision "$(params.revision)" \
         -path "$CHECKOUT_DIR" \
-        -sslVerify "$(params.sslVerify)" \
-        -submodules "$(params.submodules)" \
-        -depth "$(params.depth)"
+        -sslVerify="$(params.sslVerify)" \
+        -submodules="$(params.submodules)" \
+        -depth="$(params.depth)"
       cd "$CHECKOUT_DIR"
       RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
       EXIT_CODE="$?"


### PR DESCRIPTION
fixes #275

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Use flag=val for bool and int flags passed to git-init

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
