### PR TITLE
Run Sonar-scanner as root

### DIFF
--- a/sonarqube/sonarqube.yaml
+++ b/sonarqube/sonarqube.yaml
@@ -62,3 +62,5 @@ spec:
       workingDir: $(workspaces.source-dir.path)
       command:
         - sonar-scanner
+      securityContext:
+        runAsUser: 0


### PR DESCRIPTION
# Changes

This will fix the issue of task not working on OpenShift as it needs root access and by default on OpenShift pod run as nonroot.

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
