### PR TITLE
Make git-init image configurable

### DIFF
--- a/task/git-batch-merge/0.2/git-batch-merge.yaml
+++ b/task/git-batch-merge/0.2/git-batch-merge.yaml
@@ -72,7 +72,7 @@ spec:
       default: "false"
     - name: gitInitImage
       description: The image used where the git-init binary is.
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2"
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.15.1"
       type: string
   results:
     - name: commit

--- a/task/git-batch-merge/0.2/git-batch-merge.yaml
+++ b/task/git-batch-merge/0.2/git-batch-merge.yaml
@@ -70,6 +70,10 @@ spec:
       description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
       type: string
       default: "false"
+    - name: gitInitImage
+      description: The image used where the git-init binary is.
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2"
+      type: string
   results:
     - name: commit
       description: The final commit SHA that was obtained after batching all provided refs onto revision
@@ -77,7 +81,7 @@ spec:
       description: The git tree SHA that was obtained after batching all provided refs onto revision.
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2
+      image: $(params.gitInitImage)
       script: |
         CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -64,12 +64,16 @@ spec:
       description: git no proxy - opt out of proxying HTTP/HTTPS requests
       type: string
       default: ""
+    - name: gitInitImage
+      description: The image used where the git-init binary is.
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2"
+      type: string
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.14.2
+      image: $(params.gitInitImage)
       script: |
         CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 

--- a/task/kaniko/0.1/kaniko.yaml
+++ b/task/kaniko/0.1/kaniko.yaml
@@ -59,7 +59,7 @@ spec:
       runAsUser: 0
   - name: write-digest
     workingDir: $(workspaces.source.path)
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.14.2
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.15.1
     # output of imagedigestexport [{"key":"digest","value":"sha256:eed29..660","resourceRef":{"name":"myrepo/myimage"}}]
     command: ["/ko-app/imagedigestexporter"]
     args:

--- a/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml
+++ b/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml
@@ -61,7 +61,7 @@ spec:
     - name: output
   steps:
     - name: write
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.14.2
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.15.1
       command: ["/ko-app/kubeconfigwriter"]
       args:
         # passing the required json in the form of string to generate the kubeconfig file.

--- a/task/pull-request/0.1/pull-request.yaml
+++ b/task/pull-request/0.1/pull-request.yaml
@@ -35,7 +35,7 @@ spec:
   - name: pr
   steps:
   - name: pullrequest-init
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.14.2
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.15.1
     command: ["/ko-app/pullrequest-init"]
     env:
     - name: AUTH_TOKEN

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -16,7 +16,7 @@
 
 set -x
 
-export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.14.2/release.yaml
+export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.15.1/release.yaml
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh


### PR DESCRIPTION
# Changes

If the user want to use another image than what we release on gcr.io let give
this option by introducing the param `gitInitImage` to set this up which would
default to the gcr.io image as it was before.

Bump along the way to Pipeline 0.15.1

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)