### PR TITLE
Add task to include code coverage for Python

### DIFF
--- a/task/python-coverage/0.1/README.md
+++ b/task/python-coverage/0.1/README.md
@@ -1,0 +1,47 @@
+# Python Coverage
+
+The task provides code coverage based on [coverage](https://coverage.readthedocs.io/en/coverage-5.2.1/) for Python. The used images are based on the official Docker Hub [Python images](https://hub.docker.com/_/python). The installation of the packages is performed via a `pip install`.
+
+**It is required that `pytest` and `coverage` is part of the requirements file for the task. If the module is not included a warning will be printed.**
+
+## Install the Task
+
+### Workspaces
+
+- **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the python code.
+
+### Install pytest
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/python-coverage/0.1/python-coverage.yaml
+```
+
+## Parameters
+
+- **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `3.8`)
+- **ARGS**: The additional arguments to be used with pytest
+- **SOURCE_PATH**: The path to the source code (_default_: `.`)
+- **REQUIREMENTS_FILE**: The name of the requirements file inside the source location (_default_: `requirements.txt`)
+
+## Usage
+
+This `TaskRun` runs `pytest` and `coverage` on a repository.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: python-coverage-run
+spec:
+  taskRef:
+    name: python-coverage
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: PYTHON
+      value: "3.7"
+    - name: ARGS
+      value: "-rfs"
+```

--- a/task/python-coverage/0.1/python-coverage.yaml
+++ b/task/python-coverage/0.1/python-coverage.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: python-coverage
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: python, coverage
+    tekton.dev/displayName: python coverage
+
+spec:
+  description: >-
+    This task can be used to measure code coverage of Python projects.
+
+  workspaces:
+    - name: source
+  params:
+    - name: PYTHON
+      description: The used Python version, more precisely the tag for the Python image
+      type: string
+      default: "3.8"
+    - name: ARGS
+      description: The additional arguments to be used with pytest
+      type: string
+      default: ""
+    - name: SOURCE_PATH
+      description: The path to the source code
+      default: "."
+    - name: REQUIREMENTS_FILE
+      description: The name of the requirements file inside the source location
+      default: "requirements.txt"
+  steps:
+    - name: code-coverage
+      image: docker.io/python:$(inputs.params.PYTHON)
+      workingDir: $(workspaces.source.path)
+      script: |
+        export PATH=$PATH:$HOME/.local/bin
+        pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
+        pip show pytest || (echo "###\nWarning: Pytest is missing in your requirements\n###" && pip install pytest)
+        pip show coverage || (echo "###\nWarning: Coverage is missing in your requirements\n###" && pip install coverage)
+        coverage run -m pytest $(inputs.params.ARGS) $(inputs.params.SOURCE-PATH)
+        coverage report -m

--- a/task/python-coverage/0.1/tests/pre-apply-task-hook.sh
+++ b/task/python-coverage/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+add_git_clone_task

--- a/task/python-coverage/0.1/tests/resources.yaml
+++ b/task/python-coverage/0.1/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: python-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/task/python-coverage/0.1/tests/run.yaml
+++ b/task/python-coverage/0.1/tests/run.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: python-coverage-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/wumaxd/pylint-pytest-example.git
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+
+    - name: python-coverage
+      taskRef:
+        name: python-coverage
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: PYTHON
+          value: "3.7"
+        - name: ARGS
+          value: "-rfs"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: python-coverage-pipeline-run
+spec:
+  pipelineRef:
+    name: python-coverage-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: python-source-pvc


### PR DESCRIPTION
# Changes

The following task uses `coverage` dependency in python to measure code coverage of Python projects. This task works along with the pytest so that coverage can be calculated properly.

Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [X] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
