### PR TITLE
fix: git-batch-merge should default to depth=0 and subdirectory=""

### DIFF
--- a/task/git-batch-merge/0.2/README.md
+++ b/task/git-batch-merge/0.2/README.md
@@ -1,0 +1,49 @@
+# Git Task
+
+This `Task` is Git task to work with repositories used by other tasks
+in your Pipeline.
+
+## `git-batch-merge`
+
+This task takes a set of refspecs, fetches them and performs git operations
+(cherry-pick or merge) to apply them in order on the given base revision (default master).
+The resulting commit SHA will not match across taskruns, but the git tree SHA should
+match. This can be useful for batch testing changes, for example, when you want to
+batch up your PRs into a single merge by taking the HEAD of the branch you want to merge
+to, and adding all the PRs to it. This concept is used in tools such as [Tide][tide] to
+batch test PR's, and [Zuul CI Gating][zuul-ci], to perform speculative execution of
+PR's/change requests individually
+
+This `Task` has four required inputs:
+
+1. The URL of a git repo to clone provided with the `url` param.
+1. A space separated string of refs `BatchedRefs` to fetch and batch over the given `revision`
+1. Merge `mode` to use while batching (merge, merge-resolve, merge-squash, cherry-pick)
+1. A Workspace called `output`.
+
+There are 4 additional parameters in addition to the ones mentioned above for the git-clone task:
+* **batchedRefs**: space separated git [refnames][git-ref] to fetch and batch on top of revision using the given mode
+    (must be a valid refs, no commit SHA's).
+* **mode**: Batch mode to select (_default_: merge) <br>
+  &nbsp;&nbsp;`merge`: corresponds to git merge -s recursive. This is the default mode used by github <br>
+  &nbsp;&nbsp;`cherry-pick`: corresponds to git cherry-pick <br>
+  See [git-merge][git-merge] and [git-cherry-pick][git-cherry-pick]
+* **gitUserName**: git user name to use for creating the batched commit (First Last)
+    (_default_: GitBatch Task). See [git-user-config][git-user-config]
+* **gitUserEmail**: git user email to use for creating the batched commit (First.Last@domain.com)
+  (_default_: GitBatch.Task@tekton.dev). See [git-user-config][git-user-config]
+
+### Results
+
+* **commit**: The precise commit SHA that was fetched by this Task
+* **tree**: The [git tree][git-tree] object SHA that was created after batch merging the refs on HEAD.
+
+### Usage
+
+[git-ref](https://git-scm.com/book/en/v2/Git-Internals-Git-References)
+[git-merge](https://git-scm.com/docs/git-merge)
+[git-cherry-pick](https://git-scm.com/docs/git-cherry-pick)
+[git-user-config](https://git-scm.com/docs/git-config#Documentation/git-config.txt-username)
+[git-tree](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects)
+[tide](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/README.md)
+[zuul-ci](https://zuul-ci.org/docs/zuul/discussion/gating.html)

--- a/task/git-batch-merge/0.2/git-batch-merge.yaml
+++ b/task/git-batch-merge/0.2/git-batch-merge.yaml
@@ -1,0 +1,139 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-batch-merge
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git batch merge"
+spec:
+  description: >-
+    This task takes a set of refspecs, fetches them and performs git operations
+    (cherry-pick or merge) to apply them in order on the given base revision (default master).
+
+    The resulting commit SHA will not match across taskruns, but the git tree SHA should
+    match. This can be useful for batch testing changes, for example, when you want to
+    batch up your PRs into a single merge by taking the HEAD of the branch you want to merge
+    to, and adding all the PRs to it. This concept is used in tools such as Tide to
+    batch test PR’s, and Zuul CI Gating, to perform speculative execution of
+    PR’s/change requests individually
+
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this workspace
+  params:
+    - name: url
+      description: git url to clone
+      type: string
+    - name: revision
+      description: base git revision to checkout (branch, tag, sha, ref…)
+      type: string
+      default: master
+    - name: refspec
+      description: base git refspec to fetch before checking out revision
+      type: string
+      default: "refs/heads/master:refs/heads/master"
+    - name: batchedRefs
+      description: git refs to fetch and batch on top of revision using the given mode (must be a valid refname, no commit SHA's)
+      type: string
+    - name: gitUserName
+      description: git user name to use for creating the batched commit (First Last)
+      type: string
+      default: GitBatch Task
+    - name: gitUserEmail
+      description: git user email to use for creating the batched commit (First.Last@domain.com)
+      type: string
+      default: GitBatch.Task@tekton.dev
+    - name: mode
+      description: git operation to perform while batching (choose from merge, cherry-pick)
+      type: string
+      default: merge
+    - name: submodules
+      description: defines if the resource should initialize and fetch the submodules
+      type: string
+      default: "true"
+    - name: depth
+      description: performs a shallow clone where only the most recent commit(s) will be fetched
+      type: string
+      default: "0"
+    - name: sslVerify
+      description: defines if http.sslVerify should be set to true or false in the global git config
+      type: string
+      default: "true"
+    - name: subdirectory
+      description: subdirectory inside the "output" workspace to clone the git repo into
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
+      type: string
+      default: "false"
+  results:
+    - name: commit
+      description: The final commit SHA that was obtained after batching all provided refs onto revision
+    - name: tree
+      description: The git tree SHA that was obtained after batching all provided refs onto revision.
+  steps:
+    - name: clone
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2
+      script: |
+        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+          # or the root of a mounted volume.
+          if [[ -d "$CHECKOUT_DIR" ]] ; then
+            # Delete non-hidden files and directories
+            rm -rf "$CHECKOUT_DIR"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "$CHECKOUT_DIR"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "$CHECKOUT_DIR"/..?*
+          fi
+        }
+
+        if [[ "$(params.deleteExisting)" == "true" ]] ; then
+          cleandir
+        fi
+
+        p="$(params.batchedRefs)"
+        refs="$(params.refspec)"
+        for ref in $p; do
+          refs="$refs $ref:refs/batch/$ref"
+        done
+
+        /ko-app/git-init \
+          -url "$(params.url)" \
+          -revision "$(params.revision)" \
+          -refspec "$refs" \
+          -path "$CHECKOUT_DIR" \
+          -sslVerify="$(params.sslVerify)" \
+          -submodules="$(params.submodules)" \
+          -depth "$(params.depth)"
+
+        git -C $CHECKOUT_DIR config user.name "$(params.gitUserName)"
+        git -C $CHECKOUT_DIR config user.email "$(params.gitUserEmail)"
+
+        mode="$(params.mode)"
+        if [[ $mode == "merge" ]]; then
+          for ref in $p; do
+             git -C $CHECKOUT_DIR merge --quiet --allow-unrelated-histories refs/batch/$ref
+          done
+        elif [[ $mode == "cherry-pick" ]]; then
+          for ref in $p; do
+             git -C $CHECKOUT_DIR cherry-pick --allow-empty --keep-redundant-commits refs/batch/$ref
+          done
+        else
+            echo "unsupported mode $mode"
+            exit 1
+        fi
+
+        RESULT_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD)"
+        TREE_SHA="$(git -C $CHECKOUT_DIR rev-parse HEAD^{tree})"
+        # Make sure we don't add a trailing newline to the result!
+        echo -n "$(echo $RESULT_SHA | tr -d '\n')" > $(results.commit.path)
+        echo -n "$(echo $TREE_SHA | tr -d '\n')" > $(results.tree.path)

--- a/task/git-batch-merge/0.2/samples/git-cli/pipeline.yaml
+++ b/task/git-batch-merge/0.2/samples/git-cli/pipeline.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: git-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: input
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/kelseyhightower/nocode
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: git-cli
+      taskRef:
+        name: git-cli
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: input
+          workspace: input
+      params:
+        - name: GIT_USER_NAME
+          value: git_username
+        - name: GIT_USER_EMAIL
+          value: git_email
+        - name: GIT_SCRIPT
+          value: |
+
+            cp $(workspaces.input.path)/* $(workspaces.source.path)
+            git add .
+            git commit -m 'Add sample file'
+            git push origin master
+  results:
+    - name: commit
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-pipeline-run
+spec:
+  serviceAccountName: git-service-account
+  pipelineRef:
+    name: git-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: source-pvc
+    - name: input
+      configmap:
+        name: files

--- a/task/git-batch-merge/0.2/samples/git-cli/pvc.yaml
+++ b/task/git-batch-merge/0.2/samples/git-cli/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: source-pvc
+spec:
+  resources:
+    requests:
+      storage: 500Mi
+  accessModes:
+    - ReadWriteOnce

--- a/task/git-batch-merge/0.2/samples/git-cli/secret.yaml
+++ b/task/git-batch-merge/0.2/samples/git-cli/secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-auth
+  annotations:
+    # Replace with the desired domain name.
+    tekton.dev/git-0: https://github.com
+type: kubernetes.io/basic-auth
+stringData:
+  username: git_username
+  # Access token should be provided here, if 2 factor authentication is enabled.
+  password: git_password

--- a/task/git-batch-merge/0.2/samples/git-cli/service-account.yaml
+++ b/task/git-batch-merge/0.2/samples/git-cli/service-account.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: git-service-account
+secrets:
+  - name: github-auth

--- a/task/git-batch-merge/0.2/samples/git-clone-checking-out-a-branch.yaml
+++ b/task/git-batch-merge/0.2/samples/git-clone-checking-out-a-branch.yaml
@@ -1,0 +1,86 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cat-branch-readme
+spec:
+  description: |
+    cat-branch-readme takes a git repository and a branch name and
+    prints the README.md file from that branch. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a branch
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: branch-name
+    type: string
+    description: The git branch to clone.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the repo's README.md file to be read.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.branch-name)
+  - name: cat-readme
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          cat $(workspaces.source.path)/README.md
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-checking-out-a-branch
+spec:
+  podTemplate:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: "tekton.dev/pipelineRun"
+              operator: In
+              values:
+              - git-clone-checking-out-a-branch
+          topologyKey: kubernetes.io/hostname
+  pipelineRef:
+    name: cat-branch-readme
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: branch-name
+    value: release-v0.12.x

--- a/task/git-batch-merge/0.2/samples/git-clone-checking-out-a-commit.yaml
+++ b/task/git-batch-merge/0.2/samples/git-clone-checking-out-a-commit.yaml
@@ -1,0 +1,87 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: checking-out-a-revision
+spec:
+  description: |
+    checking-out-a-revision takes a git repository and a commit SHA
+    and validates that cloning the revision succeeds. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a specific commit
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: commit
+    type: string
+    description: The git commit to fetch.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the commit to be checked.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.commit)
+  - name: compare-received-commit-to-expected
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    params:
+    - name: expected-commit
+      value: $(params.commit)
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      params:
+      - name: expected-commit
+      workspaces:
+      - name: source
+      steps:
+      - image: alpine/git:v2.24.3
+        script: |
+          #!/usr/bin/env sh
+          cd $(workspaces.source.path)
+          receivedCommit=$(git rev-parse HEAD)
+          if [ $receivedCommit != $(params.expected-commit) ]; then
+            echo "Expected commit $(params.expected-commit) but received $receivedCommit."
+            exit 1
+          else
+            echo "Received commit $receivedCommit as expected."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-clone-checking-out-a-commit-
+spec:
+  pipelineRef:
+    name: checking-out-a-revision
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: commit
+    value: 301b41380e95382a18b391c2165fa3a6a3de93b0  # Tekton Pipeline's first ever commit!

--- a/task/git-batch-merge/0.2/samples/git-rebase/run.yaml
+++ b/task/git-batch-merge/0.2/samples/git-rebase/run.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: git-rebase-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/divyansh42/squash-test.git
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+        - name: depth
+          value: "10"
+        - name: refspec
+          value: "refs/heads/master:refs/heads/master"
+    - name: git-rebase
+      taskRef:
+        name: git-rebase
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: SQUASH_COUNT
+          value: "2"
+        - name: COMMIT_MSG
+          value: "squashed commit"
+        - name: GIT_USER_NAME
+          value: "divyansh42"
+        - name: GIT_USER_EMAIL
+          value: diagrwa@redhat.com
+        - name: PULL_REMOTE_NAME
+          value: origin
+        - name: PULL_REMOTE_URL
+          value: https://github.com/divyansh42/squash-test.git
+        - name: PULL_BRANCH_NAME
+          value: feature
+        - name: PUSH_REMOTE_NAME
+          value: origin
+        - name: PUSH_REMOTE_URL
+          value: https://github.com/divyansh42/squash-test.git
+        - name: PUSH_BRANCH_NAME
+          value: master
+  results:
+    - name: commit
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-rebase-pipeline-run
+spec:
+  serviceAccountName: git-rebase-service-account
+  pipelineRef:
+    name: git-rebase-pipeline
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi

--- a/task/git-batch-merge/0.2/samples/git-rebase/secret.yaml
+++ b/task/git-batch-merge/0.2/samples/git-rebase/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-auth
+  annotations:
+    tekton.dev/git-0: https://github.com  # Replace with the desired domain name.
+type: kubernetes.io/basic-auth
+stringData:
+  username: $(username)
+  password: $(password)  # Access token should be provided here, if 2 factor authentication is enabled.

--- a/task/git-batch-merge/0.2/samples/git-rebase/service-account.yaml
+++ b/task/git-batch-merge/0.2/samples/git-rebase/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: git-rebase-service-account
+secrets:
+  - name: github-auth

--- a/task/git-batch-merge/0.2/samples/using-git-clone-result.yaml
+++ b/task/git-batch-merge/0.2/samples/using-git-clone-result.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: validate-tag-sha
+spec:
+  description: |
+    validate-tag-sha takes a git repository, tag name, and a commit SHA and
+    checks whether the given tag resolves to that commit. This example
+    Pipeline demonstrates the following:
+      - How to use the git-clone catalog Task
+      - How to use the git-clone Task's "commit" Task Result from another Task.
+      - How to discard the contents of the git repo when it isn't needed by
+        passing an `emptyDir` Volume as its "output" workspace.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: tag-name
+    type: string
+    description: The git tag to clone.
+  - name: expected-sha
+    type: string
+    description: The expected SHA to be received for the supplied revision.
+  workspaces:
+  - name: output
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: output
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.tag-name)
+  - name: validate-revision-sha
+    params:
+    - name: revision-name
+      value: $(params.tag-name)
+    - name: expected-sha
+      value: $(params.expected-sha)
+    - name: received-sha
+      value: $(tasks.fetch-repository.results.commit)
+    taskSpec:
+      params:
+      - name: revision-name
+      - name: expected-sha
+      - name: received-sha
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          if [ "$(params.expected-sha)" != "$(params.received-sha)" ]; then
+            echo "Expected revision $(params.revision-name) to have SHA $(params.expected-sha)."
+            exit 1
+          else
+            echo "Revision $(params.revision-name) has expected SHA $(params.expected-sha)."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: using-git-clone-result-
+spec:
+  pipelineRef:
+    name: validate-tag-sha
+  workspaces:
+  - name: output
+    emptyDir: {}  # We don't care about the repo contents in this example, just the "commit" result
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: tag-name
+    value: v0.12.1
+  - name: expected-sha
+    value: a54dd3984affab47f3018852e61a1a6f9946ecfa

--- a/task/git-batch-merge/0.2/tests/run.yaml
+++ b/task/git-batch-merge/0.2/tests/run.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-batch-merge-test-mode-merge
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-batch-merge
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/tektoncd/catalog
+      - name: mode
+        value: "merge"
+      - name: batchedRefs
+        value: "refs/pull/474/head refs/pull/475/head"
+      - name: revision
+        value: 3c23c446a970c5e02c011c894e2387e685ca086c
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: git-batch-merge-test-mode-merge-cherry-pick
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-batch-merge
+  inputs:
+    params:
+      - name: url
+        value: https://github.com/tektoncd/catalog
+      - name: mode
+        value: "cherry-pick"
+      - name: batchedRefs
+        value: "refs/pull/474/head refs/pull/475/head"
+      - name: revision
+        value: 3c23c446a970c5e02c011c894e2387e685ca086c


### PR DESCRIPTION
# Changes

Set better/more consistent defaults for `depth` and `subdirectory` on the `git-batch-merge` task.

I also modified the test for `git-batch-merge` to actually use a real repo (this repo), real PRs with changes to existing files (PRs #474 and #475), and a `revision` set to the immediate ancestor of PR #474, so that it's actually testing something meaningful. If the test had been structured like this before my change to `git-batch-merge` itself, it would have failed, so...yeah.

fixes #477 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
