### PR TITLE
Fix image digest result in kaniko task

### DIFF
--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -34,7 +34,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kanik
 
 ## Results
 
-* **digest**: The digest of the image just built.
+* **IMAGE-DIGEST**: The digest of the image just built.
 
 ## ServiceAccount
 

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -20,7 +20,7 @@ spec:
   workspaces:
   - name: source
   results:
-  - name: IMAGE_DIGEST
+  - name: IMAGE-DIGEST
     description: Digest of the image just built.
 
   steps:
@@ -45,6 +45,7 @@ spec:
     workingDir: $(workspaces.source.path)
     image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.11.1
     # output of imagedigestexport [{"name":"image","digest":"sha256:eed29..660"}]
+    # output of imagedigestexport [{"key":"digest","value":"sha256:eed29..660","resourceRef":{"name":"myrepo/myimage"}}]
     command: ["/ko-app/imagedigestexporter"]
     args:
     - -images=[{"name":"$(params.IMAGE)","type":"image","url":"$(params.IMAGE)","digest":"","OutputImageDir":"$(workspaces.source.path)/image-digest"}]
@@ -53,4 +54,4 @@ spec:
     workingDir: $(workspaces.source.path)
     image: stedolan/jq
     script: |
-      cat image-digested | jq '.[0].digest' | tee /tekton/results/IMAGE_DIGEST
+      cat image-digested | jq -j '.[0].value' | tee /tekton/results/IMAGE-DIGEST

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -44,7 +44,6 @@ spec:
   - name: write-digest
     workingDir: $(workspaces.source.path)
     image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.11.1
-    # output of imagedigestexport [{"name":"image","digest":"sha256:eed29..660"}]
     # output of imagedigestexport [{"key":"digest","value":"sha256:eed29..660","resourceRef":{"name":"myrepo/myimage"}}]
     command: ["/ko-app/imagedigestexporter"]
     args:

--- a/kaniko/tests/run.yaml
+++ b/kaniko/tests/run.yaml
@@ -36,6 +36,24 @@ spec:
       value: $(params.image)
     - name: EXTRA_ARGS
       value: "--skip-tls-verify"
+  - name: verify-digest
+    runAfter:
+    - kaniko
+    params:
+    - name: digest
+      value: $(tasks.kaniko.results.IMAGE-DIGEST)
+    taskSpec:
+      params:
+      - name: digest
+      steps:
+      - name: bash
+        image: ubuntu
+        script: |
+          echo $(params.digest)
+          case .$(params.digest) in
+            ".sha"*) exit 0 ;;
+            *)       echo "Digest value is not correct" && exit 1 ;;
+          esac
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun


### PR DESCRIPTION
Fixes #285 

# Changes

* Fixes kaniko.yaml as described in the issue.
* Updates the e2e test to test that the digest result is working.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
