### PR TITLE
Wait until all TaskRuns are complete to print logs

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -136,16 +136,14 @@ function test_task_creation() {
                 echo -n "Could not find a created taskrun or pipelinerun in ${tns}"
             fi
 
-            breakit=
+            breakit=True
             for status in ${all_status};do
 
                 [[ ${status} == *ERROR || ${reason} == *Fail* || ${reason} == Couldnt* ]] && show_failure ${testname} ${tns}
 
-                if [[ ${status} == True ]];then
-                    breakit=True
-                else
+                if [[ ${status} != True ]];then
                     breakit=
-                fi
+                fi  
             done
 
             if [[ ${breakit} == True ]];then


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The loop in the test runner script that was waiting for all TaskRuns to
complete had a bug where it would break out of the loop as soon as any one of
the TaskRuns completed. The test runner then tries to print the logs for all
TaskRuns (which includes some Running ones) which will sometimes fail e.g. if
the TaskRun's pod is in a PodInitializing state.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
