### PR TITLE
Fix/160 support v1beta1 platform envs

### DIFF
--- a/buildpacks/README.md
+++ b/buildpacks/README.md
@@ -18,13 +18,17 @@ The Cloud Native Buildpacks website describes v3 buildpacks as:
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/buildpacks/buildpacks-v3.yaml
 ```
 
-> **NOTE:** This task is currently only compatible with Tekton **v0.6.0** and above, and CNB Platform API 0.3 (lifecycle v0.7.0 and above). For previous Platform API versions, [see below](#previous-platform-api-versions).
+> **NOTE:** This task is currently only compatible with Tekton **v0.11.0** and above, and CNB Platform API 0.3 (lifecycle v0.7.0 and above). For previous Platform API versions, [see below](#previous-platform-api-versions).
 
 ## Parameters
 
 * **`BUILDER_IMAGE`**: The image on which builds will run. (must include v3 lifecycle and compatible buildpacks; _required_)
 
-* **`CACHE`**: The name of the persistent app cache volume. (_default:_ an empty directory -- effectively no cache)
+* **`CACHE`**: The name of the persistent app cache volume. (_default:_ an empty
+  directory -- effectively no cache)
+
+* **`PLATFORM_DIR`**: The name of the platform directory. (_default:_ an empty
+  directory)
 
 * **`USER_ID`**: The user ID of the builder image user, as a string value. (_default:_ `"1000"`)
 
@@ -55,12 +59,16 @@ metadata:
 spec:
   taskRef:
     name: buildpacks-v3
+  podTemplate:
+    volumes:
 # Uncomment the lines below to use an existing cache
-#  podTemplate:
-#    volumes:
 #    - name: my-cache
 #      persistentVolumeClaim:
-#        claimName: task-pv-claim
+#        claimName: my-cache-pvc
+# Uncomment the lines below to provide a platform directory
+#    - name: my-platform-dir
+#      persistentVolumeClaim:
+#        claimName: my-platform-dir-pvc
   params:
   - name: SOURCE_SUBPATH
     value: <optional subpath within your source repo, e.g. "apps/java-maven">
@@ -69,6 +77,9 @@ spec:
 # Uncomment the lines below to use an existing cache
 #  - name: CACHE
 #    value: my-cache
+# Uncomment the lines below to provide a platform directory
+#  - name: PLATFORM_DIR
+#    value: my-platform-dir
   resources:
     outputs:
     - name: image
@@ -76,12 +87,11 @@ spec:
         type: image
         params:
         - name: url
-          value: <your output image tag,
-          e.g. "gcr.io/app-repo/app-image:app-tag">
+          value: <your output image tag, e.g. "gcr.io/app-repo/app-image:app-tag">
   workspaces:
   - name: source
     persistentVolumeClaim:
-      claimName: my-source
+      claimName: my-source-pvc
 ```
 
 ### Example builders

