### PR TITLE
Fix kythe-go task on restricted environment

### DIFF
--- a/task/kythe-go/0.1/kythe-go.yaml
+++ b/task/kythe-go/0.1/kythe-go.yaml
@@ -29,3 +29,5 @@ spec:
         - name: OUTPUT
           value: $(workspaces.output.path)
       args: ["$(params.package)"]
+      securityContext:
+        privileged: true

--- a/task/kythe-go/0.1/tests/run.yaml
+++ b/task/kythe-go/0.1/tests/run.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
-  name: kythe-go
+  name: kythe-go-run
 spec:
   workspaces:
     - name: output


### PR DESCRIPTION
This will fix the task to run on restricted environments
as this task do some chown operations and fails on
environments like opneshift

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [ ] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
