### PR TITLE
Add Blue-Green Deployment using K8s

### DIFF
--- a/task/blue-green-deploy/0.1/README.md
+++ b/task/blue-green-deploy/0.1/README.md
@@ -1,0 +1,86 @@
+# Blue Green Deploy on Kubernetes
+
+The following task can help you to deploy an application using the Blue-Green deployment strategy. This task gives you the flexibility to deploy a version of the application from the blue zone to the green zone without disturbing the previous version in the blue zone. It works by making the service point to the newer version of the application deployed.
+
+- If you are deploying the first version of the application then it will go into the blue zone and for that you need to provide deployment and service manifests via the `workspaces` and in the `params` the service name and version. Sample Kubernetes manifests for version v1 can be found [here](./example/v1-deploy).
+- For further new deployments, it will get deployed in the other zone and then the current service will now point to the new deployment. For example if we have a deployment running in the blue zone then we will deploy the next deployment in the green zone and make the service point to the green zone or vice versa.
+
+## Installing the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/blue-green-deploy/0.1/blue-green-deploy.yaml
+```
+
+## Installing the ClusterRoleBinding
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/blue-green-deploy/0.1/support/clusterrolebinding.yaml
+```
+
+## Workspaces
+
+- **manifest-dir**: Manifest files can be provided via the workspaces.(Default: _emptyDir:{}_ in case no manifest is provided)
+- **kubeconfig-dir**: If you want to deploy you application to another cluster then you can mount your `kubeconfig` file via this `workspace`. (Default: _emptyDir:{}_ in case `kubeconfig` is not mounted)
+
+## Parameters
+
+- **SERVICE_NAME**: The service name pointing to the existing deployment. (_Note_: The service name for the new deployment should be same)
+- **NEW_VERSION**: The version of the deployment to be deployed in the green/blue zone
+- **MANIFEST**: The deployment manifest URL file path provided in case the manifest is present on Github. (_Example_: "https://raw.githubusercontent.com/tektoncd/catalog/master/task/blue-green-deploy/0.1/example/v1-deploy/blue-deployment.yaml")
+
+# Usage
+
+This TaskRun runs the Task to deploy the given Kubernetes resource in the green/blue zone and toggle the service to point to the new zone.
+
+## Without using ConfigMap
+
+TaskRun :-
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: blue-green-deploy-run
+spec:
+  taskRef:
+    name: blue-green-deploy-k8s
+  params:
+    - name: SERVICE_NAME
+      value: myapp
+    - name: NEW_VERSION
+      value: v2
+    - name: MANIFEST
+      value: "https://raw.githubusercontent.com/tektoncd/catalog/master/task/blue-green-deploy/0.1/example/v2-deploy/green-deployment.yaml"
+  workspaces:
+    - name: manifest-dir
+      emptyDir: {}
+```
+
+## Using ConfigMap
+
+1. Create the `ConfigMap`
+
+```bash
+kubectl create configmap manifests --from-file="green-deployment.yaml"
+```
+
+2. TaskRun:-
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: blue-green-deploy-run
+spec:
+  taskRef:
+    name: blue-green-deploy-k8s
+  params:
+    - name: SERVICE_NAME
+      value: myapp
+    - name: NEW_VERSION
+      value: v2
+  workspaces:
+    - name: manifest-dir
+      configMap:
+        name: manifests
+```

--- a/task/blue-green-deploy/0.1/blue-green-deploy.yaml
+++ b/task/blue-green-deploy/0.1/blue-green-deploy.yaml
@@ -33,6 +33,7 @@ spec:
       workingDir: $(workspaces.manifest-dir.path)
       script: |
         #!/usr/bin/env bash
+        set -u -o pipefail
 
         if [[ -f $(workspaces.kubeconfig-dir.path)/kubeconfig ]]; then
           export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
@@ -79,7 +80,7 @@ spec:
           for reason in $(getReasons $deploy_name); do
             if [[ "$reason" == "ProgressDeadlineExceeded" ]]; then
               local status=$(getStatusAtIndex $deploy_name ${INDEX})
-              [[ "$status" != "False" ]] && return 0 || return 1
+              [[ "$status" == "True" ]] && return 0 || return 1
             fi
             ((INDEX++))
           done
@@ -104,6 +105,12 @@ spec:
             [[ $? -eq 0 ]] && break
             sleep 5
           done
+          # If ProgressDeadlineExceeded then break from the main
+          # and avoid checking for the next condition
+          checkProgressDeadline ${deploy_name}
+          if [[ $? -eq 0 ]]; then
+            echo "Failed to change the service" && break
+          fi
           # If MinimumReplicas are available then check
           # for the unavailable Pods
           # Also checking for the ProgressDeadlineExceeded condition