--- a/buildpacks/README.md
+++ b/buildpacks/README.md
@@ -18,25 +18,21 @@ The Cloud Native Buildpacks website describes v3 buildpacks as:
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/buildpacks/buildpacks-v3.yaml
 ```
 
-> **NOTE:** This task is currently only compatible with Tekton **v0.6.0** and above, and CNB Platform API 0.2 (lifecycle v0.6.0 and above). For previous Platform API versions, [see below](#previous-platform-api-versions).
+> **NOTE:** This task is currently only compatible with Tekton **v0.6.0** and above, and CNB Platform API 0.3 (lifecycle v0.7.0 and above). For previous Platform API versions, [see below](#previous-platform-api-versions).
 
 ## Parameters
 
-* **`BUILDER_IMAGE`**: The image on which builds will run (must include v3 lifecycle and compatible buildpacks; _required_)
+* **`BUILDER_IMAGE`**: The image on which builds will run. (must include v3 lifecycle and compatible buildpacks; _required_)
 
-* **`USE_CRED_HELPERS`**: Use Docker credential helpers. Set to `"true"` or
-  `"false"` as string a value. (_default:_ `"false"`)
+* **`CACHE`**: The name of the persistent app cache volume. (_default:_ an empty directory -- effectively no cache)
 
-* **`CACHE`**: The name of the persistent app cache volume (_default:_ an empty
-  directory -- effectively no cache)
+* **`USER_ID`**: The user ID of the builder image user, as a string value. (_default:_ `"1000"`)
 
-* **`USER_ID`**: The user ID of the builder image user, as a string value (_default:_ `"1000"`)
+* **`GROUP_ID`**: The group ID of the builder image user, as a string value. (_default:_ `"1000"`)
 
-* **`GROUP_ID`**: The group ID of the builder image user, as a string value (_default:_ `"1000"`)
+* **`PROCESS_TYPE`**: The default process type to set on the image. (_default:_ `"web"`)
 
-* **`SOURCE_SUBPATH`**: A subpath within the `source` input where the source to build is located (_default:_ `""`)
-
-## Resources
+* **`SOURCE_SUBPATH`**: A subpath within the `source` input where the source to build is located. (_default:_ `""`)
 
 ### Outputs
 
@@ -45,8 +41,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 
 ## Workspaces
 
-The `source` workspace holds the source that will be used by buildpack
-to build and publish the container image.
+The `source` workspace holds the source to build. See `SOURCE_SUBPATH` above if source is located within a subpath of this input.
 
 ## Usage
 
@@ -102,10 +97,18 @@ Heroku:
 
 Use one of the following commands to install a previous version of this task. Be sure to also supply a compatible builder image (`BUILDER_IMAGE` input) when running the task (i.e. one that has a lifecycle implementing the expected platform API).
 
+### CNB Platform API 0.2
+
+Commit: [8c34055](https://github.com/tektoncd/catalog/tree/8c34055ea728413fb72af061e7bcbf1859a9fbd6/buildpacks#inputs)
+
+```
+kubectl -f https://raw.githubusercontent.com/tektoncd/catalog/8c34055ea728413fb72af061e7bcbf1859a9fbd6/buildpacks/buildpacks-v3.yaml
+```
+
 ### CNB Platform API 0.1
 
 Commit: [5c2ab7d6](https://github.com/tektoncd/catalog/tree/5c2ab7d6c3b2507d43b49577d7f1bee9c49ed8ab/buildpacks#inputs)
 
 ```
