### PR TITLE
Improve examples for the git-clone Task

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -46,96 +46,11 @@ as well as
 
 ### `git-clone`
 
-This pipeline uses the git-clone Task to check out the
-[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline) repository
-and then display that repo's README.md.
+The following pipelines demonstrate usage of the git-clone Task:
 
-A workspace called "shared-workspace" is passed first to the `git-clone`
-Task for the code to be checked out on and then to the `cat-readme` Task
-to print the README.md file from.
-
-After the Pipeline has run you'll be able to see a
-[Task Result](https://github.com/tektoncd/pipeline/blob/master/docs/taskruns.md#results)
-named `commit` in the PipelineRun's Status with the commit SHA that was
-fetched by the `git-clone` Task.
-
-```yaml
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: cat-readme
-spec:
-  workspaces:
-  - name: source
-    mountPath: /source
-  params:
-  - name: subdirectory
-    description: Subdirectory inside "source" workspace that contains the README.md.
-    default: "."
-  steps:
-  - name: cat-readme
-    image: ubuntu
-    script: cat "$(workspaces.source.path)/$(params.subdirectory)/README.md"
----
-apiVersion: tekton.dev/v1beta1
-kind: Pipeline
-metadata:
-  name: cat-pipeline-readme
-spec:
-  workspaces:
-  - name: shared-workspace
-    # description: The git repo will be cloned into this workspace and the readme will be read from it.
-  tasks:
-  - name: fetch-repository
-    taskRef:
-      name: git-clone
-    workspaces:
-    - name: output
-      workspace: shared-workspace
-    params:
-    - name: url
-      value: https://github.com/tektoncd/pipeline.git
-    - name: subdirectory
-      value: pipeline-checkout
-  - name: print-readme
-    taskRef:
-      name: cat-readme
-    runAfter:
-    - fetch-repository # required to ensure clone occurs before reading
-    workspaces:
-    - name: source
-      workspace: shared-workspace
-    params:
-    - name: subdirectory
-      value: pipeline-checkout
-```
-
-This pipeline can be used as the following `PipelineRun` does.
-
-```yaml
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: workspace-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 500Mi
----
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: cat-pipeline-readme-run
-spec:
-  pipelineRef:
-    name: cat-pipeline-readme
-  workspaces:
-  - name: shared-workspace
-    persistentVolumeClaim:
-      claimName: workspace-pvc
-```
+- [Cloning a branch](./examples/git-clone-checking-out-a-branch.yaml)
+- [Checking out a specific git commit](./examples/git-clone-checking-out-a-commit.yaml)
+- [Checking out a git tag and using the "commit" Task Result](./examples/using-git-clone-task-result.yaml)
 
 ## `git-batch-merge`
 

--- a/git/examples/git-clone-checking-out-a-branch.yaml
+++ b/git/examples/git-clone-checking-out-a-branch.yaml
@@ -1,0 +1,86 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cat-branch-readme
+spec:
+  description: |
+    cat-branch-readme takes a git repository and a branch name and
+    prints the README.md file from that branch. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a branch
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: branch-name
+    type: string
+    description: The git branch to clone.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the repo's README.md file to be read.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.branch-name)
+  - name: cat-readme
+    runAfter: ["fetch-repo"] # Wait until the clone is done before reading the readme.
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          cat $(workspaces.source.path)/README.md
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-checking-out-a-branch
+spec:
+  podTemplate:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: "tekton.dev/pipelineRun"
+              operator: In
+              values:
+              - git-clone-checking-out-a-branch
+          topologyKey: kubernetes.io/hostname
+  pipelineRef:
+    name: cat-branch-readme
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: branch-name
+    value: release-v0.12.x

--- a/git/examples/git-clone-checking-out-a-commit.yaml
+++ b/git/examples/git-clone-checking-out-a-commit.yaml
@@ -1,0 +1,87 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: checking-out-a-revision
+spec:
+  description: |
+    checking-out-a-revision takes a git repository and a commit SHA
+    and validates that cloning the revision succeeds. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a specific commit
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: commit
+    type: string
+    description: The git commit to fetch.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the commit to be checked.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.commit)
+  - name: compare-received-commit-to-expected
+    runAfter: ["fetch-repo"] # Wait until the clone is done before reading the readme.
+    params:
+    - name: expected-commit
+      value: $(params.commit)
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      params:
+      - name: expected-commit
+      workspaces:
+      - name: source
+      steps:
+      - image: alpine/git:v2.24.3
+        script: |
+          #!/usr/bin/env sh
+          cd $(workspaces.source.path)
+          receivedCommit=$(git rev-parse HEAD)
+          if [ $receivedCommit != $(params.expected-commit) ]; then
+            echo "Expected commit $(params.expected-commit) but received $receivedCommit."
+            exit 1
+          else
+            echo "Received commit $receivedCommit as expected."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-clone-checking-out-a-commit-
+spec:
+  pipelineRef:
+    name: checking-out-a-revision
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: commit
+    value: 301b41380e95382a18b391c2165fa3a6a3de93b0 # Tekton Pipeline's first ever commit!

--- a/git/examples/using-git-clone-result.yaml
+++ b/git/examples/using-git-clone-result.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: validate-tag-sha
+spec:
+  description: |
+    validate-tag-sha takes a git repository, tag name, and a commit SHA and
+    checks whether the given tag resolves to that commit. This example
+    Pipeline demonstrates the following:
+      - How to use the git-clone catalog Task
+      - How to use the git-clone Task's "commit" Task Result from another Task.
+      - How to discard the contents of the git repo when it isn't needed by
+        passing an `emptyDir` Volume as its "output" workspace.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: tag-name
+    type: string
+    description: The git tag to clone.
+  - name: expected-sha
+    type: string
+    description: The expected SHA to be received for the supplied revision.
+  workspaces:
+  - name: output
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: output
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.tag-name)
+  - name: validate-revision-sha
+    params:
+    - name: revision-name
+      value: $(params.tag-name)
+    - name: expected-sha
+      value: $(params.expected-sha)
+    - name: received-sha
+      value: $(tasks.fetch-repository.results.commit)
+    taskSpec:
+      params:
+      - name: revision-name
+      - name: expected-sha
+      - name: received-sha
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          if [ "$(params.expected-sha)" != "$(params.received-sha)" ]; then
+            echo "Expected revision $(params.revision-name) to have SHA $(params.expected-sha)."
+            exit 1
+          else
+            echo "Revision $(params.revision-name) has expected SHA $(params.expected-sha)."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: using-git-clone-result-
+spec:
+  pipelineRef:
+    name: validate-tag-sha
+  workspaces:
+  - name: output
+    emptyDir: {} # We don't care about the repo contents in this example, just the "commit" result
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: tag-name
+    value: v0.12.1
+  - name: expected-sha
+    value: a54dd3984affab47f3018852e61a1a6f9946ecfa


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes https://github.com/tektoncd/catalog/issues/320

The git-clone example only demonstrated the very simplest of behaviour and didn't provide much in the way of instruction on using its features.

This PR adds examples for cloning a branch, cloning a specific commit, and cloning tags. Each example includes clear description of its purpose and the features it demonstrates.

I've removed the inline git-clone example from the README because it's really long and the
README needs to serve the purpose of documenting multiple Tasks (git-clone as well as git-batch-merge, and any future Tasks we add as well). Rather than bloat the README with many examples which can go stale if we modify git-clone's behaviour I've simply linked to the new example files.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
