### PR TITLE
Add Tasks to install Tekton Pipelines itself 🤯

### DIFF
--- a/task/gke-add-cluster-admin/0.1/gke-add-cluster-admin.yaml
+++ b/task/gke-add-cluster-admin/0.1/gke-add-cluster-admin.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gke-add-cluster-admin
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "gke"
+    tekton.dev/displayName: "GKE Add Cluster Admin"
+spec:
+  description: |
+    Create a cluster admin user in a GKE cluster.
+
+    This Task will authenticate with a GKE cluster using gcloud and then create a new
+    user in the cluster with cluster admin priviledges.
+    The service account provided via gcp-service-account must have `container.clusterRoleBindings.create`
+    permissions in the target GKE project that the cluster lives in.
+
+  params:
+  - name: private-key-path
+    description: The path to the private key within the gcp-service-account workspace.
+  - name: new-username
+    description: The name to use for the new user
+    default: cluster-admin
+  workspaces:
+  - name: gcp-service-account
+    description: |
+      A Secret or volume containing the private key of a GCP service account that can access the GKE cluster
+      in the kubeconfig, is able to create users in the cluster and can grant cluster-admin permissions.
+      gcloud auth will be initialized with this service account.
+  - name: kubeconfig
+    description: |
+      A workspace into which a kubeconfig file called `kubeconfig` has been written that contains the information
+      required to access the cluster. The kubeconfig will be used in a container that has gcloud installed and
+      so supports using gcloud to authenticate.
+
+      The new user's token information will be added to the kubeconfig and the user for the current context will be
+      set to this user.
+  steps:
+  - name: create-user
+    image: google/cloud-sdk@sha256:12fada1b09cde6aaaab8a8638923d98f87ac3f3fb9b2c9a7872c45d14e3439e2
+    script: |
+      # Configure gcloud to use the provided service account
+      gcloud auth activate-service-account --key-file=$(workspaces.gcp-service-account.path)/$(params.private-key-path)
+
+      # Create the new user
+      export KUBECONFIG=$(workspaces.kubeconfig.path)/kubeconfig
+      kubectl -n kube-system create serviceaccount $(params.new-username)
+
+      # Give the new user cluster-admin priviledges
+      kubectl create clusterrolebinding $(params.new-username)-binding \
+        --clusterrole=cluster-admin \
+        --serviceaccount=kube-system:$(params.new-username)
+
+      # Get the user's auth token
+      TOKENNAME=`kubectl -n kube-system get serviceaccount/$(params.new-username) -o jsonpath='{.secrets[0].name}'`
+      TOKEN=`kubectl -n kube-system get secret $TOKENNAME -o jsonpath='{.data.token}'| base64 --decode`
+
+      # Add the new user's token to the kubeconfig file and update update the current context to use it
+      kubectl config set-credentials $(params.new-username) --token=$TOKEN
+      kubectl config set-context --current --user=$(params.new-username)
+
+      kubectl get pod

--- a/task/gke-add-cluster-admin/0.1/samples/install.yaml
+++ b/task/gke-add-cluster-admin/0.1/samples/install.yaml
@@ -1,0 +1,1 @@
+task/tekton-pipelines-install/0.1/samples/install.yaml

--- a/task/gke-add-cluster-admin/OWNERS
+++ b/task/gke-add-cluster-admin/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- bobcatfish

--- a/task/gke-add-cluster-admin/README.md
+++ b/task/gke-add-cluster-admin/README.md
@@ -1,0 +1,37 @@
+# GKE Add Cluster Admin
+
+The Task `gke-add-cluster-admin` can be used to create a user with cluster admin priviledges
+in an existing GKE cluster.
+
+This Task will authenticate with a GKE cluster using gcloud and then create a new
+user in the cluster with cluster admin priviledges.
+
+_The service account provided via gcp-service-account must have `container.clusterRoleBindings.create`
+permissions in the target GKE project that the cluster lives in._
+
+## ServiceAccount
+
+This Task will use the service account provided via the `gcp-service-account` workspace and will
+not use the permissions of the TaskRun's ServiceAccount.
+
+## Parameters
+
+* **private-key-path**: The path to the private key within the gcp-service-account workspace. (_required_)
+* **new-username**: The name to give the new users. (_default_: cluster-admin)
+
+## Workspaces
+
+* **gcp-service-account**: A Secret or volume containing the private key of a GCP service account that can
+  access the GKE cluster in the kubeconfig, is able to create users in the cluster and can grant
+  cluster-admin permissions. gcloud auth will be initialized with this service account.
+* **kubeconfig**: A workspace into which a kubeconfig file called `kubeconfig` has been written that contains
+  the information required to access the cluster. The kubeconfig will be used in a container that has gcloud
+  installed and so supports using gcloud to authenticate. The new user's token information will be added to
+  tphe kubeconfig and the user for the current context will be set to this user.
+
+## Usage
+
+See [samples/install.yaml](samples/install.yaml) for an example of a Pipeline that uses
+[boskos-acquire](../../boskos-acquire) to obtain a project using Boskos, creates a new cluster using
+[gke-cluster-create](../../gke-cluster-create), uses this Task to create a cluster admin users and then
+with that user, installs Tekton Pipelines with [tekton-pipelines-install](../../tekton-pipelines-install).

