### PR TITLE
Parallelize calls to copy from/to GCS

### DIFF
--- a/task/gcs-download/0.1/gcs-download.yaml
+++ b/task/gcs-download/0.1/gcs-download.yaml
@@ -55,7 +55,7 @@ spec:
 
       if [[ "$(params.typeDir)" == "true" ]]; then
         mkdir -p "$DESTINATION"
-        gsutil rsync -d -r "$(params.location)" "$DESTINATION"
+        gsutil -m rsync -d -r "$(params.location)" "$DESTINATION"
       else
         gsutil cp $(params.location) "$DESTINATION"
       fi

--- a/task/gcs-upload/0.1/gcs-upload.yaml
+++ b/task/gcs-upload/0.1/gcs-upload.yaml
@@ -50,7 +50,7 @@ spec:
       fi
 
       if [[ -d "$SOURCE" ]]; then
-        gsutil rsync -d -r "$SOURCE" "$(params.location)"
+        gsutil -m rsync -d -r "$SOURCE" "$(params.location)"
       else
         gsutil cp "$SOURCE" "$(params.location)"
       fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The -m flag copies from multiple threads and makes a huge
performance difference for large trees.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ na] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [na ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ na] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ na] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ na] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ na] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ na] mandatory `spec.description` follows the convention
