### PR TITLE
Fix pytest and pylint task

### DIFF
--- a/task/pylint/0.1/pylint.yaml
+++ b/task/pylint/0.1/pylint.yaml
@@ -39,6 +39,7 @@ spec:
       image: docker.io/python:$(inputs.params.PYTHON)
       workingDir: /workspace/source
       script: |
-          pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
-          pip show pylint || echo "###\nWarning: Pylint is missing in your requirements\n###" && pip install pylint
-          pylint $(inputs.params.ARGS) $(inputs.params.MODULE_PATH)
+        export PATH=$PATH:$HOME/.local/bin
+        pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
+        pip show pylint || echo "###\nWarning: Pylint is missing in your requirements\n###" && pip install pylint
+        pylint $(inputs.params.ARGS) $(inputs.params.MODULE_PATH)

--- a/task/pytest/0.1/pytest.yaml
+++ b/task/pytest/0.1/pytest.yaml
@@ -36,6 +36,7 @@ spec:
       image: docker.io/python:$(inputs.params.PYTHON)
       workingDir: /workspace/source
       script: |
-          pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
-          pip show pytest || echo "###\nWarning: Pytest is missing in your requirements\n###" && pip install pytest
-          pytest $(inputs.params.ARGS) $(inputs.params.SOURCE-PATH)
+        export PATH=$PATH:$HOME/.local/bin
+        pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
+        pip show pytest || echo "###\nWarning: Pytest is missing in your requirements\n###" && pip install pytest
+        pytest $(inputs.params.ARGS) $(inputs.params.SOURCE-PATH)


### PR DESCRIPTION
This will the fix the pytest and pylint task
which fails if run as non root user
in case of non-root user, it install at
location which is not in PATH of image
so adding the required PATH fix the issue

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [ ] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