--- a/task/gke-cluster-create/0.1/README.md
+++ b/task/gke-cluster-create/0.1/README.md
@@ -8,6 +8,11 @@ The cluster created will have a firewall applied such that the only traffic allo
 in the cluster will be SSH, TCP services running on 80 or 8080, and services exposed via the
 NodePort default range (https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
 
+## ServiceAccount
+
+This Task will use the service account provided via the `gcp-service-account` workspace and will
+not use the permissions of the TaskRun's ServiceAccount.
+
 ## Parameters
 
 * **project-name**: The name of the GCP project in which to create the GKE cluster. (_required_)

--- a/task/gke-cluster-create/0.1/gke-cluster-create.yaml
+++ b/task/gke-cluster-create/0.1/gke-cluster-create.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "gke,test"
+    tekton.dev/tags: "gke"
     tekton.dev/displayName: "GKE Cluster Create"
 spec:
   description: |

--- a/task/gke-cluster-create/OWNERS
+++ b/task/gke-cluster-create/OWNERS
@@ -1,5 +1,2 @@
 approvers:
 - bobcatfish
-
-reviewers:
-- bobcatfish

--- a/task/tekton-pipelines-install/0.1/README.md
+++ b/task/tekton-pipelines-install/0.1/README.md
@@ -1,0 +1,24 @@
+# Tekton Pipelines Install
+
+The Task `tekton-pipelines-install` can be used to install Tekton Pipelines (very meta!).
+
+If you are looking to manage an installation of Tekton Pipelines, you probably want to use
+https://github.com/tektoncd/operator instead. This Task can be used to apply a specified
+release of Tekton to an existing cluster, for example for testing.
+
+## Parameters
+
+* **pipelines-version**: The version of Tekton Pipelines to install. Expected format `v.0.0`. (_required_)
+
+## Workspaces
+
+* **kubeconfig**: A workspace into which a kubeconfig file called `kubeconfig` has been written that contains
+  the information required to access the cluster. The current context configured in this file should refer to
+  a user that has permission to install the Tekton Pipelines components.
+
+## Usage
+
+See [samples/install.yaml](samples/install.yaml) for an example of a Pipeline that uses
+[boskos-acquire](../../boskos-acquire) to obtain a project using Boskos, creates a new cluster using
+[gke-cluster-create](../../gke-cluster-create), uses [gke-add-cluster-admin](../../gke-cluster-admin)
+to create a cluster admin users and then with that user, installs Tekton Pipelines with this Task.

--- a/task/tekton-pipelines-install/0.1/samples/install.yaml
+++ b/task/tekton-pipelines-install/0.1/samples/install.yaml
@@ -1,0 +1,86 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pipelines-install-
+spec:
+  # This service account exists in the tekton-releases prow cluster
+  serviceAccountName: boskos-heartbeat
+  workspaces:
+  - name: kubeconfig
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5M
+  - name: test-account-secret
+    secret:
+      # This secret exists in the tekton-releases prow cluster
+      secretName: test-account
+  pipelineSpec:
+    params:
+    - name: owner-name
+      default: pipelines-install-
+    workspaces:
+    - name: kubeconfig
+    - name: test-account-secret
+    tasks:
+    - name: boskos-acquire
+      taskRef:
+        name: boskos-acquire
+      params:
+        - name: owner-name
+          value: $(params.owner-name)
+    - name: create-cluster
+      taskRef:
+        name: gke-cluster-create
+      params:
+      - name: project-name
+        value: $(tasks.boskos-acquire.results.leased-resource)
+      - name: private-key-path
+        value: service-account.json
+      - name: identifier
+        value: create-and-add-test
+      workspaces:
+      - name: gcp-service-account
+        workspace: test-account-secret
+      - name: kubeconfig
+        workspace: kubeconfig
+    - name: add-cluster-admin
+      # TODO(pipeline#1878): actually a dependency on the kubeconfig workspace
+      runAfter: [create-cluster]
+      taskRef:
+        name: gke-add-cluster-admin
+      params:
+      - name: new-username
+        value: cluster-admin-user
+      - name: private-key-path
+        value: service-account.json
+      workspaces:
+      - name: gcp-service-account
+        workspace: test-account-secret
+      - name: kubeconfig
+        workspace: kubeconfig
+    - name: install
+      # TODO(pipeline#1878): actually a dependency on the kubeconfig workspace
+      runAfter: [add-cluster-admin]
+      taskRef:
+        name: tekton-pipelines-install
+      params:
+      - name: pipelines-version
+        value: v0.12.0
+      workspaces:
+      - name: kubeconfig
+        workspace: kubeconfig
+    - name: boskos-release
+      runAfter: [install]
+      taskRef:
+        name: boskos-release
+      params:
+      - name: leased-resource
+        # TODO(pipeline#2557): This is a good candidate for a finally clause: without it
+        # you'll need to manually delete the heatbeat pod if the pipeline fails
+        value: $(tasks.boskos-acquire.results.leased-resource)
+      - name: owner-name
+        value: $(params.owner-name)

--- a/task/tekton-pipelines-install/0.1/tekton-pipelines-install.yaml
+++ b/task/tekton-pipelines-install/0.1/tekton-pipelines-install.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: tekton-pipelines-install
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "tekton,test"
+    tekton.dev/displayName: "Tekton Pipelines Install"
+spec:
+  description: |
+    Install the specified version of Tekton Pipelines.
+
+    If you are looking to manage an installation of Tekton Pipelines, you probably want
+    to use https://github.com/tektoncd/operator instead. This Task can be used to apply
+    a specified release of Tekton to an existing cluster, for example for testing.
+  params:
+  - name: pipelines-version
+    description: The version of Tekton Pipelines to install. Expected format `v.0.0`.
+  workspaces:
+  - name: kubeconfig
+    description: |
+      A workspace into which a kubeconfig file called `kubeconfig` has been written that contains a default
+      context configured to have cluster admin priviledges on the cluster.
+  steps:
+  - name: apply-config
+    image: lachlanevenson/k8s-kubectl@sha256:3a5e22a406a109f4f26ec06b5f1f6a66ae0cd0e185bc28499eb7b7a3bbf1fe09
+    args:
+    - "--kubeconfig"
+    - "$(workspaces.kubeconfig.path)/kubeconfig"
+    - "apply"
+    - "--filename"
+    - "https://storage.googleapis.com/tekton-releases/pipeline/previous/$(params.pipelines-version)/release.yaml"

--- a/task/tekton-pipelines-install/OWNERS
+++ b/task/tekton-pipelines-install/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- bobcatfish


### PR DESCRIPTION
# Changes

As part of #373 I'm continuing to create Tasks that we can use to run
tests for items in the catalog.

The goal of the 2 Tasks in this commit is to install Tekton Pipelines into a
cluster that was created using the Task added in #436.

There are a couple of options different from what I did in this commit
which I'd like people's opinions on:
1. I went to a lot of trouble to make it so that Pipelines can be
   installed with just a kubectl command, specifically creating a user
   with cluster admin priviledges. If instead I used a container with
   gcloud, I could use the same approach as other GKE specific Tasks,
   but I wanted to make the install Task not tied to GKE. I also had
   to give the prow-account more priviledges in all of our boskos
   projects for this to work 😬 . So my question is: is this worth
   it, or am I better off just creating a GKE specific Task for
   installing Tekton Pipelines that uses gcloud to auth?
2. If we DO want a super generic Task, how useful is this Task that just
   applies a Tekton yaml? Would we be better off with a generic kubectl
   task that I could feed the exact arguments for installing Tekton
   Pipelines?

The other confusion I ran into here (which I am going to follow up with
@sbwsg about!) is around service accounts vs. secrets. The GKE Tasks
I've made so far rely on secrets provided via workspaces, but I feel
like it's not clear if it makes sense to go that route, or to rely on
service accounts. In the meantime this approach is at least consistent
with #436.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [x] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
