### PR TITLE
Fixes and improvements to the upload-pypi Task.

### DIFF
--- a/task/upload-pypi/0.1/README.md
+++ b/task/upload-pypi/0.1/README.md
@@ -49,3 +49,23 @@ spec:
 ```
 
 In this example, the Git repo being used is expected to have a `setup.py` file at the root of the repository. [setup.py](https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py) is build script for [setuptools](https://pypi.org/project/setuptools/)
+
+This TaskRun outputs several `Results`:
+
+- A `sha256` hash for each uploaded file (the bdist and the sdist packages).
+- The name of the uploaded package
+- The version of the uploaded package
+
+This looks like:
+
+```
+  taskResults:
+  - name: bdist_sha
+    value: 97dd35b7097443b6896734d979a1a52c64023f17474e4027d69d2df0b9acb797  dist/foo.whl
+  - name: package_name
+    value: foo
+  - name: package_version
+    value: 2.24.4
+  - name: sdist_sha
+    value: 8fda69bc68ece690d135d0091ebdd10a8c15db477c2eafce0d0a65bc9712f5bf  dist/foo.tar.gz
+```

--- a/task/upload-pypi/0.1/samples/run.yaml
+++ b/task/upload-pypi/0.1/samples/run.yaml
@@ -54,6 +54,10 @@ kind: PipelineRun
 metadata:
   name: publish-package-pipeline-run
 spec:
+  podTemplate:
+    securityContext:
+      runAsNonRoot: false
+      runAsUser: 0
   pipelineRef:
     name: publish-package-pipeline
   workspaces:

--- a/task/upload-pypi/0.1/upload-pypi.yaml
+++ b/task/upload-pypi/0.1/upload-pypi.yaml
@@ -49,4 +49,20 @@ spec:
           name: pypi-secret
           key: password
     script: |
-      twine upload dist/*
+      twine upload --disable-progress-bar dist/*
+      # Now write out all our results, stripping newlines.
+      # sdist files are .tar.gz's
+      sha256sum dist/*.tar.gz | tr -d '\n' | tee $(results.sdist_sha.path)
+      # bdist files are .whls's
+      sha256sum dist/*.whl | tr -d '\n' | tee $(results.bdist_sha.path)
+      python setup.py --name | tr -d '\n' | tee $(results.package_name.path)
+      python setup.py --version | tr -d '\n' | tee $(results.package_version.path)
+  results:
+  - name: sdist_sha
+    description: sha256 (and filename) of the sdist package
+  - name: bdist_sha
+    description: sha256 (and filename) of the bdist package
+  - name: package_name
+    description: name of the uploaded package
+  - name: package_version
+    description: version of the uploaded package


### PR DESCRIPTION
# Changes

I added support for TaskRunResults for this task. This change adds four results:
- the sha256 hash of the bdist package and the sdist package.
- the package name
- the package version

I also fixed a permission issue in the sample - I could not get this to run as a non-root
user (even without my change). The git repo is cloned correctly, but the default user of the
twine image does not have write permissions in this directory.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [X] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
