### PR TITLE
(master -> v1alpha1) adding proxy settings to git-clone

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -38,6 +38,9 @@ as well as
 * **sslVerify**: defines if http.sslVerify should be set to true or false in the global git config (_default_: true)
 * **subdirectory**: subdirectory inside the "output" workspace to clone the git repo into (_default:_ src)
 * **deleteExisting**: clean out the contents of the repo's destination directory if it already exists before cloning the repo there (_default_: false)
+* **httpProxy**: git HTTP proxy server for non-SSL requests
+* **httpsProxy**: git HTTPS proxy server for SSL requests
+* **noProxy**: git no proxy - opt out of proxying HTTP/HTTPS requests
 
 ### Results
 

--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -35,6 +35,18 @@ spec:
       description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
       type: string
       default: "false"
+    - name: httpProxy
+      description: git HTTP proxy server for non-SSL requests
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: git HTTPS proxy server for SSL requests
+      type: string
+      default: ""
+    - name: noProxy
+      description: git no proxy - opt out of proxying HTTP/HTTPS requests
+      type: string
+      default: ""
   results:
   - name: commit
     description: The precise commit SHA that was fetched by this Task
@@ -62,6 +74,10 @@ spec:
       if [[ "$(inputs.params.deleteExisting)" == "true" ]] ; then
         cleandir
       fi
+
+      test -z "$(inputs.params.httpProxy)" || export HTTP_PROXY=$(inputs.params.httpProxy)
+      test -z "$(inputs.params.httpsProxy)" || export HTTPS_PROXY=$(inputs.params.httpsProxy)
+      test -z "$(inputs.params.noProxy)" || export NO_PROXY=$(inputs.params.noProxy)
 
       /ko-app/git-init \
         -url "$(inputs.params.url)" \


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adding httpsProxy, httpProxy, and noProxy in git-clone task.

Originally added here: #231 and now being cherry-picked into the v1alpha1 branch.

(cherry picked from commit 13037cb)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
