### PR TITLE
(master -> v1beta1) Add Kythe golang extractor task.

### DIFF
--- a/kythe/README.md
+++ b/kythe/README.md
@@ -1,0 +1,18 @@
+# Kythe
+
+These `Tasks` are [Kythe](https://kythe.io) tasks to generating annotations for
+source code.
+
+## `kythe-go`
+
+The `kythe-go` `Task` runs the
+[Kythe Go extractor](https://github.com/kythe/kythe/tree/master/kythe/go/extractors/cmd/gotool)
+for the given package, placing the resulting kzips in the `output` workspace.
+
+### Workspaces
+
+- **output**: A workspace for this Task to place kzip outputs into.
+
+### Parameters
+
+- **package**: Go package pattern to analyze.

--- a/kythe/kythe-go.yaml
+++ b/kythe/kythe-go.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kythe-go
+spec:
+  workspaces:
+    - name: output
+      description: Output directory for kzip output files.
+  params:
+    - name: package
+      type: string
+      description: Go package to analyze.
+  steps:
+    - name: analyze-packages
+      image: gcr.io/kythe-public/golang-extractor:stable
+      env:
+        - name: OUTPUT
+          value: $(workspaces.output.path)
+      args: ["$(params.package)"]

--- a/kythe/tests/run.yaml
+++ b/kythe/tests/run.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kythe-go
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: kythe-go
+  params:
+    - name: package
+      value: github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is a cherry-pick of https://github.com/tektoncd/catalog/pull/284 into the v1beta1 branch. During the window where catalog's default branch was switched from `master` to `v1beta1` it's possible that some PRs were merged to master but not to v1beta1.  This appears to be one of those, so I'm pulling it across here.

Description from the original PR:

This task allows you to generate Kythe annotation metadata for a given
Go project. This follows the workspace model as presented by the `git`
Task. The expectation is that any results place in the workspace will be
exported by another Task in the pipeline for remote storage (e.g. GCS,
etc).

(cherry picked from commit 20d449cd435e12b902595d91d785da4d168939ad)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
