### PR TITLE
Migrate away from PipelineResources in kn task

### DIFF
--- a/kn/kn.yaml
+++ b/kn/kn.yaml
@@ -12,14 +12,8 @@ spec:
     description: kn CLI arguments to run
     default:
     - "help"
-  resources:
-    inputs:
-    - name: image
-      type: image
   steps:
   - name: kn
     image: "$(params.kn-image)"
     command: ["/ko-app/kn"]
     args: ["$(params.ARGS)"]
-    # reference the container image resource in your taskrun/pipelinerun
-    # parameters array as "--image=$(resources.inputs.image.url)"

--- a/kn/knative-dockerfile-deploy/README.md
+++ b/kn/knative-dockerfile-deploy/README.md
@@ -77,22 +77,22 @@ roleRef:
 
   - If you've used the same names for namespace and secrets as mentioned above, you can configure the ServiceAccount with the YAML file in this repo using:
 ```bash
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/kn_deployer.yaml
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/kn_deployer.yaml
 ```
 
 4 - Install buildah task from tektoncd/catalog
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/buildah/buildah.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/buildah/buildah.yaml
 ```
 
 5 - Install the kn task from the tektoncd/catalog
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/kn.yaml
 ```
 
 5 - Install the git-clone task from the tektoncd/catalog
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/git/git-clone.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml
 ```
 
 ## Pipelines:

--- a/kn/knative-dockerfile-deploy/build_deploy/README.md
+++ b/kn/knative-dockerfile-deploy/build_deploy/README.md
@@ -46,7 +46,7 @@ spec:
       value: ""
     - name: deleteExisting
       value: "true"
-  - name: build-helloworld
+  - name: buildah-build
     taskRef:
       name: buildah
     runAfter:
@@ -61,7 +61,7 @@ spec:
     taskRef:
       name: kn
     runAfter:
-      - build-helloworld
+      - buildah-build
     params:
     - name: kn-image
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"

--- a/kn/knative-dockerfile-deploy/build_deploy/README.md
+++ b/kn/knative-dockerfile-deploy/build_deploy/README.md
@@ -67,13 +67,7 @@ spec:
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
     - name: ARGS
       value:
-      - "service"
-      - "create"
-      - "hello"
-      - "--revision-name=hello-v1"
-      - "--image=$(params.IMAGE)"
-      - "--env=TARGET=Tekton"
-      - "--service-account=kn-deployer-account"
+        - "$(params.ARGS)"
 ```
 
  - You can also create this Pipeline using the YAML file present in this repo using
@@ -135,7 +129,15 @@ spec:
       value: "https://github.com/navidshaikh/helloworld-go"
     - name: IMAGE
       value: "quay.io/navidshaikh/helloworld-go"
