### PR TITLE
Update READMEs of tasks using workspaces in place of PipelineResources

### DIFF
--- a/buildah/README.md
+++ b/buildah/README.md
@@ -29,8 +29,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/buil
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Usage
 

--- a/buildkit-daemonless/README.md
+++ b/buildkit-daemonless/README.md
@@ -24,7 +24,7 @@ task.tekton.dev/buildkit-daemonless created
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Resources
 

--- a/buildkit/README.md
+++ b/buildkit/README.md
@@ -63,7 +63,7 @@ task.tekton.dev/buildkit created
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Resources
 

--- a/conftest/README.md
+++ b/conftest/README.md
@@ -65,8 +65,7 @@ container step-conftest has failed  : Error
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 
 ## Helm usage
@@ -102,5 +101,4 @@ spec:
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.

--- a/golang/README.md
+++ b/golang/README.md
@@ -23,8 +23,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/gola
 
 ### Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## `golang-build`
 
@@ -40,8 +39,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/gola
 
 ### Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## `golang-test`
 
@@ -57,8 +55,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/gola
 
 ### Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Usage
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -19,7 +19,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/helm/
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the helm chart.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the helm chart.
 
 
 ## Usage

--- a/jib-gradle/README.md
+++ b/jib-gradle/README.md
@@ -18,8 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/jib-
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Resources
 

--- a/jib-maven/README.md
+++ b/jib-maven/README.md
@@ -18,8 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/jib-
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Resources
 

--- a/kaniko/README.md
+++ b/kaniko/README.md
@@ -29,8 +29,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kani
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Results
 

--- a/kubeval/README.md
+++ b/kubeval/README.md
@@ -39,5 +39,4 @@ By default the task will recursively scan the provided repository for YAML files
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.

--- a/makisu/README.md
+++ b/makisu/README.md
@@ -53,8 +53,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/maki
 
 ## Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Resources
 

--- a/python/publish-package/README.md
+++ b/python/publish-package/README.md
@@ -28,7 +28,7 @@ stringData:
 
 ## Workspaces
 
-- **source**: A `git`-type `PipelineResource` specifying the location of the source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Usage
 

--- a/s2i/README.md
+++ b/s2i/README.md
@@ -24,8 +24,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/s2i/
 
 # Workspaces
 
-* **source**: A `git`-type `PipelineResource` specifying the location of the
-  source to build.
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the source to build.
 
 ## Resources
 

--- a/terraform-cli/README.md
+++ b/terraform-cli/README.md
@@ -20,7 +20,7 @@ This task currently works only on kubernetes 1.6+ support for a task that works 
 
 ## Workspaces
 
-* **source:** A `git`-type `PipelineResource` specifying the location of the terraform HCL or JSON files
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the terraform HCL or JSON files.
 
 
 ## Terraform-Secret


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The tasks in this commit were updated at some point to use workspaces instead of
pipeline resources but their readmes still refer to the resources.

This commit updates the readmes to remove mention of pipeline resources and link
out to pipeline's workspaces doc.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)