### PR TITLE
Correct subdirectory error in git-clone's README

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -13,9 +13,9 @@ This `Task` has two required inputs:
 2. A Workspace called `output`.
 
 The `git-clone` `Task` will clone a repo from the provided `url` into the
-`output` Workspace. By default the repo will be cloned into a subdirectory
-called "src" in your Workspace. You can clone into an alternative subdirectory
-by setting this `Task`'s `subdirectory` param.
+`output` Workspace. By default the repo will be cloned into the root of
+your Workspace. You can clone into a subdirectory by setting this `Task`'s
+`subdirectory` param.
 
 This `Task` does the job of the legacy `GitResource` `PipelineResource` and
 is intended as its replacement. This is part of our plan to [offer replacement


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

By default git-clone now checks out a repo directly into the root
of the provided workspace. The README still states in one spot that
it checks out to the "src" subdirectory by default but this is no longer true.

This commit updates the content of the README to correctly reflect
the fact that git-clone checks out directly into the workspace's root.

(We updated the default subdirectory here: https://github.com/tektoncd/catalog/pull/290)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

