### PR TITLE
Do not use layers in buildah task, since layer caching depends on timestamps (unreliable in a CI/CD

### DIFF
--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -29,7 +29,7 @@ spec:
   - name: build
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
-    command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(params.IMAGE)', '$(params.CONTEXT)']
+    command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--no-cache', '-f', '$(params.DOCKERFILE)', '-t', '$(params.IMAGE)', '$(params.CONTEXT)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers


### PR DESCRIPTION

# Changes

See discussion in https://github.com/tektoncd/catalog/issues/265. Although using
 layer caching in the buildah build would be nice, there are two prerequisites:
* A PVC to store the cache between pipeline runs
* A fix for https://github.com/containers/buildah/issues/2215

The buildah issue is that buildah uses file timestamps to invalidate the cache. Locally, this works well, but in a CI/CD the files will always be freshly downloaded from source control, so they will be newer than the cache. This means the cache would never be used, even if it was available in a PVC. 
 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
