### PR TITLE
Remove default git Task subdir 📁

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -34,7 +34,7 @@ as well as
 * **submodules**: defines if the resource should initialize and fetch the submodules (_default_: true)
 * **depth**: performs a shallow clone where only the most recent commit(s) will be fetched (_default_: 1)
 * **sslVerify**: defines if http.sslVerify should be set to true or false in the global git config (_default_: true)
-* **subdirectory**: subdirectory inside the "output" workspace to clone the git repo into (_default:_ src)
+* **subdirectory**: subdirectory inside the "output" workspace to clone the git repo into (_default:_ "")
 * **deleteExisting**: clean out the contents of the repo's destination directory if it already exists before cloning the repo there (_default_: false)
 
 ### Results

--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -29,7 +29,7 @@ spec:
   - name: subdirectory
     description: subdirectory inside the "output" workspace to clone the git repo into
     type: string
-    default: "src"
+    default: ""
   - name: deleteExisting
     description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
     type: string


### PR DESCRIPTION
# Changes

I tried to use this Task to replace use of a git PipelineResource and
was really stumped for a while because I didn't realize that my code was
checked out by default into a directory called "src" in the workspace. I
think it makes sense to let folks specify a subdir if they want it but
I'm not sure that "src" is an intuitive default so this commit removes
it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
