### PR TITLE
Remove implicit "set -x" from git-clone, deleteExisting by default

### DIFF
--- a/task/git-clone/0.2/README.md
+++ b/task/git-clone/0.2/README.md
@@ -1,0 +1,60 @@
+# Git Task
+
+This `Task` is Git task to work with repositories used by other tasks
+in your Pipeline.
+## `git-clone`
+
+**Please Note: this Task is only compatible with Tekton Pipelines versions 0.11-rc1 and greater!**
+
+This `Task` has two required inputs:
+
+1. The URL of a git repo to clone provided with the `url` param.
+2. A Workspace called `output`.
+
+The `git-clone` `Task` will clone a repo from the provided `url` into the
+`output` Workspace. By default the repo will be cloned into the root of
+your Workspace. You can clone into a subdirectory by setting this `Task`'s
+`subdirectory` param. If the directory where the repo will be cloned is
+already populated then by default the contents will be deleted before the
+clone takes place. This behaviour can be disabled by setting the
+`deleteExisting` param to `"false"`.
+
+This `Task` does the job of the legacy `GitResource` `PipelineResource` and
+is intended as its replacement. This is part of our plan to [offer replacement
+`Tasks` for Pipeline Resources](https://github.com/tektoncd/catalog/issues/95)
+as well as
+[document those replacements](https://github.com/tektoncd/pipeline/issues/1369).
+
+### Workspaces
+
+* **output**: A workspace for this Task to fetch the git repository in to.
+
+### Parameters
+
+* **url**: git url to clone (_required_)
+* **revision**: git revision to checkout (branch, tag, sha, ref…) (_default_: master)
+* **refspec**: git refspec to fetch before checking out revision (_default_:refs/heads/master:refs/heads/master)
+* **submodules**: defines if the resource should initialize and fetch the submodules (_default_: true)
+* **depth**: performs a shallow clone where only the most recent commit(s) will be fetched (_default_: 1)
+* **sslVerify**: defines if http.sslVerify should be set to true or false in the global git config (_default_: true)
+* **subdirectory**: subdirectory inside the "output" workspace to clone the git repo into (_default:_ "")
+* **deleteExisting**: clean out the contents of the repo's destination directory if it already exists before cloning the repo there (_default_: true)
+* **httpProxy**: git HTTP proxy server for non-SSL requests (_default_: "")
+* **httpsProxy**: git HTTPS proxy server for SSL requests (_default_: "")
+* **noProxy**: git no proxy - opt out of proxying HTTP/HTTPS requests (_default_: "")
+* **verbose**: log the commands that are executed during `git-clone`'s operation (_default_: true)
+
+### Results
+
+* **commit**: The precise commit SHA that was fetched by this Task
+
+## Usage
+
+### `git-clone`
+
+The following pipelines demonstrate usage of the git-clone Task:
+
+- [Cloning a branch](../0.1/samples/git-clone-checking-out-a-branch.yaml)
+- [Checking out a specific git commit](../0.1/samples/git-clone-checking-out-a-commit.yaml)
+- [Checking out a git tag and using the "commit" Task Result](../0.1/samples/using-git-clone-result.yaml)
+

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -1,0 +1,125 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git clone"
+spec:
+  description: >-
+    These Tasks are Git tasks to work with repositories used by other tasks
+    in your Pipeline.
+
+    The git-clone Task will clone a repo from the provided url into the
+    output Workspace. By default the repo will be cloned into the root of
+    your Workspace. You can clone into a subdirectory by setting this Task's
+    subdirectory param.
+
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this workspace
+  params:
+    - name: url
+      description: git url to clone
+      type: string
+    - name: revision
+      description: git revision to checkout (branch, tag, sha, ref…)
+      type: string
+      default: master
+    - name: refspec
+      description: (optional) git refspec to fetch before checking out revision
+      default: ""
+    - name: submodules
+      description: defines if the resource should initialize and fetch the submodules
+      type: string
+      default: "true"
+    - name: depth
+      description: performs a shallow clone where only the most recent commit(s) will be fetched
+      type: string
+      default: "1"
+    - name: sslVerify
+      description: defines if http.sslVerify should be set to true or false in the global git config
+      type: string
+      default: "true"
+    - name: subdirectory
+      description: subdirectory inside the "output" workspace to clone the git repo into
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
+      type: string
+      default: "true"
+    - name: httpProxy
+      description: git HTTP proxy server for non-SSL requests
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: git HTTPS proxy server for SSL requests
+      type: string
+      default: ""
+    - name: noProxy
+      description: git no proxy - opt out of proxying HTTP/HTTPS requests
+      type: string
+      default: ""
+    - name: verbose
+      description: log the commands used during execution
+      type: string
+      default: "true"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task
+  steps:
+    - name: clone
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2
+      script: |
+        #!/bin/sh
+        set -eu -o pipefail
+
+        if [[ "$(params.verbose)" == "true" ]] ; then
+          set -x
+        fi
+
+        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+          # or the root of a mounted volume.
+          if [[ -d "$CHECKOUT_DIR" ]] ; then
+            # Delete non-hidden files and directories
+            rm -rf "$CHECKOUT_DIR"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "$CHECKOUT_DIR"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "$CHECKOUT_DIR"/..?*
+          fi
+        }
+
+        if [[ "$(params.deleteExisting)" == "true" ]] ; then
+          cleandir
+        fi
+
+        test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
+        test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
+        test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
+
+        /ko-app/git-init \
+          -url "$(params.url)" \
+          -revision "$(params.revision)" \
+          -refspec "$(params.refspec)" \
+          -path "$CHECKOUT_DIR" \
+          -sslVerify="$(params.sslVerify)" \
+          -submodules="$(params.submodules)" \
+          -depth "$(params.depth)"
+        cd "$CHECKOUT_DIR"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "$EXIT_CODE" != 0 ] ; then
+          exit $EXIT_CODE
+        fi
+        # ensure we don't add a trailing newline to the result
+        echo -n "$RESULT_SHA" > $(results.commit.path)

