### PR TITLE
test-runner: Do not show logs on success

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -82,7 +82,7 @@ function show_failure() {
     kubectl get -n ${tns} taskrun -o yaml
     echo "--- Container Logs"
     for pod in $(kubectl get pod -o name -n ${tns}); do
-        kubectl logs --all-containers -n ${tns} ${pod}
+        kubectl logs --all-containers -n ${tns} ${pod} || true
     done
     exit 1
 
@@ -143,14 +143,11 @@ function test_task_creation() {
 
                 if [[ ${status} != True ]];then
                     breakit=
-                fi  
+                fi
             done
 
             if [[ ${breakit} == True ]];then
-                echo -n "SUCCESS: ${testname} pipelinerun has successfully executed: " ;
-                for pod in $(kubectl get pod -o name -n ${tns}); do
-                    kubectl logs --all-containers -n ${tns} ${pod}
-                done
+                echo -n "SUCCESS: ${testname} pipelinerun has successfully executed" ;
                 break
             fi
 


### PR DESCRIPTION
# Changes

This can grow the log pretty big with message that we probably don't care
about.

when we show the logs on failure, make sure we are not failing if we can't show
them. Sometime some container may be in "Terminated" state until k8 cleans them
up. (i.e: affinity-assistant) so no need to worry if those are failing/exiting before
showing the next container log.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.