### PR TITLE
Bump git-init image to 0.12.1

### DIFF
--- a/git/git-batch-merge.yaml
+++ b/git/git-batch-merge.yaml
@@ -60,7 +60,7 @@ spec:
       description: The git tree SHA that was obtained after batching all provided refs onto revision.
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.0
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.1
       script: |
         CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 

--- a/git/git-clone.yaml
+++ b/git/git-clone.yaml
@@ -54,7 +54,7 @@ spec:
       description: The precise commit SHA that was fetched by this Task
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.0
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.1
       script: |
         CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 


### PR DESCRIPTION
This will bump git-init image to 0.12.1 which is
latest

This will probably fix #312 and #297

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