--- a/task/blue-green-deploy/0.1/blue-green-deploy.yaml
+++ b/task/blue-green-deploy/0.1/blue-green-deploy.yaml
@@ -1,0 +1,130 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: blue-green-deploy
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: deployment
+    tekton.dev/displayName: "blue green deployment"
+spec:
+  description: >-
+    This task can be used to do Blue-Green deployment
+  workspaces:
+    - name: manifest-dir
+      description: Consisting of kubernetes manifests
+    - name: kubeconfig-dir
+      description: Can be used in case kubeconfig file is mounted
+  params:
+    - name: SERVICE_NAME
+      type: string
+      description: Name of the service which is pointing to existing deployment
+    - name: NEW_VERSION
+      type: string
+      description: The version of newer deployment which is to be patched to existing service
+    - name: MANIFEST
+      type: string
+      default: "."
+      description: The newer version of the deployment to be deployed in another zone
+  steps:
+    - name: change-deployment
+      image: quay.io/openshift/origin-cli:latest
+      workingDir: $(workspaces.manifest-dir.path)
+      script: |
+        #!/usr/bin/env bash
+
+        if [[ -f $(workspaces.kubeconfig-dir.path)/kubeconfig ]]; then
+          export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
+        fi
+
+        getReasons() {
+          local deploy_name=$1
+          kubectl get deploy "$deploy_name" \
+            -o jsonpath='{range .status.conditions[*]}{.reason}{"\n"}{end}'
+        }
+
+        # Getting the status at particular index
+        getStatusAtIndex() {
+          local deploy_name=$1
+          local index=$2
+          kubectl get deploy "$deploy_name" \
+            -o jsonpath='{range .status.conditions['$index']}{.status}{"\n"}{end}'
+        }
+
+        # Checking for unavailable pods in case the deployment is
+        # patched with a newer image
+        checkUnavailableReplicas() {
+          local deploy_name=$1
+          local replicasUnavailable=$(kubectl get deploy "$deploy_name" -o jsonpath='{.status.unavailableReplicas}')
+          [[ "$replicasUnavailable" == "" ]] && return 0 || return 1
+        }
+
+        getMinimumReplicaStatus() {
+          local deploy_name=$1
+          local INDEX=0
+          for reason in $(getReasons $deploy_name); do
+            if [[ "$reason" == "MinimumReplicasAvailable" ]]; then
+              local ready=$(getStatusAtIndex $deploy_name ${INDEX})
+              [[ "$ready" != "True" ]] && return 1 || return 0
+            fi
+            ((INDEX++))
+          done
+          return 1
+        }
+
+        checkProgressDeadline() {
+          local deploy_name=$1
+          local INDEX=0
+          for reason in $(getReasons $deploy_name); do
+            if [[ "$reason" == "ProgressDeadlineExceeded" ]]; then
+              local status=$(getStatusAtIndex $deploy_name ${INDEX})
+              [[ "$status" != "False" ]] && return 0 || return 1
+            fi
+            ((INDEX++))
+          done
+          return 1
+        }
+
+        main() {
+          local deploy_name=$(params.SERVICE_NAME)-$(params.NEW_VERSION)
+          local service=$(params.SERVICE_NAME)
+          local version=$(params.NEW_VERSION)
+
+          kubectl apply -f $(params.MANIFEST)
+
+          # Wait until the Deployment is ready by checking the
+          # MinimumReplicasAvailable condition.
+          # Also checking for the ProgressDeadlineExceeded
+          # condition
+          while true; do
+            getMinimumReplicaStatus ${deploy_name}
+            [[ $? -eq 0 ]] && break
+            checkProgressDeadline ${deploy_name}
+            [[ $? -eq 0 ]] && break
+            sleep 5
+          done
+          # If MinimumReplicas are available then check
+          # for the unavailable Pods
+          # Also checking for the ProgressDeadlineExceeded condition
+          while true; do
+            checkUnavailableReplicas ${deploy_name}
+            [[ $? -eq 0 ]] && break
+            checkProgressDeadline ${deploy_name}
+            [[ $? -eq 0 ]] && break
+            sleep 5
+          done
+
+          # Update the service selector with the new version
+          # if ProgressDeadline not exceeded
+          checkProgressDeadline ${deploy_name}
+          if [[ $? -eq 0 ]]; then
+            echo "Failed to change the service"
+          else
+            kubectl patch svc ${service} \
+              -p "{\"spec\":{\"selector\": {\"app\": \"${service}\", \"version\": \"${version}\"}}}"
+            echo "Done."
+          fi
+        }
+
+        main "$@"

--- a/task/blue-green-deploy/0.1/samples/run.yaml
+++ b/task/blue-green-deploy/0.1/samples/run.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: blue-green-deploy-run
+spec:
+  taskRef:
+    name: blue-green-deploy
+  params:
+    - name: SERVICE_NAME
+      value: myapp
+    - name: NEW_VERSION
+      value: v2
+    - name: MANIFEST
+      value: "https://raw.githubusercontent.com/vinamra28/blue-green-deployment-k8s/master/deployment%2Bservice/green-deployment.yaml"
+  workspaces:
+    - name: manifest-dir
+      emptyDir: {}
+    - name: kubeconfig-dir
+      emptyDir: {}

--- a/task/blue-green-deploy/0.1/samples/v1-deploy/blue-deployment.yaml
+++ b/task/blue-green-deploy/0.1/samples/v1-deploy/blue-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: myapp
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: "myapp"
+        version: "v1"
+    spec:
+      containers:
+        - name: myapp
+          image: janakiramm/myapp:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http

--- a/task/blue-green-deploy/0.1/samples/v1-deploy/service.yaml
+++ b/task/blue-green-deploy/0.1/samples/v1-deploy/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp
+  labels:
+    app: myapp
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      name: http
+      targetPort: 80
+  selector:
+    app: myapp
+    version: v1

--- a/task/blue-green-deploy/0.1/samples/v2-deploy/green-deployment.yaml
+++ b/task/blue-green-deploy/0.1/samples/v2-deploy/green-deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-v2
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: myapp
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: "myapp"
+        version: "v2"
+    spec:
+      containers:
+        - name: myapp
+          image: janakiramm/myapp:v2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http

--- a/task/blue-green-deploy/0.1/support/clusterrolebinding.yaml
+++ b/task/blue-green-deploy/0.1/support/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: default-blue-green
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Changes

Blue-Green deployment is one of the deployment strategy being used to deploy the newer version of the application on kubernetes keeping the previous version in production so that if newer version fails then the router can be switched back to the previous version of the deployment without any downtime.

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
