### PR TITLE
Add OpenShift Client Python task

### DIFF
--- a/openshift-client-python/Dockerfile
+++ b/openshift-client-python/Dockerfile
@@ -1,0 +1,15 @@
+FROM quay.io/openshift/origin-cli:latest AS oc
+
+
+FROM centos:7 as builder
+
+RUN yum --enablerepo=extras install -y epel-release && \
+    yum install -y python2 python-pip && \
+    pip install openshift-client
+COPY --from=oc . . 
+
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+COPY --from=builder . . 
+
+ENTRYPOINT /bin/sh

--- a/openshift-client-python/README.md
+++ b/openshift-client-python/README.md
@@ -1,0 +1,87 @@
+# Python OpenShift Runner
+[OpenShift](http://www.openshift.com) is a Kubernetes distribution from Red Hat which provides `oc`, the [OpenShift CLI](https://docs.openshift.com/container-platform/4.1/cli_reference/getting-started-cli.html) that complements `kubectl` for simplifying deployment and configuration applications on OpenShift.
+The following task can be used to interact with the openshift cluster via `oc` commands in a python script.
+
+The set of possible scripts can be found in the docs [here](https://github.com/openshift/openshift-client-python/blob/master/README.md#usage). 
+
+## Pre-requisites
+
+1. Need to have an OpenShift cluster up and running.
+2. `config` file of the cluster needs to be mounted via the `Secrets` to the default location `~/.kube/` in order to obtain the cluster details.
+
+## Install the Task
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/openshift-client-python/openshift-client-python.yaml
+```
+
+## Parameters
+
+* **SCRIPT**: The `python` script which you want to run in the task. Default script would be :-
+```
+#!/usr/bin/python
+
+import openshift as oc
+print('OpenShift client version: {}'.format(oc.get_client_version()))
+print('OpenShift server version: {}'.format(oc.get_server_version()))
+```
+
+## Workspaces
+
+* **kubeconfig-mount**: The following workspace is used to mount the `config` file of the `kubeconfig` from the `Secrets`.
+
+The `Secrets` can be created by 
+```
+oc create secret generic kubeconfig --from-file=config
+```
+
+## TaskRun
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: openshift-client-python-run
+spec:
+  taskRef:
+    name: openshift-client-python
+  params:
+    - name: SCRIPT
+      value: |
+        #!/usr/bin/python
+
+        import openshift as oc
+
+        print('OpenShift client version: {}'.format(oc.get_client_version()))
+        print('OpenShift server version: {}'.format(oc.get_server_version()))
+        
+        # Set a project context for all inner `oc` invocations and limit execution to 10 minutes
+        with oc.project('openshift-infra'), oc.timeout(10*60):
+          # Print the list of qualified pod names (e.g. ['pod/xyz', 'pod/abc', ...]  in the current project
+          print('Found the following pods in {}: {}'.format(oc.get_project_name(), oc.selector('pods').qnames()))
+
+          # Read in the current state of the pod resources and represent them as python objects
+          for pod_obj in oc.selector('pods').objects():
+            
+            # The APIObject class exposes several convenience methods for interacting with objects
+            print('Analyzing pod: {}'.format(pod_obj.name()))
+            pod_obj.print_logs(timestamps=True, tail=15)
+            
+            # If you need access to the underlying resource definition, get a Model instance for the resource
+            pod_model = pod_obj.model
+            
+            # Model objects enable dot notation and allow you to navigate through resources
+            # to an arbitrary depth without checking if any ancestor elements exist.
+            # In the following example, there is no need for boilerplate like:
+            #    `if .... 'ownerReferences' in pod_model['metadata'] ....`
+            # Fields that do not resolve will always return oc.Missing which 
+            # is a singleton and can also be treated as an empty dict.
+            for owner in pod_model.metadata.ownerReferences:  # ownerReferences == oc.Missing if not present in resource
+              # elements of a Model are also instances of Model or ListModel
+              if owner.kind is not oc.Missing:  # Compare as singleton
+                print('  pod owned by a {}'.format(owner.kind))  # e.g. pod was created by a StatefulSet
+    
+  workspaces:
+    - name: kubeconfig-mount
+      secret:
+        secretName: kubeconfig
+```

--- a/openshift-client-python/openshift-client-python.yaml
+++ b/openshift-client-python/openshift-client-python.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: openshift-client-python
+spec:
+  workspaces:
+    - name: kubeconfig-mount
+      mountPath: /tekton/home/.kube
+  params:
+    - name: SCRIPT
+      description: Python script to be executed
+      type: string
+      default: |
+        #!/usr/bin/python
+
+        import openshift as oc
+
+        print('OpenShift client version: {}'.format(oc.get_client_version()))
+        print('OpenShift server version: {}'.format(oc.get_server_version()))
+  steps:
+    - name: execute-script
+      image: quay.io/vinamra2807/openshift-client-python:latest
+      script: $(params.SCRIPT)


### PR DESCRIPTION
# Changes

The following task can be used to interact with the openshift cluster via `oc` commands in a python script.

The set of possible scripts can be found in the docs [here](https://github.com/openshift/openshift-client-python/blob/master/README.md#usage). 

The `Dockerfile` is there as a part of PR which consists of the `openshift-cli` binary and `python` binary

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
