### PR TITLE
Add image-digest as Result in Buildah task

### DIFF
--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -25,6 +25,10 @@ spec:
   workspaces:
   - name: source
 
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+
   steps:
   - name: build
     image: $(params.BUILDER_IMAGE)
@@ -39,12 +43,16 @@ spec:
   - name: push
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
-    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '--digestfile', '$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
     securityContext:
       privileged: true
+
+  - name: digest-to-results
+    image: $(params.BUILDER_IMAGE)
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
 
   volumes:
   - name: varlibcontainers


### PR DESCRIPTION
# Changes

The Buildah task does not have a task result. Tasks executing after this task is interested in the resulting image-digest. This commit adds the pushed image-digest as a task result, very similar to the task result in the Kaniko task.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
