### PR TITLE
Add pylint and pytest task

### DIFF
--- a/task/pylint/0.1/README.md
+++ b/task/pylint/0.1/README.md
@@ -1,0 +1,50 @@
+# pylint
+
+The task provides linting based on [pylint](https://pypi.org/project/pylint/) for Python. The used images are based on the official Docker Hub [Python images](https://hub.docker.com/_/python). The installation of the packages is performed via a `pip install`.
+
+**It is required that `pylint` is part of the requirements file for the task. If the module is not included a warning will be printed.**
+
+## Install the Task
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the python code.
+
+### Install pylint
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/pylint/0.1/pylint.yaml
+```
+
+## Parameters
+
+* **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `3.6`)
+* **SOURCE_PATH**: The path to the source code (_default_: `.`)
+* **MODULE_PATH**: The path to the module which should be analysed by pylint (_default_: `.`)
+* **ARGS**: The additional arguments to be used with pylint
+* **REQUIREMENTS_FILE**: The name of the requirements file inside the source location (_default_: `requirements.txt`)
+
+## Usage
+
+This `TaskRun` runs `pylint` on a repository.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: lint
+spec:
+  taskRef:
+    name: pylint
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: PYTHON
+    value: "3.7"
+  - name: MODULE
+    value: "examples/custom.py"
+  - name: ARGS
+    value: "-r y"
+```

--- a/task/pylint/0.1/pylint.yaml
+++ b/task/pylint/0.1/pylint.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pylint
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: python, pylint
+    tekton.dev/displayName: pylint
+
+spec:
+  description: >-
+    This task will run pylint on the provided input.
+
+  workspaces:
+    - name: source
+  params:
+    - name: PYTHON
+      description: The used Python version, more precisely the tag for the Python image
+      type: string
+      default: "3.6"
+    - name: SOURCE_PATH
+      description: The path to the source code
+      default: "."
+    - name: MODULE_PATH
+      description: The path to the module which should be analysed by pylint
+      default: "."
+    - name: ARGS
+      description: The additional arguments to be used with pylint
+      type: string
+      default: ""
+    - name: REQUIREMENTS_FILE
+      description: The name of the requirements file inside the source location
+      default: "requirements.txt"
+  steps:
+    - name: lint
+      image: docker.io/python:$(inputs.params.PYTHON)
+      workingDir: /workspace/source
+      script: |
+          pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
+          pip show pylint || echo "###\nWarning: Pylint is missing in your requirements\n###" && pip install pylint
+          pylint $(inputs.params.ARGS) $(inputs.params.MODULE_PATH)

--- a/task/pylint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/pylint/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml

--- a/task/pylint/0.1/tests/resources.yaml
+++ b/task/pylint/0.1/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: python-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/task/pylint/0.1/tests/run.yaml
+++ b/task/pylint/0.1/tests/run.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: python-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/wumaxd/pylint-pytest-example.git
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+
+    - name: pylint
+      taskRef:
+        name: pylint
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: PYTHON
+          value: "3.7"
+        - name: ARGS
+          value: "-r y"
+        - name: MODULE_PATH
+          value: "src/"
+        - name: REQUIREMENTS_FILE
+          value: "requirements.txt"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: python-test-pipeline-run
+spec:
+  pipelineRef:
+    name: python-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: python-source-pvc

--- a/task/pytest/0.1/README.md
+++ b/task/pytest/0.1/README.md
@@ -1,0 +1,47 @@
+# pytest
+
+The task provides test execution based on [pytest](https://pypi.org/project/pytest/) for Python. The used images are based on the official Docker Hub [Python images](https://hub.docker.com/_/python). The installation of the packages is performed via a `pip install`.
+
+**It is required that `pytest` is part of the requirements file for the task. If the module is not included a warning will be printed.**
+
+## Install the Task
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the python code.
+
+### Install pytest
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/pytest/0.1/pytest.yaml
+```
+
+## Parameters
+
+* **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `3.6`)
+* **ARGS**: The additional arguments to be used with pytest
+* **SOURCE_PATH**: The path to the source code (_default_: `.`)
+* **REQUIREMENTS_FILE**: The name of the requirements file inside the source location (_default_: `requirements.txt`)
+
+## Usage
+
+This `TaskRun` runs `pytest` on a repository.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: pytest
+spec:
+  taskRef:
+    name: pytest
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: PYTHON
+    value: "3.7"
+  - name: ARGS
+    value: "-rfs"
+```

--- a/task/pytest/0.1/pytest.yaml
+++ b/task/pytest/0.1/pytest.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pytest
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: python, pytest
+    tekton.dev/displayName: pytest
+
+spec:
+  description: >-
+    This task will run pytest on the provided input.
+
+  workspaces:
+    - name: source
+  params:
+    - name: PYTHON
+      description: The used Python version, more precisely the tag for the Python image
+      type: string
+      default: "3.6"
+    - name: ARGS
+      description: The additional arguments to be used with pytest
+      type: string
+      default: ""
+    - name: SOURCE_PATH
+      description: The path to the source code
+      default: "."
+    - name: REQUIREMENTS_FILE
+      description: The name of the requirements file inside the source location
+      default: "requirements.txt"
+  steps:
+    - name: unit-test
+      image: docker.io/python:$(inputs.params.PYTHON)
+      workingDir: /workspace/source
+      script: |
+          pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
+          pip show pytest || echo "###\nWarning: Pytest is missing in your requirements\n###" && pip install pytest
+          pytest $(inputs.params.ARGS) $(inputs.params.SOURCE-PATH)

--- a/task/pytest/0.1/tests/pre-apply-task-hook.sh
+++ b/task/pytest/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml

--- a/task/pytest/0.1/tests/resources.yaml
+++ b/task/pytest/0.1/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: python-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/task/pytest/0.1/tests/run.yaml
+++ b/task/pytest/0.1/tests/run.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: python-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/wumaxd/pylint-pytest-example.git
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+
+    - name: pytest
+      taskRef:
+        name: pytest
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: PYTHON
+          value: "3.7"
+        - name: ARGS
+          value: "-rfs"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: python-test-pipeline-run
+spec:
+  pipelineRef:
+    name: python-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: python-source-pvc


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The Tasks can be used to run linting based on the module `pylint` and to execute unit-tests based on the module `pytest`. This is described in issue #364.

The Tasks are based on the official [Python image](https://hub.docker.com/_/python) and therefore the image tags can be used. The installation of `pylint` and `pytest` is done during the task to ensure the possibility to pin the version by using a requirements file.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [x] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
