### PR TITLE
Test tasks that only has been modified or added

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,11 @@ The way the functional tests works is that if you have a directory called
 `tests/` inside the task, it would start creating a random `Namespace`, apply
 the task and then every yaml files that you have in that `tests/` directory.
 
+Note that the test runner for the integration tests will only test the tasks
+that has been added or modified in the submitted PR and will not run any other
+tests that hasn't been changed unless the environment variable
+`TEST_RUN_ALL_TESTS` has been set.
+
 Usually in these other yaml files you would have a yaml file for the
 test resources (`PipelineResource`) and a yaml files to run the tasks
 (`TaskRun or PipelineRun`).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We are nnow only doing integration tests on the tasks that has been modified or added. This will improve the speed of each PR iteration not testing everything while the PR modify only some part of it.

/cc @sthaha 
if you know if there is any other git trickery i can use to detect
file changes between the 'main' branch and the PR

/cc @bobcatfish 
cf #373 discussion

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._