### PR TITLE
Parameterize maven task image

### DIFF
--- a/task/maven/0.1/README.md
+++ b/task/maven/0.1/README.md
@@ -10,6 +10,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 
 ## Parameters
 
+- **MAVEN_IMAGE**: The base image for maven (_default_:`gcr.io/cloud-builders/mvn`)
 - **GOALS**: Maven `goals` to be executed
 - **MAVEN_MIRROR_URL**: Maven mirror url (to be inserted into ~/.m2/settings.xml)   
 - **PROXY_USER**: Username to login to the proxy server (to be inserted into ~/.m2/settings.xml)

--- a/task/maven/0.1/maven.yaml
+++ b/task/maven/0.1/maven.yaml
@@ -15,6 +15,10 @@ spec:
     - name: source
     - name: maven-settings
   params:
+    - name: MAVEN_IMAGE
+      type: string
+      description: Maven base image
+      default: gcr.io/cloud-builders/mvn
     - name: GOALS
       description: maven goals to run
       type: array
@@ -106,7 +110,7 @@ spec:
         [[ -f $(workspaces.maven-settings.path)/settings.xml ]] || echo skipping settings
 
     - name: mvn-goals
-      image: gcr.io/cloud-builders/mvn
+      image: $(params.MAVEN_IMAGE)
       workingDir: $(workspaces.source.path)
       command: ["/usr/bin/mvn"]
       args:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Added param for the image in maven task so that
user can use specific maven version

Signed-off-by: Divyansh42 <diagrawa@redhat.com>
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [ ] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
