### PR TITLE
Updated helm catalog to allow for helm charts to be deployed from hel…

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,26 +1,42 @@
 # Helm
 
-This Task installs / upgrades a helm chart into your Kubernetes / OpenShift Cluster using [Helm](https://github.com/helm/helm).
+These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift Cluster using [Helm](https://github.com/helm/helm).
 
 ## Install the Task
 
+### helm install / upgrade from source code
+
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/helm/helm-upgrade.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/helm/helm-upgrade-from-source.yaml
 ```
 
-## Parameters
+#### Parameters
 
-- **CHARTS_DIR**: The directory in the source repository where the installable chart should be found.
-- **RELEASE_VERSION**: The version of the release (*default: v1.0.0*)
-- **RELEASE_NAME**: The name of the release (*default: helm-release*)
-- **RELEASE_NAMESPACE**: The namespace in which the release is to be installed (*default: ""*)
-- **OVERWRITE_VALUES**: The values to be overwritten (*default: ""*)
-- **HELM_VERSION**: The helm version which should be used (*default: latest*)
+- **charts_dir**: The directory in the source repository where the installable chart should be found.
+- **release_version**: The version of the release (*default: v1.0.0*)
+- **release_name**: The name of the release (*default: helm-release*)
+- **release_namespace**: The namespace in which the release is to be installed (*default: ""*)
+- **overwrite_values**: The values to be overwritten (*default: ""*)
+- **helm_version**: The helm version which should be used (*default: latest*)
 
-## Workspaces
+#### Workspaces
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the helm chart.
 
+### helm install / upgrade from repo
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/helm/helm-upgrade-from-repo.yaml
+```
+
+#### Parameters
+
+- **chart_name**: The directory in the source repository where the installable chart should be found.
+- **release_version**: The version of the release (*default: v1.0.0*)
+- **release_name**: The name of the release (*default: helm-release*)
+- **release_namespace**: The namespace in which the release is to be installed (*default: ""*)
+- **overwrite_values**: The values to be overwritten (*default: ""*)
+- **helm_version**: The helm version which should be used (*default: latest*)
 
 ## Usage
 
@@ -32,26 +48,48 @@ An example `Pipeline` with a `PipelineRun` can be found in the subdirectory `tes
 
 This `TaskRun` runs the task to retrieve a Git repo and then installs/updates the helm chart that is in the Git repo.
 
-
 ```yaml
+# example upgrade from source
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
-  name: example-helm-upgrade
+  name: example-helm-upgrade-from-source
 spec:
   taskRef:
-    name: helm-upgrade
+    name: helm-upgrade-from-source
   params:
-  - name: CHARTS_DIR
+  - name: charts_dir
     value: helm-sample-chart
-  - name: RELEASE_VERSION
+  - name: releases_version
     value: v1.0.0
-  - name: RELEASE_NAME
-    value: helm-sample
-  - name: OVERWRITE_VALUES
+  - name: release_name
+    value: helm-source-sample
+  - name: overwrite_values
     value: "autoscaling.enabled=true,autoscaling.maxReplicas=3"
   workspaces:
   - name: source
     persistentVolumeClaim:
       claimName: my-source
+```
+
+```yaml
+# example upgrade from repo
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-helm-upgrade-from-repo
+spec:
+  taskRef:
+    name: helm-upgrade-from-repo
+  params:
+  - name: helm_repo
+    value: https://kubernetes-charts.storage.googleapis.com
+  - name: chart_name
+    value: stable/envoy
+  - name: release_version
+    value: v1.0.0
+  - name: release_name
+    value: helm-repo-sample
+  - name: overwrite_values
+    value: autoscaling.enabled=true,autoscaling.maxReplicas=3
 ```

--- a/helm/example/helm-upgrade-from-repo-task-run.yaml.tmpl
+++ b/helm/example/helm-upgrade-from-repo-task-run.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-helm-upgrade-from-repo
+spec:
+  taskRef:
+    name: helm-upgrade-from-repo
+  params:
+  - name: helm_repo
+    value: https://kubernetes-charts.storage.googleapis.com
+  - name: chart_name
+    value: stable/envoy
+  - name: release_version
+    value: v1.0.0
+  - name: release_name
+    value: helm-repo-sample
+  - name: overwrite_values
+    value: autoscaling.enabled=true,autoscaling.maxReplicas=3

--- a/helm/example/helm-upgrade-from-source-task-run.yaml.tmpl
+++ b/helm/example/helm-upgrade-from-source-task-run.yaml.tmpl
@@ -1,20 +1,20 @@
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
-  name: example-helm-upgrade
+  name: example-helm-upgrade-from-source
 spec:
   taskRef:
-    name: helm-upgrade
+    name: helm-upgrade-from-source
   params:
-    - name: CHARTS_DIR
+    - name: charts_dir
       value: helm-sample-chart
-    - name: RELEASE_VERSION
+    - name: releases_version
       value: v1.0.0
-    - name: RELEASE_NAME
-      value: helm-sample
-    - name: OVERWRITE_VALUES
+    - name: release_name
+      value: helm-source-sample
+    - name: overwrite_values
       value: "autoscaling.enabled=true,autoscaling.maxReplicas=3"
   workspaces:
     - name: source
       persistentVolumeClaim:
-        claimName: helm-source-pvc
+        claimName: my-source

--- a/helm/helm-upgrade-from-repo.yaml
+++ b/helm/helm-upgrade-from-repo.yaml
@@ -1,0 +1,40 @@
+# This Task will do a helm upgrade based on the given helm repo and chart
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: helm-upgrade-from-repo
+spec:
+  params:
+    - name: helm_repo
+      description: "Specify a specific helm repo"
+    - name: chart_name
+      description: "Specify chart name that will be deployed"
+    - name: release_version
+      description: The helm release version in semantic versioning format
+      default: "v1.0.0"
+    - name: release_name
+      description: The helm release name
+      default: "helm-release"
+    - name: release_namespace
+      description: The helm release namespace
+      default: ""
+    - name: overwrite_values
+      description: "Specify the values you want to overwrite, comma separated: autoscaling.enabled=true,replicas=1"
+      default: ""
+    - name: helm_version
+      description: "Specify a specific helm version"
+      default: "latest"
+  steps:
+    - name: upgrade-from-repo
+      image: lachlanevenson/k8s-helm:$(inputs.params.helm_version)
+      script: |
+        echo current installed helm releases
+        helm list --namespace "$(inputs.params.release_namespace)"
+        echo parsing helms repo name...
+        REPO=`echo "$(inputs.params.chart_name)" | cut -d "/" -f 1`
+        echo adding helm repo...
+        helm repo add $REPO "$(inputs.params.helm_repo)"
+        echo adding updating repo...
+        helm repo update
+        echo installing helm chart...
+        helm upgrade --wait --install --namespace "$(inputs.params.release_namespace)" $(inputs.params.release_name) $(inputs.params.chart_name) --debug --set "$(inputs.params.overwrite_values)"

--- a/helm/helm-upgrade-from-source.yaml
+++ b/helm/helm-upgrade-from-source.yaml
@@ -1,35 +1,35 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: helm-upgrade
+  name: helm-upgrade-from-source
 spec:
   params:
-    - name: CHARTS_DIR
+    - name: charts_dir
       description: The directory in source that contains the helm chart
-    - name: RELEASE_VERSION
+    - name: release_version
       description: The helm release version in semantic versioning format
       default: "v1.0.0"
-    - name: RELEASE_NAME
+    - name: release_name
       description: The helm release name
       default: "helm-release"
-    - name: RELEASE_NAMESPACE
+    - name: release_namespace
       description: The helm release namespace
       default: ""
-    - name: OVERWRITE_VALUES
+    - name: overwrite_values
       description: "Specify the values you want to overwrite, comma separated: autoscaling.enabled=true,replicas=1"
       default: ""
-    - name: HELM_VERSION
+    - name: helm_version
       description: "Specify a specific helm version"
       default: "latest"
   workspaces:
     - name: source
   steps:
     - name: upgrade
-      image: lachlanevenson/k8s-helm:$(inputs.params.HELM_VERSION)
+      image: lachlanevenson/k8s-helm:$(inputs.params.helm_version)
       workingDir: /workspace/source
       script: |
         echo current installed helm releases
-        helm list --namespace "$(inputs.params.RELEASE_NAMESPACE)"
+        helm list --namespace "$(inputs.params.release_namespace)"
 
         echo installing helm chart...
-        helm upgrade --install --wait --namespace "$(inputs.params.RELEASE_NAMESPACE)" --version $(inputs.params.RELEASE_VERSION) $(inputs.params.RELEASE_NAME) $(inputs.params.CHARTS_DIR) --debug --set "$(inputs.params.OVERWRITE_VALUES)"
+        helm upgrade --install --wait --namespace "$(inputs.params.release_namespace)" --version $(inputs.params.release_version) $(inputs.params.release_name) $(inputs.params.charts_dir) --debug --set "$(inputs.params.overwrite_values)"

--- a/helm/tests/run.yaml
+++ b/helm/tests/run.yaml
@@ -7,6 +7,20 @@ spec:
   workspaces:
     - name: shared-workspace
   tasks:
+    - name: helm-upgrade-from-repo
+      taskRef:
+        name: helm-upgrade-from-repo
+      params:
+        - name: helm_repo
+          value: https://kubernetes-charts.storage.googleapis.com
+        - name: chart_name
+          value: stable/envoy
+        - name: release_version
+          value: v1.0.0
+        - name: release_name
+          value: helm-repo-sample
+        - name: overwrite_values
+          value: autoscaling.enabled=true,autoscaling.maxReplicas=3
     - name: fetch-repository
       taskRef:
         name: git-clone
@@ -20,23 +34,22 @@ spec:
           value: ""
         - name: deleteExisting
           value: "true"
-
-    - name: helm-upgrade
+    - name: helm-upgrade-from-source
       taskRef:
-        name: helm-upgrade
+        name: helm-upgrade-from-source
       runAfter:
         - fetch-repository
       workspaces:
         - name: source
           workspace: shared-workspace
       params:
-        - name: CHARTS_DIR
+        - name: charts_dir
           value: helm-sample-chart
-        - name: RELEASE_VERSION
+        - name: release_version
           value: v1.0.0
-        - name: RELEASE_NAME
-          value: helm-sample
-        - name: OVERWRITE_VALUES
+        - name: release_name
+          value: helm-source-sample
+        - name: overwrite_values
           value: "autoscaling.enabled=true,autoscaling.maxReplicas=3"
 ---
 apiVersion: tekton.dev/v1beta1


### PR DESCRIPTION
As a user, I would like to use helm repos to deploy my applications. A helm chart was added to support this usecase. As a user having a chart called helm-update and helm-update repo is confusing. Helm charts were renamed and the tests were updated. As a user having all caps params can be confusing because they are reserved for environment variables. Charts were updated to reflect to have increased readadbility.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
