### PR TITLE
Add Kubectl sample, porting from version "v1alpha1"

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -1,0 +1,50 @@
+# Kubectl
+
+This Task deploys (or delete) a Kubernates resource (pod). It uses
+[`kubectl`](https://kubernetes.io/zh/docs/reference/kubectl/kubectl/) for that.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kubectl/kubectl-deploy.yaml
+```
+
+## Install ClusterRolebinding
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kubectl/clusterrolebinding.yaml
+```
+
+## Inputs 
+
+### Parameters
+
+* **manifest:**: The content of the resource to deploy
+
+## Usage
+
+This TaskRun runs the Task to deploy the given Kubernetes resource.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kubectl-deploy-pod
+spec:
+  taskRef:
+    name: kubectl-deploy-pod
+  params:
+  - name: manifest
+    value: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: myapp-pod
+        labels:
+          app: myapp
+      spec:
+        containers:
+        - name: myapp-container
+          image: docker
+          command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 3600']
+```

--- a/kubectl/clusterrolebinding.yaml
+++ b/kubectl/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: default-admin
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubectl/kubectl-deploy.yaml
+++ b/kubectl/kubectl-deploy.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kubectl-deploy-pod
+  namespace: default
+spec:
+  params:
+  - name: manifest
+    description: Content of the resource to deploy
+  - name: image
+    default: gcr.io/cloud-builders/kubectl # it is huge
+    description: Kubectl wrapper image
+  steps:
+  - name: kubeconfig
+    image: $(params.image)
+    script: |
+      echo "$(params.manifest)" > /tmp/resource.yaml
+      kubectl create -f /tmp/resource.yaml

--- a/kubectl/taskrun.yaml
+++ b/kubectl/taskrun.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kubectl-deploy-pod
+spec:
+  taskRef:
+    name: kubectl-deploy-pod
+  params:
+  - name: manifest
+    value: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: myapp-pod
+        labels:
+          app: myapp
+      spec:
+        containers:
+        - name: myapp-container
+          image: docker
+          command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 3600']


### PR DESCRIPTION
Fix issue: #233 , Porting from `v1alpha1`

Use a image with `kubectl` installed, we can setup `step` of `task` in tekton to create arbitrary rsource of kubernates.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