-kubectl -f https://github.com/tektoncd/catalog/blob/5c2ab7d6c3b2507d43b49577d7f1bee9c49ed8ab/buildpacks/buildpacks-v3.yaml
+kubectl -f https://raw.githubusercontent.com/tektoncd/catalog/5c2ab7d6c3b2507d43b49577d7f1bee9c49ed8ab/buildpacks/buildpacks-v3.yaml
 ```

--- a/buildpacks/README.md
+++ b/buildpacks/README.md
@@ -27,8 +27,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
 * **`CACHE`**: The name of the persistent app cache volume. (_default:_ an empty
   directory -- effectively no cache)
 
-* **`PLATFORM_DIR`**: The name of the platform directory. (_default:_ an empty
-  directory)
+* **`PLATFORM_DIR`**: A directory containing platform provided configuration, such as environment variables.
+  Files of the format `/platform/env/MY_VAR` with content `my-value` will be translated by the lifecycle into
+  environment variables provided to buildpacks. For more information, see the [buildpacks spec](https://github.com/buildpacks/spec/blob/master/buildpack.md#provided-by-the-platform). (_default:_ an empty directory)
 
 * **`USER_ID`**: The user ID of the builder image user, as a string value. (_default:_ `"1000"`)
 

--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -5,31 +5,34 @@ metadata:
   name: buildpacks-v3
 spec:
   params:
-  - name: BUILDER_IMAGE
-    description: The image on which builds will run (must include v3 lifecycle and compatible buildpacks).
-  - name: CACHE
-    description: The name of the persistent app cache volume.
-    default: empty-dir
-  - name: USER_ID
-    description: The user ID of the builder image user.
-    default: "1000"
-  - name: GROUP_ID
-    description: The group ID of the builder image user.
-    default: "1000"
-  - name: PROCESS_TYPE
-    description: The default process type to set on the image.
-    default: "web"
-  - name: SOURCE_SUBPATH
-    description: A subpath within the `source` input where the source to build is located.
-    default: ""
+    - name: BUILDER_IMAGE
+      description: The image on which builds will run (must include v3 lifecycle and compatible buildpacks).
+    - name: CACHE
+      description: The name of the persistent app cache volume.
+      default: empty-dir
+    - name: PLATFORM_DIR
+      description: The name of the platform directory.
+      default: empty-dir
+    - name: USER_ID
+      description: The user ID of the builder image user.
+      default: "1000"
+    - name: GROUP_ID
+      description: The group ID of the builder image user.
+      default: "1000"
+    - name: PROCESS_TYPE
+      description: The default process type to set on the image.
+      default: "web"
+    - name: SOURCE_SUBPATH
+      description: A subpath within the `source` input where the source to build is located.
+      default: ""
 
   resources:
     outputs:
-    - name: image
-      type: image
+      - name: image
+        type: image
 
   workspaces:
-  - name: source
+    - name: source
 
   stepTemplate:
     env:
@@ -67,6 +70,8 @@ spec:
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
 
     - name: analyze
       image: $(params.BUILDER_IMAGE)
@@ -109,6 +114,8 @@ spec:
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
 
     - name: export
       image: $(params.BUILDER_IMAGE)
@@ -119,8 +126,8 @@ spec:
         - "-layers=/layers"
         - "-group=/layers/group.toml"
         - "-cache-dir=/cache"
-        - "-process-type=$(inputs.params.PROCESS_TYPE)"
-        - "$(outputs.resources.image.url)"
+        - "-process-type=$(params.PROCESS_TYPE)"
+        - "$(resources.outputs.image.url)"
       volumeMounts:
         - name: layers-dir
           mountPath: /layers

--- a/buildpacks/buildpacks-v3.yaml
+++ b/buildpacks/buildpacks-v3.yaml
@@ -7,18 +7,18 @@ spec:
   params:
   - name: BUILDER_IMAGE
     description: The image on which builds will run (must include v3 lifecycle and compatible buildpacks).
-  - name: USE_CRED_HELPERS
-    description: Use Docker credential helpers for Google's GCR, Amazon's ECR, or Microsoft's ACR.
-    default: "false"
   - name: CACHE
-    description: The name of the persistent app cache volume
+    description: The name of the persistent app cache volume.
     default: empty-dir
   - name: USER_ID
-    description: The user ID of the builder image user
+    description: The user ID of the builder image user.
     default: "1000"
   - name: GROUP_ID
-    description: The group ID of the builder image user
+    description: The group ID of the builder image user.
     default: "1000"
+  - name: PROCESS_TYPE
+    description: The default process type to set on the image.
+    default: "web"
   - name: SOURCE_SUBPATH
     description: A subpath within the `source` input where the source to build is located.
     default: ""
@@ -34,7 +34,7 @@ spec:
   stepTemplate:
     env:
       - name: CNB_PLATFORM_API
-        value: "0.2"
+        value: "0.3"
 
   steps:
     - name: prepare
@@ -74,7 +74,6 @@ spec:
       command: ["/cnb/lifecycle/analyzer"]
       args:
         - "-layers=/layers"
-        - "-helpers=$(params.USE_CRED_HELPERS)"
         - "-group=/layers/group.toml"
         - "-cache-dir=/cache"
         - "$(resources.outputs.image.url)"
@@ -118,10 +117,10 @@ spec:
       args:
         - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
         - "-layers=/layers"
-        - "-helpers=$(params.USE_CRED_HELPERS)"
         - "-group=/layers/group.toml"
         - "-cache-dir=/cache"
-        - "$(resources.outputs.image.url)"
+        - "-process-type=$(inputs.params.PROCESS_TYPE)"
+        - "$(outputs.resources.image.url)"
       volumeMounts:
         - name: layers-dir
           mountPath: /layers

--- a/buildpacks/tests/run.yaml
+++ b/buildpacks/tests/run.yaml
@@ -35,7 +35,7 @@ spec:
     - name: SOURCE_SUBPATH
       value: apps/java-maven
     - name: BUILDER_IMAGE
-      value: cnbs/sample-builder:alpine-p0.2
+      value: cnbs/sample-builder:alpine-p0.3
     - name: CACHE
       value: buildpacks-cache
     resources:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

(re-opening to hopefully satisfy the CLA)

# Changes

Add support in buildpacks task for platform envs

This change makes it possible for users to provide
environment variables to buildpacks via a volume with
appropriately configured directories.

Also updates to platform API 0.3 (previously, only the master branch was updated).

See https://buildpacks.io/docs/reference/buildpack-api/
for more info on how PLATFORM_DIR is used.

Resolves #160

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