-
+    - name: ARGS
+      value:
+        - "service"
+        - "create"
+        - "hello"
+        - "--revision-name=hello-v1"
+        - "--image=quay.io/navidshaikh/helloworld-go"
+        - "--env=TARGET=Tekton"
+        - "--service-account=kn-deployer-account"
 ```
 
  - You can also create this PipelineRun using the YAML file present in this repo using

--- a/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   workspaces:
   - name: source
-  resources:
-  - name: image
-    type: image
   params:
   - name: ARGS
     type: array
@@ -17,6 +14,9 @@ spec:
   - name: GIT_URL
     type: string
     description: Git url to clone
+  - name: IMAGE
+    type: string
+    description: The application image built by Buildah and used by kn task.
   tasks:
   - name: fetch-repository
     taskRef:
@@ -31,7 +31,7 @@ spec:
       value: ""
     - name: deleteExisting
       value: "true"
-  - name: buildah-build
+  - name: build-helloworld
     taskRef:
       name: buildah
     runAfter:
@@ -39,24 +39,23 @@ spec:
     workspaces:
     - name: source
       workspace: source
-    resources:
-      outputs:
-        - name: image
-          resource: image
+    params:
+    - name: IMAGE
+      value: "$(params.IMAGE)"
   - name: kn-service-create
     taskRef:
       name: kn
     runAfter:
-      - buildah-build
-    resources:
-      inputs:
-      - name: image
-        resource: image
-        from:
-          - buildah-build
+      - build-helloworld
     params:
     - name: kn-image
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
     - name: ARGS
       value:
-        - "$(params.ARGS)"
+      - "service"
+      - "create"
+      - "hello"
+      - "--revision-name=hello-v1"
+      - "--image=$(params.IMAGE)"
+      - "--env=TARGET=Tekton"
+      - "--service-account=kn-deployer-account"

--- a/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
@@ -16,7 +16,7 @@ spec:
     description: Git url to clone
   - name: IMAGE
     type: string
-    description: The application image built by Buildah and used by kn task.
+    description: The application image to be built by Buildah and deployed by kn task.
   tasks:
   - name: fetch-repository
     taskRef:
@@ -31,7 +31,7 @@ spec:
       value: ""
     - name: deleteExisting
       value: "true"
-  - name: build-helloworld
+  - name: buildah-build
     taskRef:
       name: buildah
     runAfter:
@@ -46,16 +46,10 @@ spec:
     taskRef:
       name: kn
     runAfter:
-      - build-helloworld
+      - buildah-build
     params:
     - name: kn-image
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
     - name: ARGS
       value:
-      - "service"
-      - "create"
-      - "hello"
-      - "--revision-name=hello-v1"
-      - "--image=$(params.IMAGE)"
-      - "--env=TARGET=Tekton"
-      - "--service-account=kn-deployer-account"
+        - "$(params.ARGS)"

--- a/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
@@ -15,3 +15,12 @@ spec:
       value: "https://github.com/navidshaikh/helloworld-go"
     - name: IMAGE
       value: "quay.io/navidshaikh/helloworld-go"
+    - name: ARGS
+      value:
+        - "service"
+        - "create"
+        - "hello"
+        - "--revision-name=hello-v1"
+        - "--image=quay.io/navidshaikh/helloworld-go"
+        - "--env=TARGET=Tekton"
+        - "--service-account=kn-deployer-account"

--- a/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
@@ -6,10 +6,6 @@ spec:
   serviceAccountName: kn-deployer-account
   pipelineRef:
     name: buildah-build-kn-create
-  resources:
-    - name: image
-      resourceRef:
-        name: buildah-build-kn-create-image
   workspaces:
     - name: source
       persistentvolumeclaim:
@@ -17,12 +13,5 @@ spec:
   params:
     - name: GIT_URL
       value: "https://github.com/navidshaikh/helloworld-go"
-    - name: ARGS
-      value:
-        - "service"
-        - "create"
-        - "hello"
-        - "--revision-name=hello-v1"
-        - "--image=$(inputs.resources.image.url)"
-        - "--env=TARGET=Tekton"
-        - "--service-account=kn-deployer-account"
+    - name: IMAGE
+      value: "quay.io/navidshaikh/helloworld-go"

--- a/kn/knative-dockerfile-deploy/build_deploy/resources.yaml
+++ b/kn/knative-dockerfile-deploy/build_deploy/resources.yaml
@@ -1,14 +1,4 @@
 ---
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: buildah-build-kn-create-image
-spec:
-  type: image
-  params:
-    - name: url
-      value: "quay.io/navidshaikh/helloworld-go"
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kn/knative-dockerfile-deploy/service_traffic/README.md
+++ b/kn/knative-dockerfile-deploy/service_traffic/README.md
@@ -6,13 +6,13 @@ configure the Service to route 50-50% traffic to each Revision.
 
 ## Pipeline:
 
-- The following Pipline is focused only on performing traffic operations
+- The following Pipeline is focused only on performing traffic operations
   on Service. It does not define/require any Pipeline resources.
 - Save the following YAML in a file say e.g.: `kn_service_traffic_pipeline.yaml` and create using
  `kubectl create -f kn_service_traffic_pipeline.yaml`.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: kn-service-traffic-splitting
@@ -37,7 +37,7 @@ spec:
 
  - You can also create this Pipeline using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_pipeline.yaml
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
 ```
 
 ## PipelineRun:
@@ -69,7 +69,7 @@ spec:
 ```
 - You can also create this PipelineRun using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
 ```
 
 - Let's monitor the logs of the Pipeline run using `tkn`

--- a/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
@@ -3,9 +3,6 @@ kind: Pipeline
 metadata:
   name: kn-service-traffic-splitting
 spec:
-  resources:
-  - name: image
-    type: image
   params:
   - name: ARGS
     type: array
