### PR TITLE
Centralize all the git-clone apply task to a common function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,12 @@ some environment variables to it that would be applied :
 1. **pre-apply-task-hook.sh**: Script to run before applying the task
 2. **pre-apply-taskrun-hook.sh**: Script to run before applying the taskruns or other yaml files.
 
+We have some helper functions you can use from your `hook` scripts :
+
+* **add_sidecar_registry**: This will add a registry as a sidecar to allow the builder tasks to upload image directly to this sidecar registry instead of having to rely on external registries.
+* **add_git_clone_task**: This will add the git clone task to your temporary namespace.
+
+
 What can you run from those scripts is whatever defined in the test-runner
 image, if you need to have another binary available feel free to make a PR to this Dockerfile :
 

--- a/task/buildah/0.1/tests/pre-apply-task-hook.sh
+++ b/task/buildah/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/buildpacks-phases/0.1/tests/pre-apply-task-hook.sh
+++ b/task/buildpacks-phases/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/buildpacks/0.1/tests/pre-apply-task-hook.sh
+++ b/task/buildpacks/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/golang-build/0.1/tests/pre-apply-task-hook.sh
+++ b/task/golang-build/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/golang-test/0.1/tests/pre-apply-task-hook.sh
+++ b/task/golang-test/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/golangci-lint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/golangci-lint/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/helm-upgrade-from-repo/0.1/tests/pre-apply-task-hook.sh
+++ b/task/helm-upgrade-from-repo/0.1/tests/pre-apply-task-hook.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task
 
 # Add service account
 kubectl -n ${tns} create serviceaccount helm-pipeline-run-sa -o yaml --dry-run=client | kubectl apply -f -

--- a/task/helm-upgrade-from-source/0.1/tests/pre-apply-task-hook.sh
+++ b/task/helm-upgrade-from-source/0.1/tests/pre-apply-task-hook.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task
 
 # Add service account
 kubectl -n ${tns} create serviceaccount helm-pipeline-run-sa -o yaml --dry-run=client | kubectl apply -f -

--- a/task/jib-gradle/0.1/tests/pre-apply-task-hook.sh
+++ b/task/jib-gradle/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/jib-maven/0.1/tests/pre-apply-task-hook.sh
+++ b/task/jib-maven/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/kaniko/0.1/tests/pre-apply-task-hook.sh
+++ b/task/kaniko/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/maven/0.1/tests/pre-apply-task-hook.sh
+++ b/task/maven/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/prettier/0.1/tests/pre-apply-task-hook.sh
+++ b/task/prettier/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/pylint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/pylint/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/pytest/0.1/tests/pre-apply-task-hook.sh
+++ b/task/pytest/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/replace-tokens/0.1/tests/pre-apply-task-hook.sh
+++ b/task/replace-tokens/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/task/s2i/0.1/tests/pre-apply-task-hook.sh
+++ b/task/s2i/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_git_clone_task

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -32,6 +32,11 @@ function add_sidecar_registry() {
     rm -f ${TMPF}.read
 }
 
+# Add the git_clone task
+function add_git_clone_task() {
+    kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+}
+
 function install_pipeline_crd() {
   local latestreleaseyaml
   echo ">> Deploying Tekton Pipelines"


### PR DESCRIPTION
Centralize all the the git-clone apply commands we had around the
pre-apply-task-hook to a central common function.

This will make easier to have the same git-clone task version used everywhere.

Add some documentation about the helper functions along the way.



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [ ] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413