### PR TITLE
Remove "lint" checklist item 📝

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,6 @@ review them:
 
 - [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
 - [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
-- [ ] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
 - [ ] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
   - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
   - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`


### PR DESCRIPTION
# Changes


To make sure the checklist is useful and folks don't ignore it, I think
it's important to keep only the items we need to in there.

If we can enforce something with CI, I suggest we do not include it in
the checklist - if we want to write down guidance somewhere else I think
that totally makes sense, but not in the checklist.

From https://github.com/tektoncd/catalog/issues/387 it looks like
linting should be applied automatically to each PR so I don't think we
need to include this checklist item.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Yaml file complies with [yamllint](https://github.com/adrienverge/yamllint) rules.
- [n/a] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
