### PR TITLE
Add support for merge requests in GitLab add-labels task

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -26,22 +26,22 @@ stringData:
   token: $(personal_access_token)
 ```
 
-## Add labels to an issue in Gitlab
+## Add labels to the GitLab issue or Merge Request
 
-[This task](../gitlab/issue-add-labels.yaml) can be used to add labels to the gitlab issue.
+[This task](../gitlab/add-labels.yaml) can be used to add labels to the gitlab `issue` or `merge request` (pull request).
 
 
 ### Install the Task
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/gitlab/issue-add-labels.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/gitlab/add-labels.yaml
 ```
 
 ### Parameters
 
 - **GITLAB_HOST_URL**: The Gitlab host(_default:_`gitlab.com`).
 - **API_PATH_PREFIX**: The API path prefix (_default.:_`api/v4`).
-- **REQUEST_URL**: The Gitlab issue URL where we want to add labels (_e.g._`https://gitlab.com/foo/bar/issues/10`).
+- **REQUEST_URL**: The Gitlab issue or merge request URL where we want to add labels (_e.g._`https://gitlab.com/foo/bar/issues/10`).
 - **LABELS**: The actual labels to add.
 - **GITLAB_TOKEN_SECRET**: The name of the `secret` holding the gitlab-token (_default:_`gitlab`).
 - **GITLAB_TOKEN_SECRET_KEY**: The name of the `secret key` holding the gitlab-token (_default:_`token`).
@@ -55,9 +55,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/gitl
 ### Usage
 
 
-This task expects a secret named `gitlab` to exists, with a Gitlab token in `token` with enough privileges to add label to an issue.
+This task expects a secret named `gitlab` to exist, with a Gitlab token in `token` with enough privileges to add label to an issue.
 
-To add labels to an issue, put all the required params, add required secrets and labels will be created.
+To add labels to an issue or merge request, put all the required params, add required secrets and labels will be created.
 
 
 `Taskrun` can be created as follows:
@@ -72,7 +72,7 @@ spec:
     name: gitlab-add-label
   params:
     - name: REQUEST_URL
-      value: https://gitlab.com/Divyanshu42/aws-cli/-/issues/1
+      value: https://gitlab.com/Divyanshu42/aws-cli/-/issues/1  # or https://gitlab.com/Divyanshu42/aws-cli/-/merge_requests/1
     - name: LABELS
       value: 
         - bug

--- a/gitlab/add-labels.yaml
+++ b/gitlab/add-labels.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: gitlab-add-label
   description: |
-    This Task will add a label to an issue in Gitlab.
+    This Task will add labels to an issue or merge request (pull request) in Gitlab.
 spec:
   params:
   - name: GITLAB_HOST_URL
@@ -20,7 +20,7 @@ spec:
 
   - name: REQUEST_URL
     description: |
-      The Gitlab issue URL where we want to add a label.
+      The Gitlab issue or merge request URL where we want to add a label.
     type: string
 
   - name: LABELS
@@ -56,11 +56,13 @@ spec:
         split_url = urllib.parse.urlparse(
             "$(params.REQUEST_URL)").path.split("/")
 
-        # This will convert https://gitlab.com/foo/bar/pull/202 to
-        # api url path /projects/foo/bar/issues/202
+        # Creating the API URL
 
+        # This will convert https://gitlab.com/foo/bar/issues/202 to
+        # api url path /projects/foo/bar/issues/202
+        
         api_url = "$(params.API_PATH_PREFIX)" + "/projects/" + "%2F".join(split_url[1:3]) + \
-                  "/issues/" + split_url[-1]
+                  "/" + split_url[4] + "/" + split_url[-1]
 
 
         # Get array of Labels


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Current task only support adding labels to Gitlab `issue` and doesn't have support for `merge requests`. Added support for merge requests in the same task.
Now we can add labels to `merge requests` as well.

Signed-off-by: Divyansh42 <diagrawa@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
