### PR TITLE
Introduce better security for buildpacks-phases task

### DIFF
--- a/task/buildpacks-phases/0.1/README.md
+++ b/task/buildpacks-phases/0.1/README.md
@@ -5,6 +5,8 @@ Buildpacks](https://buildpacks.io). To do that, it uses [builders](https://build
 
 Cloud Native Buildpacks are pluggable, modular tools that transform application source code into OCI images. They replace Dockerfiles in the app development lifecycle, and enable for swift rebasing of images and modular control over images (through the use of builders), among other benefits. This command uses a builder to construct the image, and pushes it to the registry provided.
 
+The lifecycle phases are run in separate containers to enable better security for untrusted builders. Specifically, registry credentials are hidden from the detect and build phases of the lifecycle, and the analyze, restore, and export phases (which require credentials) are run in the lifecycle image published by buildpacksio.
+
 See also [`buildpacks`](../buildpacks) for the combined version of this task, which uses the [creator binary](https://github.com/buildpacks/spec/blob/platform/0.3/platform.md#operations), to run all of the [lifecycle phases](https://buildpacks.io/docs/concepts/components/lifecycle/#phases). This task, in contrast, runs all of the phases separately.
 
 ## Install the Task

--- a/task/buildpacks-phases/0.1/README.md
+++ b/task/buildpacks-phases/0.1/README.md
@@ -5,7 +5,7 @@ Buildpacks](https://buildpacks.io). To do that, it uses [builders](https://build
 
 Cloud Native Buildpacks are pluggable, modular tools that transform application source code into OCI images. They replace Dockerfiles in the app development lifecycle, and enable for swift rebasing of images and modular control over images (through the use of builders), among other benefits. This command uses a builder to construct the image, and pushes it to the registry provided.
 
-The lifecycle phases are run in separate containers to enable better security for untrusted builders. Specifically, registry credentials are hidden from the detect and build phases of the lifecycle, and the analyze, restore, and export phases (which require credentials) are run in the lifecycle image published by buildpacksio.
+The lifecycle phases are run in separate containers to enable better security for untrusted builders. Specifically, registry credentials are hidden from the detect and build phases of the lifecycle, and the analyze, restore, and export phases (which require credentials) are run in the lifecycle image published by the [Cloud Native Buildpacks project]( https://hub.docker.com/u/buildpacksio).
 
 See also [`buildpacks`](../buildpacks) for the combined version of this task, which uses the [creator binary](https://github.com/buildpacks/spec/blob/platform/0.3/platform.md#operations), to run all of the [lifecycle phases](https://buildpacks.io/docs/concepts/components/lifecycle/#phases). This task, in contrast, runs all of the phases separately.
 

--- a/task/buildpacks-phases/0.1/buildpacks-phases.yaml
+++ b/task/buildpacks-phases/0.1/buildpacks-phases.yaml
@@ -42,6 +42,9 @@ spec:
     - name: SOURCE_SUBPATH
       description: A subpath within the `source` input where the source to build is located.
       default: ""
+    - name: HOME_OVERRIDE
+      description: Override the home directory during detect and build to hide secrets from buildpacks.
+      default: empty-dir
 
   resources:
     outputs:
@@ -76,6 +79,18 @@ spec:
       securityContext:
         privileged: true
 
+    - name: copy-stack-toml
+      image: $(params.BUILDER_IMAGE)
+      imagePullPolicy: Always
+      command: ["/bin/sh"]
+      args:
+        - "-c"
+        - >
+          cp /cnb/stack.toml /layers/
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+
     - name: detect
       image: $(params.BUILDER_IMAGE)
       imagePullPolicy: Always
@@ -89,15 +104,19 @@ spec:
           mountPath: /layers
         - name: $(params.PLATFORM_DIR)
           mountPath: /platform
+        - name: $(params.HOME_OVERRIDE)
+          mountPath: /tekton/home
 
     - name: analyze
-      image: $(params.BUILDER_IMAGE)
+      image: buildpacksio/lifecycle:0.8.1
       imagePullPolicy: Always
       command: ["/cnb/lifecycle/analyzer"]
       args:
         - "-layers=/layers"
         - "-group=/layers/group.toml"
         - "-cache-dir=/cache"
+        - "-uid=$(params.USER_ID)"
+        - "-gid=$(params.GROUP_ID)"
         - "$(resources.outputs.image.url)"
       volumeMounts:
         - name: $(params.CACHE)
@@ -106,13 +125,15 @@ spec:
           mountPath: /layers
 
     - name: restore
-      image: $(params.BUILDER_IMAGE)
+      image: buildpacksio/lifecycle:0.8.1
       imagePullPolicy: Always
       command: ["/cnb/lifecycle/restorer"]
       args:
         - "-group=/layers/group.toml"
         - "-layers=/layers"
         - "-cache-dir=/cache"
+        - "-uid=$(params.USER_ID)"
+        - "-gid=$(params.GROUP_ID)"
       volumeMounts:
         - name: $(params.CACHE)
           mountPath: /cache
@@ -133,9 +154,11 @@ spec:
           mountPath: /layers
         - name: $(params.PLATFORM_DIR)
           mountPath: /platform
+        - name: $(params.HOME_OVERRIDE)
+          mountPath: /tekton/home
 
     - name: export
-      image: $(params.BUILDER_IMAGE)
+      image: buildpacksio/lifecycle:0.8.1
       imagePullPolicy: Always
       command: ["/cnb/lifecycle/exporter"]
       args:
@@ -144,6 +167,9 @@ spec:
         - "-group=/layers/group.toml"
         - "-cache-dir=/cache"
         - "-process-type=$(params.PROCESS_TYPE)"
+        - "-uid=$(params.USER_ID)"
+        - "-gid=$(params.GROUP_ID)"
+        - "-stack=/layers/stack.toml"
         - "$(resources.outputs.image.url)"
       volumeMounts:
         - name: layers-dir

--- a/task/buildpacks-phases/0.1/buildpacks-phases.yaml
+++ b/task/buildpacks-phases/0.1/buildpacks-phases.yaml
@@ -42,9 +42,6 @@ spec:
     - name: SOURCE_SUBPATH
       description: A subpath within the `source` input where the source to build is located.
       default: ""
-    - name: HOME_OVERRIDE
-      description: Override the home directory during detect and build to hide secrets from buildpacks.
-      default: empty-dir
 
   resources:
     outputs:
@@ -104,7 +101,7 @@ spec:
           mountPath: /layers
         - name: $(params.PLATFORM_DIR)
           mountPath: /platform
-        - name: $(params.HOME_OVERRIDE)
+        - name: empty-dir
           mountPath: /tekton/home
 
     - name: analyze
@@ -154,7 +151,7 @@ spec:
           mountPath: /layers
         - name: $(params.PLATFORM_DIR)
           mountPath: /platform
-        - name: $(params.HOME_OVERRIDE)
+        - name: empty-dir
           mountPath: /tekton/home
 
     - name: export

--- a/task/buildpacks-phases/0.1/buildpacks-phases.yaml
+++ b/task/buildpacks-phases/0.1/buildpacks-phases.yaml
@@ -57,6 +57,7 @@ spec:
         value: "0.3"
 
   steps:
+    # Ensure the builder's user has read/write permissions for needed directories.
     - name: prepare
       image: alpine
       imagePullPolicy: Always
@@ -76,6 +77,7 @@ spec:
       securityContext:
         privileged: true
 
+    # Copy stack.toml so that it will be accessible to the exporter, since the lifecycle image will not contain it.
     - name: copy-stack-toml
       image: $(params.BUILDER_IMAGE)
       imagePullPolicy: Always


### PR DESCRIPTION
- Override /tekton/home for the detect and build phases of the lifecycle to hide registry credentials from buildpack code.
- Run analyze, restore, and export in the lifecycle image published by buildpacksio to hide registry credentials from untrusted builders.

Signed-off-by: Natalie Arellano <narellano@vmware.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [x] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