@@ -16,10 +13,6 @@ spec:
   - name: kn-service-traffic-splitting
     taskRef:
       name: kn
-    resources:
-      inputs:
-      - name: image
-        resource: image
     params:
     - name: kn-image
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"

--- a/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
@@ -6,10 +6,6 @@ spec:
   serviceAccountName: kn-deployer-account
   pipelineRef:
     name: kn-service-traffic-splitting
-  resources:
-    - name: image
-      resourceRef:
-        name: kn-service-update-image
   params:
     - name: ARGS
       value:

--- a/kn/knative-dockerfile-deploy/service_update/README.md
+++ b/kn/knative-dockerfile-deploy/service_update/README.md
@@ -8,7 +8,7 @@ A new Revision is created if you update the Configuration of the Service.
 - Save the following YAML in a file say e.g.: `kn_service_update_pipeline.yaml` and create using `kubectl create -f kn_service_update_pipeline.yaml`.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: kn-service-update
@@ -22,59 +22,43 @@ spec:
     description: Arguments to pass to kn CLI
     default:
       - "help"
+  - name: IMAGE
+    type: string
+    description: The application image built by Buildah and used by kn task.
   tasks:
   - name: kn-service-update
     taskRef:
       name: kn
-    resources:
-      inputs:
-      - name: image
-        resource: image
     params:
     - name: kn-image
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
     - name: ARGS
       value:
-        - "$(params.ARGS)"
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=$(params.IMAGE)"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"
 ```
 
  - You can also create this Pipeline using the YAML file present in this repo using 
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
-```
-
-## PipelineResource
-
-- If you wan't to deploy a new image to a Revision, let's create a PieplineResource for this Pipeline.
-- Note that in the below example, we're now referencing a different image,
-other than the one we created earlier using buildah.
-- Save the following YAML in a file say e.g.: `resources.yaml` and create using `kubectl create -f resources.yaml`.
-
-```yaml
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: kn-service-update-image
-spec:
-  type: image
-  params:
-    - name: url
-      value: "gcr.io/knative-samples/helloworld-go"
-```
-- You can use this PipelineResource using the YAML file present in this repo using 
-```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_update/resources.yaml
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
 ```
 
 ## PipelineRun
 
-- Create the PipelineRun to trigger the Pipeline and input the kn CLI
-parameters to deploy a new Revision to `hello` Service
+- Create the PipelineRun to trigger the Pipeline and input the kn CLI parameters to 
+deploy a new Revision to `hello` Service. Note that in the below example, we're referencing a 
+different image, other than the one we created earlier using buildah.
+                                                                                                                            other than the one we created earlier using buildah.
 
 - Save the following YAML in a file e.g.: `pipeline_run.yaml` and create using `kubectl create -f pipeline_run.yaml`
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   generateName: kn-service-update-
@@ -82,25 +66,14 @@ spec:
   serviceAccountName: kn-deployer-account
   pipelineRef:
     name: kn-service-update
-  resources:
-    - name: image
-      resourceRef:
-        name: kn-service-update-image
   params:
-    - name: ARGS
-      value:
-        - "service"
-        - "update"
-        - "hello"
-        - "--revision-name=hello-v2"
-        - "--image=$(inputs.resources.image.url)"
-        - "--env=TARGET=v2"
-        - "--service-account=kn-deployer-account"
+    - name: IMAGE
+      value: "gcr.io/knative-samples/helloworld-go"
 ```
 
 - You can also create this PipelineRun using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/master/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
 ```
 
 Let's monitor the logs of the Pipeline run using `tkn`

--- a/kn/knative-dockerfile-deploy/service_update/README.md
+++ b/kn/knative-dockerfile-deploy/service_update/README.md
@@ -41,7 +41,6 @@ kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/
 - Create the PipelineRun to trigger the Pipeline and input the kn CLI parameters to 
 deploy a new Revision to `hello` Service. Note that in the below example, we're referencing a 
 different image, other than the one we created earlier using buildah.
-                                                                                                                            other than the one we created earlier using buildah.
 
 - Save the following YAML in a file e.g.: `pipeline_run.yaml` and create using `kubectl create -f pipeline_run.yaml`
 

--- a/kn/knative-dockerfile-deploy/service_update/README.md
+++ b/kn/knative-dockerfile-deploy/service_update/README.md
@@ -13,18 +13,12 @@ kind: Pipeline
 metadata:
   name: kn-service-update
 spec:
