### PR TITLE
Add a helper script to run a task test directly on your local cluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,17 @@ image, if you need to have another binary available feel free to make a PR to th
 
 https://github.com/tektoncd/plumbing/blob/master/prow/images/test-runner/Dockerfile
 
+An helper script called [run-test.sh](test/run-test.sh) is provider in the
+[test](./test) directory to help the developer running the test locally. Just
+specify the task name and the version as the first and the second argument i.e:
+
+```bash
+./test/run-test.sh git-clone 0.1
+```
+
+and it will use your kubernetes to run the test and show you the outputs as done
+in the CI.
+
 ### Owning and Maintaining a Task
 
 Individual tasks should maintained by one or more users of

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+set -x
+set -e
+
+# So we can pass thought the set -e
+export BUILD_NUMBER=1
+
+cd $(git rev-parse --show-toplevel)
+source test/e2e-common.sh
+
+
+TEST_TASKRUN_IGNORES=${TEST_TASKRUN_IGNORES:-""}
+
+TMPF=$(mktemp /tmp/.mm.XXXXXX)
+clean() { rm -f ${TMPF} ;}
+trap clean EXIT
+
+if [[ -z ${@} || ${1} == "-h" ]];then
+    cat <<EOF
+This script will run a single task to help developers testing directly a
+single task without sending it to CI.
+
+You need to specify the task name as the first argument and the task version as
+the second argument. For example :
+
+${0} git-clone 0.1
+
+will run the tests for git-clone
+EOF
+    exit 0
+fi
+
+TASK=${1}
+VERSION=${2}
+
+taskdir=task/${TASK}/${VERSION}
+
+kubectl get ns ${TASK}-${VERSION//./-} >/dev/null 2>/dev/null && kubectl delete ns ${TASK}-${VERSION//./-}
+
+if [[ ! -d ${taskdir}/tests ]];then
+    echo "No 'tests' directory is located in ${taskdir}"
+    exit 1
+fi
+
+test_task_creation task/${TASK}/${VERSION}/tests


### PR DESCRIPTION
# Changes

This script will allow the developer to test a task directly withouth having to
send it to the CI and wait that all tasks runs to test it.

Usage is : 

```./test/run-test.sh git-clone 0.1```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)