### PR TITLE
Add task which can run shell commands on remote Host

### DIFF
--- a/task/remote-ssh-commands/0.1/README.md
+++ b/task/remote-ssh-commands/0.1/README.md
@@ -1,0 +1,122 @@
+# Remote SSH Commands
+
+This task can be used to run shell commands on remote machine and produce the result. It is done by SSHing into the remote Host by providing the required credentials and the shell script which we want to run over there.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/remote-ssh-commands/0.1/remote-ssh-commands.yaml
+```
+
+## Parameters
+
+- **HOST**: The server host to which you want to connect. (**Required**)
+- **USERNAME**: Connect as an user. (**Required**)
+- **PORT**: Port number to connect (_default:_ 22).
+- **SSH_SCRIPT**: The shell script which you want to run on remote host. (**Required**)
+- **USE_INSECURE_CIPHER**: Boolean value to include ciphers or not. (_default_:"false")
+
+## Workspaces
+
+- **credentials**: The workspace contains secrets can be used to authenticate with the HOST.
+  ### Secrets
+  - **privatekey**: The private SSH key in case public SSH key is present on host.
+  - **passphrase**: The passphrase used at the time of generating the private key for encryption.
+  - **password**: User password to connect to host.
+  - **fingerprint**: Fingerprint SHA256 of the host public key, default is to skip verification.
+  - **ciphers**: The allowed cipher algorithms. If unspecified then a sensible.
+
+## Usage
+
+1. Create the `Secret` by putting in the required values
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: remote-ssh-secret
+data:
+  passphrase: passphrase
+  privatekey: privatekey
+```
+
+2. Create the `TaskRun`
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: remote-ssh-commands-run
+spec:
+  taskRef:
+    name: remote-ssh-commands
+  workspaces:
+    - name: credentials
+      secret:
+        secretName: remote-ssh-secret
+  params:
+    - name: HOST
+      value: "127.0.0.1"
+    - name: USERNAME
+      value: "username"
+    - name: SSH_SCRIPT
+      value: |
+        #!/bin/sh
+        hostname
+        echo "--------"
+        pwd
+        ls -a
+```
+
+### Output
+
+```bash
+$ tkn t logs -f
+? Select task: remote-ssh-commands
+[ssh] + export 'script=#!/bin/sh
+[ssh] hostname
+[ssh] echo --------
+[ssh] pwd
+[ssh] ls -a
+[ssh] '
+[ssh] + cmd=
+[ssh] + '[[' -f ./privatekey ]]
+[ssh] + cmd=' -i ./privatekey'
+[ssh] + '[[' -f ./password ]]
+[ssh] + '[[' -f ./passphrase ]]
+[ssh] + cat ./passphrase
+[ssh] + cmd=' -i ./privatekey --ssh-passphrase XXXXXX'
+[ssh] + '[[' -f ./fingerprint ]]
+[ssh] + '[[' -f ./ciphers ]]
+[ssh] + '[[' false '==' true ]]
+[ssh] + drone-ssh -H 127.0.0.1 -p 22 -u username -s '#!/bin/sh
+[ssh] hostname
+[ssh] echo --------
+[ssh] pwd
+[ssh] ls -a
+[ssh] ' -i ./privatekey --ssh-passphrase 'XXXXX'
+[ssh] ======CMD======
+[ssh] #!/bin/sh
+[ssh] hostname
+[ssh] echo --------
+[ssh] pwd
+[ssh] ls -a
+[ssh]
+[ssh] ======END======
+[ssh] out: ssh-test
+[ssh] out: --------
+[ssh] out: /home/username
+[ssh] out: .
+[ssh] out: ..
+[ssh] out: .bash_history
+[ssh] out: .bash_logout
+[ssh] out: .bashrc
+[ssh] out: .gnupg
+[ssh] out: .profile
+[ssh] out: .ssh
+[ssh] out: desktop
+[ssh] ==============================================
+[ssh] ✅ Successfully executed commands to all host.
+[ssh] ==============================================
+```

--- a/task/remote-ssh-commands/0.1/remote-ssh-commands.yaml
+++ b/task/remote-ssh-commands/0.1/remote-ssh-commands.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: remote-ssh-commands
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: ssh, ssh remote
+    tekton.dev/displayName: "ssh remote commands"
+spec:
+  description: >-
+    The following task can be used to execute commands on remote machine.
+
+    The following task takes host and required credentials as input along
+    with the script and execute them on respective host machine and
+    produce the output.
+  workspaces:
+    - name: credentials
+      description: >-
+        The workspace contains secrets can be used to authenticate
+        with the HOST.
+  params:
+    - name: HOST
+      type: string
+      description: Remote host to connect
+    - name: USERNAME
+      type: string
+      description: SSH username
+    - name: PORT
+      type: string
+      description: SSH port, default is 22
+      default: "22"
+    - name: SSH_SCRIPT
+      type: string
+      description: The script which you want to execute on remote server
+    - name: USE_INSECURE_CIPHER
+      type: string
+      description: include more ciphers with use_insecure_cipher
+      default: "false"
+  steps:
+    - name: ssh
+      image: appleboy/drone-ssh
+      workingDir: $(workspaces.creds.path)
+      script: |
+
+        export script="$(params.SSH_SCRIPT)"
+        cmd=""
+        [[ -f ./privatekey ]] && cmd="$cmd -i ./privatekey"
+        [[ -f ./password ]] && cmd="$cmd -P $(cat ./password)"
+        [[ -f ./passphrase ]] && cmd="$cmd --ssh-passphrase $(cat ./passphrase)"
+        [[ -f ./fingerprint ]] && cmd="$cmd --fingerprint $(cat ./fingerprint)"
+        [[ -f ./ciphers ]] && cmd="$cmd --ciphers $(cat ./ciphers)"
+        [[ $(params.USE_INSECURE_CIPHER) == "true" ]] && cmd="$cmd --useInsecureCipher true"
+
+        drone-ssh -H $(params.HOST) -p $(params.PORT) -u $(params.USERNAME) -s "$script" $cmd

--- a/task/remote-ssh-commands/0.1/samples/run.yaml
+++ b/task/remote-ssh-commands/0.1/samples/run.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: remote-ssh-commands-run
+spec:
+  taskRef:
+    name: remote-ssh-commands
+  workspaces:
+    - name: credentials
+      secret:
+        secretName: remote-ssh-secret
+  params:
+    - name: HOST
+      value: "127.0.0.1"
+    - name: USERNAME
+      value: "username"
+    - name: SSH_SCRIPT
+      value: |
+        #!/bin/sh
+        hostname
+        uname
+        ps -ef

--- a/task/remote-ssh-commands/0.1/samples/secrets.yaml
+++ b/task/remote-ssh-commands/0.1/samples/secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: remote-ssh-secret
+data:
+  passphrase: passphrase of the private ssh key in base64
+  privatekey: your private ssh key in base64
+  password: password (if used to login the remote server)
+  fingerprint: |
+    fingerprint SHA256 of the host public key. Default is to skip verification
+  ciphers: |
+    The allowed cipher algorithms. If unspecified then a sensible


### PR DESCRIPTION
# Changes

The following task can be used to run the shell command (single/multiple) on remote Host by SSHing into the remote machine by providing the required credentials required to login into that Host and get back the result as output.

Tests are not provided in the PR as this task requires a remote Host along with credentials. So I have tested this task on my machine and included a sample in the README.

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [X] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