-  resources:
-  - name: image
-    type: image
   params:
   - name: ARGS
     type: array
     description: Arguments to pass to kn CLI
     default:
       - "help"
-  - name: IMAGE
-    type: string
-    description: The application image built by Buildah and used by kn task.
   tasks:
   - name: kn-service-update
     taskRef:
@@ -34,13 +28,7 @@ spec:
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
     - name: ARGS
       value:
-        - "service"
-        - "update"
-        - "hello"
-        - "--revision-name=hello-v2"
-        - "--image=$(params.IMAGE)"
-        - "--env=TARGET=v2"
-        - "--service-account=kn-deployer-account"
+        - "$(params.ARGS)"
 ```
 
  - You can also create this Pipeline using the YAML file present in this repo using 
@@ -67,8 +55,15 @@ spec:
   pipelineRef:
     name: kn-service-update
   params:
-    - name: IMAGE
-      value: "gcr.io/knative-samples/helloworld-go"
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=gcr.io/knative-samples/helloworld-go"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"
 ```
 
 - You can also create this PipelineRun using the YAML file present in this repo using

--- a/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
@@ -12,17 +12,22 @@ spec:
     description: Arguments to pass to kn CLI
     default:
       - "help"
+  - name: IMAGE
+    type: string
+    description: The application image built by Buildah and used by kn task.
   tasks:
   - name: kn-service-update
     taskRef:
       name: kn
-    resources:
-      inputs:
-      - name: image
-        resource: image
     params:
     - name: kn-image
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
     - name: ARGS
       value:
-        - "$(params.ARGS)"
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=$(params.IMAGE)"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"

--- a/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
@@ -3,18 +3,12 @@ kind: Pipeline
 metadata:
   name: kn-service-update
 spec:
-  resources:
-  - name: image
-    type: image
   params:
   - name: ARGS
     type: array
     description: Arguments to pass to kn CLI
     default:
       - "help"
-  - name: IMAGE
-    type: string
-    description: The application image built by Buildah and used by kn task.
   tasks:
   - name: kn-service-update
     taskRef:
@@ -24,10 +18,4 @@ spec:
       value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
     - name: ARGS
       value:
-        - "service"
-        - "update"
-        - "hello"
-        - "--revision-name=hello-v2"
-        - "--image=$(params.IMAGE)"
-        - "--env=TARGET=v2"
-        - "--service-account=kn-deployer-account"
+        - "$(params.ARGS)"

--- a/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
@@ -6,17 +6,6 @@ spec:
   serviceAccountName: kn-deployer-account
   pipelineRef:
     name: kn-service-update
-  resources:
-    - name: image
-      resourceRef:
-        name: kn-service-update-image
   params:
-    - name: ARGS
-      value:
-        - "service"
-        - "update"
-        - "hello"
-        - "--revision-name=hello-v2"
-        - "--image=$(inputs.resources.image.url)"
-        - "--env=TARGET=v2"
-        - "--service-account=kn-deployer-account"
+    - name: IMAGE
+      value: "gcr.io/knative-samples/helloworld-go"

--- a/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
@@ -7,5 +7,12 @@ spec:
   pipelineRef:
     name: kn-service-update
   params:
-    - name: IMAGE
-      value: "gcr.io/knative-samples/helloworld-go"
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=gcr.io/knative-samples/helloworld-go"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"

--- a/kn/knative-dockerfile-deploy/service_update/resources.yaml
+++ b/kn/knative-dockerfile-deploy/service_update/resources.yaml
@@ -1,9 +1,0 @@
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: kn-service-update-image
-spec:
-  type: image
-  params:
-    - name: url
-      value: "gcr.io/knative-samples/helloworld-go"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

According to https://github.com/tektoncd/pipeline/blob/master/docs/migrating-v1alpha1-to-v1beta1.md#replacing-pipelineresources-with-tasks the PipelineResources stay at alpha version. This PR moves the `kn` task to using Tasks instead of PipelineResources where sources and images are shared between tasks rather than through the PipelineResources custom resource. This is a more straightforward approach which can be seen on the number of lines added vs. removed in this PR.

This also fixes documentation for the `kn` task - fix links to us v1beta1, fix some typos, update examples to use v1beta1.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
