### PR TITLE
Refactor namespace name to have version

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -98,7 +98,13 @@ function test_task_creation() {
         local runtestdir=${runtest#*/}
         # remove /0.1/tests from end
         local testname=${runtestdir%%/*}
-        local tns="${testname}-$$"
+        # get version of the task
+        local version=$(basename $(basename $(dirname $runtest)))
+        # check version is in given format
+        [[ ${version} =~ ^[0-9]+\.[0-9]+$ ]] || { echo "ERROR: version of the task is not set properly"; exit 1;}
+        # replace . with - in version as not supported in namespace name
+        version="$( echo $version | tr '.' '-' )"
+        local tns="${testname}-${version}"
         local skipit=
         local maxloop=60 # 10 minutes max
 


### PR DESCRIPTION
This will refactor the namespace name to have version of task
in namespace name as current logic may create issue in case
of multiple versions running in same namespace as pid will
remain same

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [ ] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
