### PR TITLE
Add Tasks to acquire and release boskos resources 🐑

### DIFF
--- a/task/boskos-acquire/0.1/README.md
+++ b/task/boskos-acquire/0.1/README.md
@@ -1,0 +1,39 @@
+# Boskos Acquire
+
+The `boskos-acquire` Task can be used to acquire cloud projects from a pool with
+[Boskos](https://github.com/kubernetes-sigs/boskos#boskos), by invoking `boskosctl`.
+
+To release projects obtained with `boskos-acquire` can be released with
+[`boskos-release`](../boskos-release).
+
+It is implemented using [`boskosctl`](https://github.com/kubernetes-sigs/boskos/tree/master/cmd/boskosctl).
+
+_The Task assumes already have Boskos up and running. To set it up yourself, you
+can look at [this example deployment](https://github.com/kubernetes-sigs/boskos/tree/master/deployments/overlays/example).
+
+## ServiceAccount
+
+After acquiring a project, the Task will start a running `pod` in your cluster to send
+heartbeat requests to Boskos (Boskos will automatically clean up abandoned clusters).
+This means the Task must be run with a serviceAccount that has the ability to interact
+with `pods` (see [service-account.yaml](samples/service-account.yaml) for an example).
+
+## Parameters
+
+* **server-url**: The URL of the running boskos server. (_default_: http://boskos.test-pods.svc.cluster.local)
+* **type**: The type of resource to request. Resource types are specified in the resource
+            ConfigMap provided to the Boskos server. (_default_: gke-project)
+* **owner-name**: A string that identifies the owner of the leased resource to request. (_required_)
+
+## Results
+
+* **leased-resource**: The name of the leased resource
+
+## Usage
+
+See [samples/pipelinerun.yaml](samples/pipelinerun.yaml) for an example of a Pipeline that obtains
+a resource using Boskos, then waits (this is when you would do whatever you need to do with the resource),
+and finally releases it with [`boskos-release`](../boskos-release).
+
+Boskos doesn't do anything to provide you with the credentials you need to interact with the resource you
+have leased. Setting up and managing these credentials is outside the scope of Boskos's responsibilities.

--- a/task/boskos-acquire/0.1/boskos-acquire.yaml
+++ b/task/boskos-acquire/0.1/boskos-acquire.yaml
@@ -1,0 +1,63 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: boskos-acquire
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "boskos,test"
+spec:
+  description: |
+    Acquire a project using Boskos.
+
+    The boskos-acquire Task will request a resource of the specified type from the
+    server-url. If successful, it will start a pod that will run the boskosctl heartbeat
+    command. When you are done with the resource, release it with boskos-release.
+  params:
+  - name: server-url
+    description: The URL of the running boskos server
+    default: "http://boskos.test-pods.svc.cluster.local"
+  - name: type
+    description: |
+      The type of resource to request. Resource types are specified in the resource
+      ConfigMap provided to the Boskos server.
+    default: gke-project
+  - name: owner-name
+    description: A string that identifies the owner of the leased resource to request.
+  results:
+  - name: leased-resource
+    description: The name of the leased resource
+  steps:
+  - name: boskosctl-acquire
+    image: gcr.io/k8s-staging-boskos/boskosctl@sha256:a7fc984732c5dd0b4e0fe0a92e2730fa4b6bddecd0f6f6c7c6b5501abe4ab105
+    script: |
+      RESOURCE=$(boskosctl acquire \
+        --server-url=$(params.server-url) \
+        --owner-name=$(params.owner-name) \
+        --type=$(params.type) \
+        --state=free \
+        --target-state=busy)
+      echo $RESOURCE > /workspace/full-resource-output.json
+      echo $RESOURCE | jq -rj ".name" > /tekton/results/leased-resource
+  - name: create-heartbeat-pod-yaml
+    image: lachlanevenson/k8s-kubectl@sha256:3a5e22a406a109f4f26ec06b5f1f6a66ae0cd0e185bc28499eb7b7a3bbf1fe09
+    script: |
+      FULL_RESOURCE_OUTPUT=$(cat /workspace/full-resource-output.json)
+      LEASED_RESOURCE=$(cat /tekton/results/leased-resource)
+      cat <<EOF | kubectl apply -f -
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: boskos-heartbeat-$LEASED_RESOURCE
+      spec:
+        containers:
+        - name: heartbeat
+          image: gcr.io/k8s-staging-boskos/boskosctl@sha256:a7fc984732c5dd0b4e0fe0a92e2730fa4b6bddecd0f6f6c7c6b5501abe4ab105
+          args:
+          - heartbeat
+          - --server-url=$(params.server-url)
+          - --owner-name=$(params.owner-name)
+          - --resource=$FULL_RESOURCE_OUTPUT
+          - --period=5m
+      EOF

--- a/task/boskos-acquire/0.1/samples/pipelinerun.yaml
+++ b/task/boskos-acquire/0.1/samples/pipelinerun.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: do-boskos-
+spec:
+  serviceAccountName: boskos-heartbeat
+  pipelineSpec:
+    params:
+    - name: owner-name
+      default: trying-out-boskos
+    tasks:
+      - name: boskos-acquire
+        taskRef:
+          name: boskos-acquire
+        params:
+          - name: owner-name
+            value: $(params.owner-name)
+      - name: wait
+        runAfter: [boskos-acquire]
+        taskSpec:
+          steps:
+          - image: alpine
+            script: |
+              sleep 1m
+      - name: boskos-release
+        runAfter: [wait]
+        taskRef:
+          name: boskos-release
+        params:
+          - name: leased-resource
+            # TODO(pipeline#2557): This is a good candidate for a finally clause
+            value: $(tasks.boskos-acquire.results.leased-resource)
+          - name: owner-name
+            value: $(params.owner-name)

--- a/task/boskos-acquire/0.1/samples/service-account.yaml
+++ b/task/boskos-acquire/0.1/samples/service-account.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: boskos-heartbeat
+  namespace: default
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-editor
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: boskos-heartbeat-pod-editor
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: boskos-heartbeat
+    namespace: default
+roleRef:
+  kind: Role
+  name: pod-editor
+  apiGroup: rbac.authorization.k8s.io

--- a/task/boskos-acquire/OWNERS
+++ b/task/boskos-acquire/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- bobcatfish

--- a/task/boskos-release/0.1/README.md
+++ b/task/boskos-release/0.1/README.md
@@ -1,0 +1,31 @@
+# Boskos Release
+
+The `boskos-release` Task can be used to release cloud projects
+which were obtained from a pool with [Boskos](https://github.com/kubernetes-sigs/boskos#boskos)
+via [`boskos-acquire`](../boskos-acquire).
+
+It will mark the resource as `dirty` so that Boskos will clear any obtained resources.
+
+It is implemented using [`boskosctl`](https://github.com/kubernetes-sigs/boskos/tree/master/cmd/boskosctl).
+
+_The Task assumes already have Boskos up and running. To set it up yourself, your
+best bet would be to find an example of it already configured, for example
+[the boskos configuration used for Tekton itself](https://github.com/tektoncd/plumbing/tree/master/boskos)._
+
+## ServiceAccount
+
+[`boskos-acquire`](../boskos-acquire) will start a `pod` in your cluster to maintain the lease
+via a heartbeat. `boskos-release` will delete that pod, and so the Task must be run with a
+serviceAccount that has the ability to delete `pods` (see [service-account.yaml](samples/service-account.yaml) for an example).
+
+## Parameters
+
+* **server-url**: The URL of the running boskos server. (_default_: http://boskos.test-pods.svc.cluster.local)
+* **leased-resource**: The name of the leased resource. (_required_)
+* **owner-name**: A string that identifies the owner of the leased resource to request. (_required_)
+
+## Usage
+
+See [samples/pipelinerun.yaml](samples/pipelinerun.yaml) for an example of a Pipeline that obtains
+a resource using [`boskos-acquire`](../boskos-acquire), then waits (this is when you would do whatever
+you need to do with the resource), and finally releases it with `boskos-release`.

--- a/task/boskos-release/0.1/boskos-release.yaml
+++ b/task/boskos-release/0.1/boskos-release.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: boskos-release
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "boskos,test"
+spec:
+  description: |
+    Release a project acquired using Boskos.
+
+    The boskos-release Task will release the specified resource from the boskos instance
+    at server-url. It also assumes the resource was obtained via boskos-acquire and so
+    terminates the heartbeat pod that was created by that Task to keep the resource obtained.
+    It will mark the resource as dirty so that the boskos Janitor will clean it (by deleting
+    any state created).
+  params:
+  - name: server-url
+    description: The URL of the running boskos server
+    default: "http://boskos.test-pods.svc.cluster.local"
+  - name: leased-resource
+    description: A string that identifies the leased resource to release.
+  - name: owner-name
+    description: A string that identifies the owner of the leased resource to request.
+  steps:
+  - name: boskosctl-release
+    image: gcr.io/k8s-staging-boskos/boskosctl@sha256:a7fc984732c5dd0b4e0fe0a92e2730fa4b6bddecd0f6f6c7c6b5501abe4ab105
+    args:
+    - "release"
+    - "--server-url=$(params.server-url)"
+    - "--owner-name=$(params.owner-name)"
+    - "--name=$(params.leased-resource)"
+    - "--target-state=dirty"
+  - name: stop-boskosctl-heartbeat
+    image: lachlanevenson/k8s-kubectl@sha256:3a5e22a406a109f4f26ec06b5f1f6a66ae0cd0e185bc28499eb7b7a3bbf1fe09
+    args:
+    - "delete"
+    - "pod"
+    - "boskos-heartbeat-$(params.leased-resource)"

--- a/task/boskos-release/0.1/samples/pipelinerun.yaml
+++ b/task/boskos-release/0.1/samples/pipelinerun.yaml
@@ -1,0 +1,1 @@
+boskos-acquire/0.1/samples/pipelinerun.yaml

--- a/task/boskos-release/0.1/samples/service-account.yaml
+++ b/task/boskos-release/0.1/samples/service-account.yaml
@@ -1,0 +1,1 @@
+boskos-acquire/0.1/samples/service-account.yaml

--- a/task/boskos-release/OWNERS
+++ b/task/boskos-release/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- bobcatfish


### PR DESCRIPTION
# Changes

Boskos is a tool that allows one to create a pool of cloud projects
(definitely GCP, I think it supports other providers as well), and
manages acquiring, releasing, and cleaning them between leases.

We use it for Tekton test infrastructure for our end to end tests and
we'd like to use it for our catalog Tasks as well.

This commit adds boskos acquire and release Tasks.

The acquire Task also creates a pod in the running cluster to perform
heartbeating so that boskos knows that the resource is still in use.
(Lemme know if you have a better idea for making this work! I have this
slightly crazy idea that Pipeline level sidecars might make sense ....)

The intention of the release Task is that it would be run in a
Pipeline's `finally` clause, however today that would be difficult
because finally Tasks can't yet use the results of other Tasks, but this
functionality is on the way: https://github.com/tektoncd/pipeline/issues/2557

This is part of the work in #373 to create a Pipeline for the catalog.

Thanks to @ixdy for helping me figure this out! This also might be relevant to your interests @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [?] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
