### PR TITLE
Add support to mount kubeconfig  in `tkn` task

### DIFF
--- a/task/tkn/0.2/README.md
+++ b/task/tkn/0.2/README.md
@@ -1,0 +1,70 @@
+# tkn
+
+This task performs operations on Tekton resources using
+[`tkn`](https://github.com/tektoncd/cli).
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/tkn/0.2/tkn.yaml
+```
+
+## Parameters
+
+| name      | description                                 | default                               |
+| --------- | ------------------------------------------- | ------------------------------------- |
+| TKN_IMAGE | `tkn` CLI container image to run this task. | gcr.io/tekton-releases/dogfooding/tkn |
+| ARGS      | The arguments to pass to the `tkn` CLI.     | --help                                |
+| SCRIPT    | `tkn` CLI script to execute                 | tkn \$@                               |
+
+## Workspaces
+
+- **kubeconfig**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md#using-workspaces-in-tasks) that allows you to provide a `.kube/config` file for `tkn` to access the cluster. The file should be placed at the root of the Workspace with name `kubeconfig`.
+
+## Usage
+
+1. Passing only `ARGS`
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tkn-run
+spec:
+  taskRef:
+    name: tkn
+  params:
+    - name: ARGS
+      value:
+        - task
+        - list
+```
+
+2. Passing `SCRIPT` and `ARGS` and `WORKSPACE`
+
+   1. Sample secret can be found [here](https://github.com/tektoncd/catalog/tree/master/task/tkn/0.2/samples/secrets.yaml)
+
+   2. Create `TaskRun`
+
+   ```yaml
+   apiVersion: tekton.dev/v1beta1
+   kind: TaskRun
+   metadata:
+     name: tkn-run
+   spec:
+     taskRef:
+       name: tkn
+     workspaces:
+       - name: kubeconfig
+         secret:
+           secretName: kubeconfig
+     params:
+       - name: SCRIPT
+         value: |
+           tkn task start $1
+           tkn taskrun list
+           tkn task logs $1 -f
+       - name: ARGS
+         value:
+           - taskRunName
+   ```

--- a/task/tkn/0.2/samples/run-with-workspace.yaml
+++ b/task/tkn/0.2/samples/run-with-workspace.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tkn-run-with-workspace
+spec:
+  taskRef:
+    name: tkn
+  workspaces:
+    - name: kubeconfig
+      secret:
+        secretName: kubeconfig
+  params:
+    - name: SCRIPT
+      value: |
+        tkn task list
+        tkn pipeline list

--- a/task/tkn/0.2/samples/run-without-worksapce.yaml
+++ b/task/tkn/0.2/samples/run-without-worksapce.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tkn-run-without-workspace
+spec:
+  taskRef:
+    name: tkn
+  params:
+    - name: SCRIPT
+      value: |
+        tkn task list
+        tkn pipeline list

--- a/task/tkn/0.2/samples/secrets.yaml
+++ b/task/tkn/0.2/samples/secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeconfig
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    preferences: {}
+    clusters:
+    - cluster:
+        certificate-authority-data: LS0exampleexampleexample=
+        server: https://cluster.example.com:8443
+      name: my-cluster
+    contexts:
+    - context:
+        cluster: my-cluster
+        user: my-cluster-user
+      name: my-cluster
+    current-context: my-cluster
+    users:
+    - name: my-cluster-user
+      user:
+        client-certificate-data: LS0exampleexampleexample=
+        client-key-data: LS0exampleexampleexample=

--- a/task/tkn/0.2/tkn.yaml
+++ b/task/tkn/0.2/tkn.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: tkn
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: cli
+    tekton.dev/displayName: "Tekton CLI"
+spec:
+  workspaces:
+    - name: kubeconfig
+      description: >-
+        An optional workspace that allows you to provide a .kube/config
+        file for tkn to access the cluster. The file should be placed at
+        the root of the Workspace with name kubeconfig.
+      optional: true
+  description: >-
+    This task performs operations on Tekton resources using tkn
+
+  params:
+    - name: TKN_IMAGE
+      description: tkn CLI container image to run this task
+      default: gcr.io/tekton-releases/dogfooding/tkn@sha256:defb97935a4d4be26c760e43a397b649fb5591ac1aa6a736ada01e559c13767b
+    - name: SCRIPT
+      description: tkn CLI script to execute
+      type: string
+      default: "tkn $@"
+    - name: ARGS
+      type: array
+      description: tkn CLI arguments to run
+      default: ["--help"]
+  steps:
+    - name: tkn
+      image: "$(params.TKN_IMAGE)"
+      script: |
+        if [ "$(workspaces.kubeconfig.bound)" == "true" ] && [[ -e $(workspaces.kubeconfig.path)/kubeconfig ]]; then
+          export KUBECONFIG=$(workspaces.kubeconfig.path)/kubeconfig
+        fi
+
+        $(params.SCRIPT)
+      args: ["$(params.ARGS)"]


### PR DESCRIPTION
# Changes

The tkn task will be able to work with a kubeconfig for a cluster so that it can operate on it. The following task can also accept a SCRIPT as input so that we can run multiple tkn commands.

Closes #405 

Signed-off-by: vinamra28 <vinjain@redhat.com>

/cc @sbwsg @vdemeester 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Orgainization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
