### PR TITLE
[WIP] Add generic git task - with alternative auth

### DIFF
--- a/git-ssh/README.md
+++ b/git-ssh/README.md
@@ -1,0 +1,35 @@
+git-clone ssh
+====
+
+Prepare secrets for ssh authentication.
+
+### Prepare known_hosts file
+Example using github.com as host
+
+1. Create file with known_hosts (you may also want to verify this further)
+
+    ssh-keyscan github.com > ssh_known_hosts
+
+2. Create secret from file
+
+    kubectl create secret generic github-known-hosts --from-file=ssh_known_hosts
+
+### Generate and distribute SSH key pair
+Generate a separate SSH key pair for Tekton
+
+1. Generate keypair to local file
+
+    ssh-keygen -t rsa -b 4096 -f id_rsa -q -N ""
+
+2. Create a secret from the private key
+
+   kubectl create secret generic github-private-key --from-file=id_rsa
+
+3. Upload the public key id_rsa.pub to GitHub
+
+   Start with copying the content of the public key with
+
+    pbcopy < id_rsa.pub
+
+   And follow [Adding a new SSH key to your GitHub account](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account)
+~                                                                                                                                                                   

--- a/git-ssh/git-clone-ssh.yaml
+++ b/git-ssh/git-clone-ssh.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone-ssh
+spec:
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this workspace
+  params:
+    - name: url
+      type: string
+      description: git url to clone
+  steps:
+    - name: git-clone
+      image: bitnami/git:2.26.2
+      command: ['git', '-c', 'core.sshCommand=ssh -i /etc/ssh/id_rsa', 'clone', '$(params.url)', '$(workspaces.output.path)']
+      volumeMounts:
+        - mountPath: /etc/ssh
+          name: ssh-auth
+  volumes:
+    - name: ssh-auth
+      projected:
+        defaultMode: 0400
+        sources:
+          - secret:
+              name: github-known-hosts
+          - secret:
+              name: github-private-key


### PR DESCRIPTION
# Changes
The existing [git-clone task](https://github.com/tektoncd/catalog/tree/v1beta1/git) is very opinionated and custom. This task use a generic _git image_. The plan is to add tasks for `git-add`, `git-commit` and `git-push` as well.

This commit also shows an alternative way to setup authentication. This authentication is independent of [Tekton Pipeline Auth documentation](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md) and does not use _annotations on Secrets_ and no need for custom _credential initialization process_ and does not copy or move any sensitive values, but mount them using a projected volume.

Related to https://github.com/tektoncd/pipeline/issues/2343

/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
