### PR TITLE
Add support for passing extra args to the buildah commands.

### DIFF
--- a/buildah/README.md
+++ b/buildah/README.md
@@ -26,6 +26,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/build
   non-TLS registry) (_default:_ `true`)
 * **FORMAT**: The format of the built container, oci or docker (_default:_
  `oci`)
+* **BUILD_EXTRA_ARGS**: Extra parameters passed for the build command when
+  building images. (_default:_ `""`)
+* **PUSH_EXTRA_ARGS**: Extra parameters passed for the push command when
+  pushing images. (_default:_ `""`)
 
 ## Workspaces
 

--- a/buildah/buildah.yaml
+++ b/buildah/buildah.yaml
@@ -25,6 +25,13 @@ spec:
   - name: FORMAT
     description: The format of the built container, oci or docker
     default: "oci"
+  - name: BUILD_EXTRA_ARGS
+    description: Extra parameters passed for the build command when building images.
+    default: ""
+  - name: PUSH_EXTRA_ARGS
+    description: Extra parameters passed for the push command when pushing images.
+    type: string
+    default: ""
   workspaces:
   - name: source
 
@@ -36,7 +43,11 @@ spec:
   - name: build
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
-    command: ['buildah', '--storage-driver=$(params.STORAGE_DRIVER)', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--no-cache', '-f', '$(params.DOCKERFILE)', '-t', '$(params.IMAGE)', '$(params.CONTEXT)']
+    script: |
+      buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+        --tls-verify=$(params.TLSVERIFY) --no-cache \
+        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
@@ -46,7 +57,11 @@ spec:
   - name: push
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
-    command: ['buildah', '--storage-driver=$(params.STORAGE_DRIVER)', 'push', '--tls-verify=$(params.TLSVERIFY)', '--digestfile', '$(workspaces.source.path)/image-digest', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+    script: |
+      buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+        docker://$(params.IMAGE)
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers


### PR DESCRIPTION
# Changes

This adds two extra optional parameters which allow passing extra args to build when it's building and pushing images.

For example:

    - name: BUILD_EXTRA_ARGS
      value: "--label=test=yes --label=other=label --label=this=too"

Would add  three additional labels to the pushed image

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
