### PR TITLE
[Fixes #481] remove add registry sidecar from docker-build tests

### DIFF
--- a/task/docker-build/0.1/docker-build.yaml
+++ b/task/docker-build/0.1/docker-build.yaml
@@ -11,11 +11,9 @@ metadata:
 spec:
   description: >-
     This task will build and push an image using docker.
-
     The task will build an out image out of a Dockerfile.
     This image will be pushed to an image registry.
     The image will be built and pushed using a dind sidecar over TCP+TLS.
-
   params:
   - name: image
     description: Reference of the image docker will produce.
@@ -33,6 +31,9 @@ spec:
     default: ""
   - name: push_extra_args
     description: Extra parameters passed for the push command when pushing images.
+    default: ""
+  - name: insecure_registry
+    description: Allows the user to push to an insecure registry that has been specified
     default: ""
   workspaces:
   - name: source
@@ -86,6 +87,7 @@ spec:
       - --storage-driver=vfs
       - --userland-proxy=false
       - --debug
+      - --insecure-registry=$(params.insecure_registry)
     securityContext:
       privileged: true
     env:

--- a/task/docker-build/0.1/tests/pre-apply-task-hook.sh
+++ b/task/docker-build/0.1/tests/pre-apply-task-hook.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 
-# Add an internal registry as sidecar to the task so we can upload it directly
-# from our tests without having to go to an external registry.
-add_sidecar_registry ${TMPF}
-
 # Add git-clone
 kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml

--- a/task/docker-build/0.1/tests/resources.yaml
+++ b/task/docker-build/0.1/tests/resources.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -9,3 +8,39 @@ spec:
   resources:
     requests:
       storage: 500Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-docker-build-local
+  namespace: docker-build-0-1
+spec:
+  selector:
+    matchLabels:
+      app: registry-docker-build-local
+  template:
+    metadata:
+      labels:
+        app: registry-docker-build-local
+    spec:
+      containers:
+      - name: registry-docker-build-local
+        image: registry:2
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 5000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: docker-build-0-1
+spec:
+  selector:
+    app: registry-docker-build-local
+  ports:
+  - port: 5000
+    targetPort: 5000

--- a/task/docker-build/0.1/tests/run.yaml
+++ b/task/docker-build/0.1/tests/run.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
@@ -30,7 +29,9 @@ spec:
       workspace: shared-workspace
     params:
     - name: image
-      value: localhost:5000/nocode
+      value: registry.docker-build-0-1.svc.cluster.local:5000/nocode
+    - name: insecure_registry
+      value: registry.docker-build-0-1.svc.cluster.local:5000
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -46,7 +46,7 @@ TEST_YAML_IGNORES=${TEST_YAML_IGNORES:-""}
 
 # Allow ignoring some yaml tests, space separated, should be the basename of the
 # test for example "s2i"
-TEST_TASKRUN_IGNORES=${TEST_TASKRUN_IGNORES:-"docker-build"}
+TEST_TASKRUN_IGNORES=${TEST_TASKRUN_IGNORES:-""}
 
 set -ex
 set -o pipefail


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

## Overview
* Removed docker-build from skip task
* Removed add_sidecar_registry from tests
* Added a deployment with an image registry instead of sidecar.

## Summary
The end to end test attaches a sidecar with a image registry for tasks to push into to. This task is optional and is encouraged to be used for testing. However, the function add_sidecar_registry sets the sidecar registry instead of appending it. Not using the tasks will fix the test https://github.com/tektoncd/catalog/issues/481

## TLDR;
Script sets sidecar equal to an object instead of appending it. So, Im not going to use it in my test.