### PR TITLE
Update to Pipelines 0.12.1 for e2e tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -16,8 +16,7 @@
 
 set -x
 
-# FIXME(vdemeester) Remove once 0.11 is released
-export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.11.0-rc2/release.yaml
+export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.12.1/release.yaml
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We've been using Pipelines 0.11.0-rc2 for e2e tests but that's now several months old and there are features in 0.12+ that we can expect to appear in Catalog Tasks and their Tests.  Here's an example of a PR that relies on 0.12 features (volumeClaimTemplate) as part of the tests it runs: https://github.com/tektoncd/catalog/pull/321

This commit attempts to update the version of Tekton used for e2e tests.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
