### PR TITLE
Make jib-gradle and jib-maven future-proof regarding Tekton $HOME deprecation

### DIFF
--- a/task/jib-gradle/0.1/README.md
+++ b/task/jib-gradle/0.1/README.md
@@ -31,8 +31,8 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 This TaskRun runs the Task to fetch a Git repo, and build and push a container
 image using Jib (Gradle)
 
-```
-apiVersion: tekton.dev/v1alpha1
+```yaml
+apiVersion: tekton.dev/v1beta1
 kind: PipelineResource
 metadata:
   name: example-image
@@ -43,7 +43,7 @@ spec:
     value: gcr.io/tekton-task-project/my-image
 ```
 
-```
+```yaml
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:

--- a/task/jib-gradle/0.1/jib-gradle.yaml
+++ b/task/jib-gradle/0.1/jib-gradle.yaml
@@ -47,28 +47,36 @@ spec:
                   project.apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
                 }
               }
-            }" > /tekton/home/init-script.gradle
+            }" > $HOME/init-script.gradle
       # Runs the Gradle Jib build.
       gradle jib \
         --stacktrace --console=plain \
-        --init-script=/tekton/home/init-script.gradle \
-        -Duser.home=/tekton/home \
-        -Dgradle.user.home=/tekton/home/.gradle \
+        --init-script=$HOME/init-script.gradle \
+        --gradle-user-home=$HOME/.gradle \
+        -Dgradle.user.home=$HOME/.gradle \
+        -Duser.home=$HOME \
         -Djib.allowInsecureRegistries=$(params.INSECUREREGISTRY) \
         -Djib.to.image=$(resources.outputs.image.url)
     workingDir: $(workspaces.source.path)/$(params.DIRECTORY)
+    env:
+    - name: HOME
+      value: /workspace
     volumeMounts:
+    # empty volume required to make the Gradle home globally writable
+    - name: empty-dir-volume
+      mountPath: /workspace/.gradle
+      subPath: gradle-user-home
     - name: $(params.CACHE)
-      mountPath: /tekton/home/.gradle/caches
+      mountPath: /workspace/.gradle/caches
       subPath: gradle-caches
     - name: $(params.CACHE)
-      mountPath: /tekton/home/.gradle/wrapper
+      mountPath: /workspace/.gradle/wrapper
       subPath: gradle-wrapper
     - name: $(params.CACHE)
-      mountPath: /tekton/home/.m2
+      mountPath: /workspace/.m2
       subPath: m2-cache
     - name: $(params.CACHE)
-      mountPath: /tekton/home/.cache
+      mountPath: /workspace/.cache
       subPath: jib-cache
     securityContext:
       runAsUser: 0

--- a/task/jib-maven/0.1/README.md
+++ b/task/jib-maven/0.1/README.md
@@ -31,8 +31,8 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 This TaskRun runs the Task to fetch a Git repo, and build and push a container
 image using Jib (Maven)
 
-```
-apiVersion: tekton.dev/v1alpha1
+```yaml
+apiVersion: tekton.dev/v1beta1
 kind: PipelineResource
 metadata:
   name: example-image
@@ -43,7 +43,7 @@ spec:
     value: gcr.io/tekton-task-project/my-image
 ```
 
-```
+```yaml
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:

--- a/task/jib-maven/0.1/jib-maven.yaml
+++ b/task/jib-maven/0.1/jib-maven.yaml
@@ -33,21 +33,25 @@ spec:
   steps:
   - name: build-and-push
     image: gcr.io/cloud-builders/mvn
-    command:
-    - mvn
-    - -B
-    - compile
-    - com.google.cloud.tools:jib-maven-plugin:build
-    - -Duser.home=/tekton/home
-    - -Djib.allowInsecureRegistries=$(params.INSECUREREGISTRY)
-    - -Djib.to.image=$(resources.outputs.image.url)
+    # Make sh evaluate $HOME.
+    script: |
+      #!/bin/sh
+      mvn -B \
+        -Duser.home=$HOME \
+        -Djib.allowInsecureRegistries=$(params.INSECUREREGISTRY) \
+        -Djib.to.image=$(resources.outputs.image.url) \
+        compile \
+        com.google.cloud.tools:jib-maven-plugin:build
     workingDir: $(workspaces.source.path)/$(params.DIRECTORY)
+    env:
+    - name: HOME
+      value: /workspace
     volumeMounts:
     - name: $(params.CACHE)
-      mountPath: /tekton/home/.m2
+      mountPath: /workspace/.m2
       subPath: m2-cache
     - name: $(params.CACHE)
-      mountPath: /tekton/home/.cache
+      mountPath: /workspace/.cache
       subPath: jib-cache
 
   volumes:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

@sbwsg

As Tekton prepares for `/tekton/home` deprecation (with the `disable-home-env-overwrite` and `disable-working-directory-overwrite` switches), these changes make `jib-gradle` and `jib-maven` tasks compatible with the current Tekton release and future releases that will flip the switches.

- Set `$HOME` env to `/workspace` at the Task level. (Luckily, this works even if `disable-home-env-overwrite=false`.)
- Use `$HOME` for accessing the home directory wherever possible
- Gradle: mount empty dir volume at `$HOME/.gradle` to make it globally writable (context: https://github.com/tektoncd/pipeline/issues/2165#issuecomment-655578620)
- Maven: switch from `command:` to `script:` to use `$HOME` variable

I've verified these work before and after flipping the deprecation switches.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

There are yamllint violations mostly due to different array element indentation, but I decided not to take care of this after finding out it makes really difficult to diff changes on GitHub.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
