### PR TITLE
Add "ClusterRole" to aviod binding "cluster-admin"

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -6,13 +6,20 @@ This Task deploys (or delete) a Kubernates resource (pod). It uses
 ## Install the Task
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kubectl/kubectl-deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kubectl/kubectl-deploy.yaml
+```
+
+## Install ClusterRole
+**CAUTION:** The `clusterrole.yaml` is just a sample, should be modified based on real requirements to avoid potential security issues.
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kubectl/clusterrole.yaml
 ```
 
 ## Install ClusterRolebinding
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kubectl/clusterrolebinding.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kubectl/clusterrolebinding.yaml
 ```
 
 ## Inputs 

--- a/kubectl/clusterrole.yaml
+++ b/kubectl/clusterrole.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-admin
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - configmaps/status
+  - secrets
+  - namespaces
+  - serviceaccounts
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  - deployments/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - get
+  - create
+  - update
+  - delete  

--- a/kubectl/clusterrolebinding.yaml
+++ b/kubectl/clusterrolebinding.yaml
@@ -8,5 +8,5 @@ subjects:
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: cluster-admin
+  name: default-admin
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
To binding `cluster-admin` to SA default/default without warning user will introduce some potential security issue, so:

1. Make it clearer to users that this is only intended for insecure/non-critical use cases, and should be modified after installation to match the user's use case and needs, and/or
2. Provide a more scoped-down role binding initially, which users can add to as they need.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
