### PR TITLE
Fix kaniko digest results 🔧

### DIFF
--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -64,12 +64,4 @@ spec:
   - name: source
     persistentVolumeClaim:
       claimName: my-source
-  resources:
-    outputs:
-    - name: image
-      resourceSpec:
-        type: image
-        params:
-        - name: url
-          value: gcr.io/my-repo/my-image
 ```

--- a/kaniko/kaniko.yaml
+++ b/kaniko/kaniko.yaml
@@ -38,7 +38,7 @@ spec:
     - --dockerfile=$(params.DOCKERFILE)
     - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
     - --destination=$(params.IMAGE)
-    - --oci-layout-path=$(workspaces.source.path)/image-digest
+    - --oci-layout-path=$(workspaces.source.path)/$(params.CONTEXT)/image-digest
     securityContext:
       runAsUser: 0
   - name: write-digest
@@ -47,10 +47,10 @@ spec:
     # output of imagedigestexport [{"key":"digest","value":"sha256:eed29..660","resourceRef":{"name":"myrepo/myimage"}}]
     command: ["/ko-app/imagedigestexporter"]
     args:
-    - -images=[{"name":"$(params.IMAGE)","type":"image","url":"$(params.IMAGE)","digest":"","OutputImageDir":"$(workspaces.source.path)/image-digest"}]
-    - -terminationMessagePath=image-digested
+    - -images=[{"name":"$(params.IMAGE)","type":"image","url":"$(params.IMAGE)","digest":"","OutputImageDir":"$(workspaces.source.path)/$(params.CONTEXT)/image-digest"}]
+    - -terminationMessagePath=$(params.CONTEXT)/image-digested
   - name: digest-to-results
     workingDir: $(workspaces.source.path)
     image: stedolan/jq
     script: |
-      cat image-digested | jq -j '.[0].value' | tee /tekton/results/IMAGE-DIGEST
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE-DIGEST


### PR DESCRIPTION
# Changes

I tried to use the kaniko task to update the build + deploy pipelinerun
example in the pipelines repo and run into some trouble which I have
fixed here:
- The jq parsing of the digest from the imagedigestexporter output
  wasn't quite right, the name of the field was incorrect and it was
  surrounded by quotes (removed with -r) and followed by a newline
  (removed with -j)
- If the kaniko Task was used more than once with the same workspace,
  even if it was building from different directories, the digests would
  conflict b/c it was always writing to the same files. Now the files it
  writes to are relative to the context the image is alreayd using to
  build

I've also extended the test so that it both verifies that a digest is
parsed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [😅 ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
