### PR TITLE
Add git-clone-ssh

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -177,6 +177,17 @@ There are 4 additional parameters in addition to the ones mentioned above for th
 
 ### Usage
 
+## `git-clone-ssh`
+
+This task does `git clone` using SSH with the authentication described in [Git SSH Auth](./git-ssh-auth.md).
+
+This `Task` has two input parameters:
+
+1. `url` (**required**) is the url to the git repository
+2. `path` (optional) is the path on the workspace volume, `code` is default directory.
+
+See [example `Pipeline`](./git-ssh-auth.md#example-pipeline)
+
 [git-ref]: https://git-scm.com/book/en/v2/Git-Internals-Git-References
 [git-merge]: https://git-scm.com/docs/git-merge
 [git-cherry-pick]: https://git-scm.com/docs/git-cherry-pick

--- a/git/git-clone-ssh.yaml
+++ b/git/git-clone-ssh.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone-ssh
+spec:
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this workspace
+  params:
+    - name: url
+      type: string
+      description: git url to clone
+    - name: path
+      type: string
+      default: code
+      description: path on the workspace to where the files are cloned
+  steps:
+    - name: git-clone
+      image: bitnami/git:2.26.2
+      command: ['git', '-c', 'core.sshCommand=ssh -i /etc/ssh/id_rsa', 'clone', '$(params.url)', '$(workspaces.output.path)/$(params.path)']
+      volumeMounts:
+        - mountPath: /etc/ssh
+          name: ssh-auth

--- a/git/git-ssh-auth.md
+++ b/git/git-ssh-auth.md
@@ -1,0 +1,107 @@
+# Git SSH Auth
+
+## Configuration of SSH with GitHub as example
+
+Prepare secrets for SSH authentication.
+
+### Prepare `known_hosts` file
+Example using github.com
+
+1. Create file with `known_hosts` (you may also want to verify this further)
+
+   ```
+   ssh-keyscan github.com > ssh_known_hosts
+   ```
+
+2. Create secret from file
+
+    ```
+    kubectl create secret generic github-known-hosts --from-file=ssh_known_hosts
+    ```
+   
+### Generate and distribute SSH key pair
+Generate a separate SSH key pair for Tekton
+
+1. Generate keypair to local file
+
+    ```
+    ssh-keygen -t rsa -b 4096 -f id_rsa -q -N ""
+    ```
+
+2. Create a secret from the private key
+
+   ```
+   kubectl create secret generic github-private-key --from-file=id_rsa
+   ```
+   
+3. Upload the public key `id_rsa.pub` to GitHub
+
+   Start with copying the content of the public key with
+
+   ```
+   pbcopy < id_rsa.pub
+   ```
+   
+   And follow [Adding a new SSH key to your GitHub account](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account)
+
+
+## Example Pipeline
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-with-git-clone
+spec:
+  params:
+  - name: git-url
+    type: string
+    description: Url to git repo
+  tasks:
+  - name: git-clone
+    taskRef:
+      name: git-clone-ssh
+    params:
+    - name: url
+      value: "$(params.git-url)"
+    workspaces:
+    - name: output
+      workspace: ws
+  workspaces:
+  - name: ws
+```
+
+An example `PipelineRun` for triggering a `git clone`
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-clone-ssh-
+spec:
+  params:
+  - name: git-url
+    value: git@github.com:jlpettersson/myapp.git    # example GitHub repo url
+  pipelineRef:
+    name: pipeline-with-git-clone
+  workspaces:
+  - name: ws
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+  taskRunSpecs:
+  - pipelineTaskName: git-clone         # name of task in the Pipeline
+    taskPodTemplate:
+      volumes:
+      - name: ssh-auth                  # name of volume - matching name in Task
+        projected:
+          defaultMode: 0400
+          sources:
+          - secret:
+              name: github-known-hosts  # name of Secret from Auth setup
+          - secret:
+              name: github-private-key  # name of Secret from Auth setup
+```


### PR DESCRIPTION
# Changes

This is a git-clone Task using SSH authentication that is easy to configure. With this Task Tekton only orchestrate tasks, but does not handle Secrets. The user declare the Secrets he has configured and Tekton does not manage them. This is similar to _immutable infrastructure_ practices and serves as an alternative.

Here, _runtime considerations_, e.g. volumes and secret names is handled in a way as described in https://github.com/tektoncd/pipeline/issues/2680
This depends on the bugfix in https://github.com/tektoncd/pipeline/pull/2683

Closes https://github.com/tektoncd/catalog/pull/309

/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [?] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
