### PR TITLE
Update step command for ansible-runner task

### DIFF
--- a/task/ansible-runner/0.1/README.md
+++ b/task/ansible-runner/0.1/README.md
@@ -19,14 +19,13 @@ tkn task ls
 ## Parameters
 
 * **project-dir**: The ansible-runner private data dir
-* **script**: The ansible runner command. (__default__: ansible-runner run $@)
 * **args:**: The array of arguments to pass to the runner command (_default:_ --help)
 
 ## Workspaces
 
 * **runner-dir**: A [workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) to hold the `private_data_dir` as described in https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-input-directory-hierarchy[Runner Directory]
 
-## Usage 
+## Usage
 
 The TaskRun uses the repository https://github.com/kameshsampath/tektoncd-ansible-runner-example, that houses some example playbooks.
 

--- a/task/ansible-runner/0.1/ansible-runner.yaml
+++ b/task/ansible-runner/0.1/ansible-runner.yaml
@@ -22,10 +22,6 @@ spec:
     - name: project-dir
       description: The project directory under the workspace runner-dir
       default: 'project'
-    - name: script
-      description: The ansible-playbook command to run
-      type: string
-      default: 'ansible-runner run $@'
     - name: args
       description: The arguments to pass ansible-runner
       type: array
@@ -37,6 +33,7 @@ spec:
       script: |
         #!/bin/bash
         set -e
+
         if [ -f requirements.txt ];
         then
           pip3 install --user \
@@ -54,8 +51,10 @@ spec:
 
     - name: run-playbook
       image: docker.io/ansible/ansible-runner
-      script: '$(params.script)'
+      command: ['entrypoint']
       args:
+        - ansible-runner
+        - run
         - $(params.args)
         - $(params.project-dir)
       workingDir: '$(workspaces.runner-dir.path)'


### PR DESCRIPTION
Signed-off-by: Kamesh Sampath <ksampath@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Made the ansible-runner task to be run via `entrypoint` to allow the  proper uid/guid setup in OpenShift environments.  Removed the `script` parameter.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention
          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
