### PR TITLE
Task to publish python module to PyPI

### DIFF
--- a/python/publish-package/README.md
+++ b/python/publish-package/README.md
@@ -1,0 +1,51 @@
+# Publish-Python-Package
+
+This Task publishes Python packages to PyPI index using [Twine](https://pypi.org/project/twine/) utility module. It provides build system independent uploads of source and binary distribution artifacts for both new and existing projects.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/python/publish-package/update-pypi.yaml
+```
+
+## Requirement
+
+Secret is needed with Twine credentials(TWINE_USERNAME:TWINE_PASSWORD) to be provided for python module publishing to PyPI index.
+
+- **username**: The username to authenticate to the repository (package index).
+- **password**: The password to authenticate to the repository (package index).
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pypi-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: foo
+  password: bar
+```
+
+## Workspaces
+
+- **source**: A `git`-type `PipelineResource` specifying the location of the source to build.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and publishes a python module.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: publish-package
+spec:
+  taskRef:
+    name: upload-pypi
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+In this example, the Git repo being used is expected to have a `setup.py` file at the root of the repository. [setup.py](https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py) is build script for [setuptools](https://pypi.org/project/setuptools/)

--- a/python/publish-package/example/run.yaml
+++ b/python/publish-package/example/run.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pypi-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: foo
+  password: bar
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-task-storage
+spec:
+  resources:
+    requests:
+      storage: 500Mi
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: publish-package-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/pypa/twine.git
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+
+  - name: upload-pypi-run
+    taskRef:
+      name: upload-pypi
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    runAfter:
+    - fetch-repository
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: publish-package-pipeline-run
+spec:
+  pipelineRef:
+    name: publish-package-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentVolumeClaim:
+      claimName: shared-task-storage

--- a/python/publish-package/tests/pre-apply-task-hook.sh
+++ b/python/publish-package/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Add an internal PyPI server as sidecar to the task so we can upload it directly
+# from our tests without having to go to official PyPI server.
+cat ${TMPF} | python -c 'import yaml,sys;data=yaml.load(sys.stdin.read());data["spec"]["sidecars"]=[{"image":"pypiserver/pypiserver:latest", "name":"server", "command":["pypi-server","-P",".","-a",".","/data/packages"], "volumeMounts":[{"name":"packages", "mountPath":"/data/packages"}]}];data["spec"]["volumes"]=[{"name":"packages", "emptyDir":{}}];print(yaml.dump(data, default_flow_style=False));' > ${TMPF}
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./git/git-clone.yaml

--- a/python/publish-package/tests/run.yaml
+++ b/python/publish-package/tests/run.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pypi-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: foo
+  password: bar
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-task-storage
+spec:
+  resources:
+    requests:
+      storage: 500Mi
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: publish-package-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/pypa/twine.git
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+
+  - name: upload-pypi-run
+    taskRef:
+      name: upload-pypi
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: TWINE_REPOSITORY_URL
+      value: "http://localhost:8080"
+    runAfter:
+    - fetch-repository
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: publish-package-pipeline-run
+spec:
+  pipelineRef:
+    name: publish-package-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentVolumeClaim:
+      claimName: shared-task-storage

--- a/python/publish-package/update-pypi.yaml
+++ b/python/publish-package/update-pypi.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: upload-pypi
+spec:
+  params:
+  - name: TWINE_REPOSITORY_URL
+    description: The repository (package index) to upload the package to.
+    default: "https://upload.pypi.org/legacy/"
+    type: string
+
+  workspaces:
+  - name: source
+
+  steps:
+  - name: build-package
+    image: quay.io/thoth-station/twine:latest
+    workingDir: $(workspaces.source.path)
+    script: |
+      python setup.py sdist bdist_wheel
+
+  - name: upload-package
+    image: quay.io/thoth-station/twine:latest
+    workingDir: $(workspaces.source.path)
+    env:
+    - name: TWINE_REPOSITORY_URL
+      value: $(params.TWINE_REPOSITORY_URL)
+    - name: TWINE_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: pypi-secret
+          key: username
+    - name: TWINE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: pypi-secret
+          key: password
+    script: |
+      twine upload dist/*


### PR DESCRIPTION
The task to publish a python module to PyPI.
Python module can be published through CI/CD pipeline using this Tekton Task.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This Task publishes python packages to the PyPI index using [Twine](https://pypi.org/project/twine/) utility module. It provides build system independent uploads of source and binary distribution artifacts for both new and existing projects.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.