--- a/task/git-clone/0.2/samples/git-clone-checking-out-a-branch.yaml
+++ b/task/git-clone/0.2/samples/git-clone-checking-out-a-branch.yaml
@@ -1,0 +1,75 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cat-branch-readme
+spec:
+  description: |
+    cat-branch-readme takes a git repository and a branch name and
+    prints the README.md file from that branch. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a branch
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: branch-name
+    type: string
+    description: The git branch to clone.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the repo's README.md file to be read.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.branch-name)
+  - name: cat-readme
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          cat $(workspaces.source.path)/README.md
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-checking-out-a-branch
+spec:
+  pipelineRef:
+    name: cat-branch-readme
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: branch-name
+    value: release-v0.12.x

--- a/task/git-clone/0.2/samples/git-clone-checking-out-a-commit.yaml
+++ b/task/git-clone/0.2/samples/git-clone-checking-out-a-commit.yaml
@@ -1,0 +1,87 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: checking-out-a-revision
+spec:
+  description: |
+    checking-out-a-revision takes a git repository and a commit SHA
+    and validates that cloning the revision succeeds. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a specific commit
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: commit
+    type: string
+    description: The git commit to fetch.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the commit to be checked.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.commit)
+  - name: compare-received-commit-to-expected
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    params:
+    - name: expected-commit
+      value: $(params.commit)
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      params:
+      - name: expected-commit
+      workspaces:
+      - name: source
+      steps:
+      - image: alpine/git:v2.24.3
+        script: |
+          #!/usr/bin/env sh
+          cd $(workspaces.source.path)
+          receivedCommit=$(git rev-parse HEAD)
+          if [ $receivedCommit != $(params.expected-commit) ]; then
+            echo "Expected commit $(params.expected-commit) but received $receivedCommit."
+            exit 1
+          else
+            echo "Received commit $receivedCommit as expected."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-clone-checking-out-a-commit-
+spec:
+  pipelineRef:
+    name: checking-out-a-revision
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: commit
+    value: 301b41380e95382a18b391c2165fa3a6a3de93b0  # Tekton Pipeline's first ever commit!

--- a/task/git-clone/0.2/samples/using-git-clone-result.yaml
+++ b/task/git-clone/0.2/samples/using-git-clone-result.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: validate-tag-sha
+spec:
+  description: |
+    validate-tag-sha takes a git repository, tag name, and a commit SHA and
+    checks whether the given tag resolves to that commit. This example
+    Pipeline demonstrates the following:
+      - How to use the git-clone catalog Task
+      - How to use the git-clone Task's "commit" Task Result from another Task.
+      - How to discard the contents of the git repo when it isn't needed by
+        passing an `emptyDir` Volume as its "output" workspace.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: tag-name
+    type: string
+    description: The git tag to clone.
+  - name: expected-sha
+    type: string
+    description: The expected SHA to be received for the supplied revision.
+  workspaces:
+  - name: output
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: output
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.tag-name)
+  - name: validate-revision-sha
+    params:
+    - name: revision-name
+      value: $(params.tag-name)
+    - name: expected-sha
+      value: $(params.expected-sha)
+    - name: received-sha
+      value: $(tasks.fetch-repository.results.commit)
+    taskSpec:
+      params:
+      - name: revision-name
+      - name: expected-sha
+      - name: received-sha
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          if [ "$(params.expected-sha)" != "$(params.received-sha)" ]; then
+            echo "Expected revision $(params.revision-name) to have SHA $(params.expected-sha)."
+            exit 1
+          else
+            echo "Revision $(params.revision-name) has expected SHA $(params.expected-sha)."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: using-git-clone-result-
+spec:
+  pipelineRef:
+    name: validate-tag-sha
+  workspaces:
+  - name: output
+    emptyDir: {}  # We don't care about the repo contents in this example, just the "commit" result
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: tag-name
+    value: v0.12.1
+  - name: expected-sha
+    value: a54dd3984affab47f3018852e61a1a6f9946ecfa

--- a/task/git-clone/0.2/tests/run.yaml
+++ b/task/git-clone/0.2/tests/run.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-noargs
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-tag
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: revision
+      value: 1.0.0
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-submodules
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/githubtraining/example-dependency
+    - name: submodules
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-depth-2
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: depth
+      value: "2"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-sslverify-none
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: sslVerify
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-subdirectory
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: subdirectory
+      value: "hellomoto"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-delete-existing
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: deleteExisting
+      value: "true"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-without-verbose
+spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: verbose
+      value: "false"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds git-clone v0.2. One default behaviour has changed
and one new param has been introduced in this version:

1) Tasks that don't start their script with #! automatically receive
a preamble that includes `set -x`. This results in verbose output
because every command is printed while the Task is running.

This commit adds a new param, "verbose", that - when set to "false" -
prevents the commands run by the task from being printed to logs.
The default value is "true": the commands run by the task will be
printed in the log.

2) The git-clone Task offers a param, deleteExisting, that cleans
any existing directory before performing a clone into it. This
has previously been set to "false" by default since it's potentially
destructive. But it sounds like there's quite often a request for
how to enable this behaviour, so it seems like the more pragmatic
default would be "true".

This commit sets deleteExisting to be defaulted to "true" so that
any existing git checkout is removed prior to a new clone being
performed.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [x] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows convention