### PR TITLE
Fixes for python coverage and pytest and added OWNERS

### DIFF
--- a/task/pylint/0.1/README.md
+++ b/task/pylint/0.1/README.md
@@ -18,7 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 
 ## Parameters
 
-* **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `3.6`)
+* **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `latest`)
 * **SOURCE_PATH**: The path to the source code (_default_: `.`)
 * **MODULE_PATH**: The path to the module which should be analysed by pylint (_default_: `.`)
 * **ARGS**: The additional arguments to be used with pylint

--- a/task/pylint/0.1/pylint.yaml
+++ b/task/pylint/0.1/pylint.yaml
@@ -20,7 +20,7 @@ spec:
     - name: PYTHON
       description: The used Python version, more precisely the tag for the Python image
       type: string
-      default: "3.6"
+      default: "latest"
     - name: SOURCE_PATH
       description: The path to the source code
       default: "."

--- a/task/pylint/OWNERS
+++ b/task/pylint/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- wumaxd
+- vinamra28
+
+reviewers:
+- wumaxd
+- vinamra28

--- a/task/pytest/0.1/README.md
+++ b/task/pytest/0.1/README.md
@@ -18,7 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 
 ## Parameters
 
-* **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `3.6`)
+* **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `latest`)
 * **ARGS**: The additional arguments to be used with pytest
 * **SOURCE_PATH**: The path to the source code (_default_: `.`)
 * **REQUIREMENTS_FILE**: The name of the requirements file inside the source location (_default_: `requirements.txt`)

--- a/task/pytest/0.1/pytest.yaml
+++ b/task/pytest/0.1/pytest.yaml
@@ -20,7 +20,7 @@ spec:
     - name: PYTHON
       description: The used Python version, more precisely the tag for the Python image
       type: string
-      default: "3.6"
+      default: "latest"
     - name: ARGS
       description: The additional arguments to be used with pytest
       type: string
@@ -34,9 +34,16 @@ spec:
   steps:
     - name: unit-test
       image: docker.io/python:$(inputs.params.PYTHON)
-      workingDir: /workspace/source
+      workingDir: $(workspaces.source.path)
       script: |
         export PATH=$PATH:$HOME/.local/bin
-        pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
-        pip show pytest || echo "###\nWarning: Pytest is missing in your requirements\n###" && pip install pytest
-        pytest $(inputs.params.ARGS) $(inputs.params.SOURCE-PATH)
+        if [ -n "$(inputs.params.REQUIREMENTS_FILE)" ] && [ -e "$(inputs.params.REQUIREMENTS_FILE)" ];then
+          pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
+          pip show pytest || {
+            echo "###\nWarning: Pytest is missing in your requirements\n###";
+            pip install pytest
+          }
+        else
+          pip install pytest
+        fi
+        pytest $(inputs.params.ARGS) $(inputs.params.SOURCE_PATH)

--- a/task/pytest/OWNERS
+++ b/task/pytest/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- wumaxd
+- vinamra28
+
+reviewers:
+- wumaxd
+- vinamra28

--- a/task/python-coverage/0.1/README.md
+++ b/task/python-coverage/0.1/README.md
@@ -18,7 +18,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 
 ## Parameters
 
-- **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `3.8`)
+- **PYTHON**: The used Python version, more precisely the tag for the Python image (_default_: `latest`)
 - **ARGS**: The additional arguments to be used with pytest
 - **SOURCE_PATH**: The path to the source code (_default_: `.`)
 - **REQUIREMENTS_FILE**: The name of the requirements file inside the source location (_default_: `requirements.txt`)

--- a/task/python-coverage/0.1/python-coverage.yaml
+++ b/task/python-coverage/0.1/python-coverage.yaml
@@ -20,7 +20,7 @@ spec:
     - name: PYTHON
       description: The used Python version, more precisely the tag for the Python image
       type: string
-      default: "3.8"
+      default: "latest"
     - name: ARGS
       description: The additional arguments to be used with pytest
       type: string
@@ -37,8 +37,18 @@ spec:
       workingDir: $(workspaces.source.path)
       script: |
         export PATH=$PATH:$HOME/.local/bin
-        pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
-        pip show pytest || (echo "###\nWarning: Pytest is missing in your requirements\n###" && pip install pytest)
-        pip show coverage || (echo "###\nWarning: Coverage is missing in your requirements\n###" && pip install coverage)
-        coverage run -m pytest $(inputs.params.ARGS) $(inputs.params.SOURCE-PATH)
+        if [ -n "$(inputs.params.REQUIREMENTS_FILE)" ] && [ -e "$(inputs.params.REQUIREMENTS_FILE)" ];then
+          pip install -r $(inputs.params.SOURCE_PATH)/$(inputs.params.REQUIREMENTS_FILE)
+          pip show pytest || {
+            echo "###\nWarning: Pytest is missing in your requirements\n###";
+            pip install pytest
+          }
+          pip show coverage || {
+            echo "###\nWarning: Coverage is missing in your requirements\n###";
+            pip install coverage
+          }
+        else
+          pip install pytest coverage
+        fi
+        coverage run -m pytest $(inputs.params.ARGS) $(inputs.params.SOURCE_PATH)
         coverage report -m

--- a/task/python-coverage/OWNERS
+++ b/task/python-coverage/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- wumaxd
+- vinamra28
+
+reviewers:
+- wumaxd
+- vinamra28


### PR DESCRIPTION
# Changes

* Only install the requirements when the file is here and fix workspace -- following #459 
* Add OWNERS file
* Use latest tag for the python images as default

Now the default value for the python version is latest. This removes the burden to update to the newest python version.
I added myself also to the OWNERS file to drive the development of the tasks. Further, for the tests currently one of my repos is used and I wanted to be updated if there are issues. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [x] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413

Signed-off-by: wumaxd <wurzer.maxi@gmx.de>