### PR TITLE
gcs-generic: Make credential file optional.

### DIFF
--- a/task/gcs-generic/0.1/gcs-generic.yaml
+++ b/task/gcs-generic/0.1/gcs-generic.yaml
@@ -26,11 +26,11 @@ spec:
    description: |
       The path inside the credentials workspace to the GOOGLE_APPLICATION_CREDENTIALS key file.
    type: string
-   default: service_account.json
+   default: ''
  - name: image
    description: google cloud image that will be used in steps.
    type: string
-   default: google/cloud-sdk
+   default: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
  steps:
  - name: credential-setup
    image: "$(params.image)"

--- a/task/gcs-generic/0.1/samples/ls-taskrun.yaml
+++ b/task/gcs-generic/0.1/samples/ls-taskrun.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: gcs-ls-
+spec:
+  workspaces:
+    - name: credentials
+      emptyDir: {}
+  params:
+    - name: "command"
+      value: "ls"
+    - name: "options"
+      value: ["gs://tekton-releases"]
+  taskRef:
+    name: "gcs-generic"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When running on GCP, gsutil will try to infer identity from the GKE
metadata service instead of an explicitly defined credential file. The
easiest way to support this is to only set the credentials iff the file
is provided, otherwise just fallback to gsutils default behavior.

Also adds a simpler example that doesn't require credentials.

Provides working example for issue described in https://github.com/tektoncd/pipeline/issues/3208.

/cc @dansiviter (confirmed this works for a private GCS file w/ a Workload Identity enabled cluster)

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x]  Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
