### PR TITLE
Add Server's User to the maven task

### DIFF
--- a/task/maven/0.2/README.md
+++ b/task/maven/0.2/README.md
@@ -13,6 +13,8 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 - **MAVEN_IMAGE**: The base image for maven (_default_: `gcr.io/cloud-builders/mvn`)
 - **GOALS**: Maven `goals` to be executed
 - **MAVEN_MIRROR_URL**: Maven mirror url (to be inserted into ~/.m2/settings.xml)
+- **SERVER_USER**: Username to authenticate to the server (to be inserted into ~/.m2/settings.xml)
+- **SERVER_PASSWORD**: Password to authenticate to the server (to be inserted into ~/.m2/settings.xml)
 - **PROXY_USER**: Username to login to the proxy server (to be inserted into ~/.m2/settings.xml)
 - **PROXY_PASSWORD**: Password to login to the proxy server (to be inserted into ~/.m2/settings.xml)
 - **PROXY_HOST**: Hostname of the proxy server (to be inserted into ~/.m2/settings.xml)

--- a/task/maven/0.2/maven.yaml
+++ b/task/maven/0.2/maven.yaml
@@ -32,6 +32,14 @@ spec:
       description: The Maven repository mirror url
       type: string
       default: ""
+    - name: SERVER_USER
+      description: The username for the server
+      type: string
+      default: ""
+    - name: SERVER_PASSWORD
+      description: The password for the server
+      type: string
+      default: ""
     - name: PROXY_USER
       description: The username for the proxy server
       type: string
@@ -73,6 +81,10 @@ spec:
 
         cat > $(workspaces.maven-settings.path)/settings.xml <<EOF
         <settings>
+          <servers>
+            <!-- The servers added here are generated from environment variables. Don't change. -->
+            <!-- ### SERVER's USER INFO from ENV ### -->
+          </servers>
           <mirrors>
             <!-- The mirrors added here are generated from environment variables. Don't change. -->
             <!-- ### mirrors from ENV ### -->
@@ -104,6 +116,17 @@ spec:
           xml="$xml\
               </proxy>"
           sed -i "s|<!-- ### HTTP proxy from ENV ### -->|$xml|" $(workspaces.maven-settings.path)/settings.xml
+        fi
+
+        if [ -n "$(params.SERVER_USER)" -a -n "$(params.SERVER_PASSWORD)" ]; then
+          xml="<server>\
+            <id>serverid</id>"
+          xml="$xml\
+                <username>$(params.SERVER_USER)</username>\
+                <password>$(params.SERVER_PASSWORD)</password>"
+          xml="$xml\
+              </server>"
+          sed -i "s|<!-- ### SERVER's USER INFO from ENV ### -->|$xml|" $(workspaces.maven-settings.path)/settings.xml
         fi
 
         if [ -n "$(params.MAVEN_MIRROR_URL)" ]; then


### PR DESCRIPTION
This PR is to add `servers` tag for the private repository server.
It is assumed to be used with `MAVEN_MIRROR_URL`, for example, when using a cached library on a private network.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Add `servers` tag for the private repository server.

This PR is a reworked version of #410.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
