### PR TITLE
Skip docker-build in CI

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -46,7 +46,7 @@ TEST_YAML_IGNORES=${TEST_YAML_IGNORES:-""}
 
 # Allow ignoring some yaml tests, space separated, should be the basename of the
 # test for example "s2i"
-TEST_TASKRUN_IGNORES=${TEST_TASKRUN_IGNORES:-""}
+TEST_TASKRUN_IGNORES=${TEST_TASKRUN_IGNORES:-"docker-build"}
 
 set -ex
 set -o pipefail


### PR DESCRIPTION
This will docker-build test in CI as it is
flaky atm and causing other PR not able
to merge

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
