### PR TITLE
Pylint: use an image with pylint preinstall and don't install requirements.txt

### DIFF
--- a/task/pylint/0.2/README.md
+++ b/task/pylint/0.2/README.md
@@ -1,0 +1,47 @@
+# pylint
+
+The task provides linting based on [pylint](https://pypi.org/project/pylint/) for Python.
+## Install the Task
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) volume containing the python code.
+
+### Install the pylint task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/pylint/0.2/pylint.yaml
+```
+
+## Parameters
+
+* **args**: The arguments to be passed to the pylint CLI. This parameter is required to run this task. (_Default_: `[""]`)
+* **path**: The path to the module which should be analysed by pylint. (_Default_: `"."`)
+
+## Usage
+
+This `TaskRun` runs `pylint` in a python module directory called `module/`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: lint
+spec:
+  taskRef:
+    name: pylint
+  workspaces:
+  - name: source
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi
+  params:
+  - name: args
+    value: ["-r", "y"]
+  - name: path
+    value: "module/"
+```

--- a/task/pylint/0.2/pylint.yaml
+++ b/task/pylint/0.2/pylint.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pylint
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: python, pylint
+    tekton.dev/displayName: pylint
+
+spec:
+  description: >-
+    This task will run pylint on the provided input.
+
+  workspaces:
+    - name: source
+  params:
+    - name: image
+      description: The container image with pylint
+      default: docker.io/cytopia/pylint@sha256:6e5b49b6d54cbd845b93139eeb3f4f558b07bf6a87001ce254782463df1443d2
+    - name: args
+      description: The arguments to pass to the pylint CLI.
+      type: array
+      default: [""]
+    - name: path
+      description: The path to the module which should be analysed by pylint
+      default: "."
+      type: string
+  steps:
+    - name: pylint
+      image: $(params.image)
+      workingDir: $(workspaces.source.path)
+      command:
+        - pylint
+      args:
+        - $(params.args)
+        - $(params.path)

--- a/task/pylint/0.2/tests/pre-apply-task-hook.sh
+++ b/task/pylint/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone task
+add_task git-clone latest

--- a/task/pylint/0.2/tests/run.yaml
+++ b/task/pylint/0.2/tests/run.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: python-test-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/wumaxd/pylint-pytest-example.git
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+
+      - name: pylint
+        taskRef:
+          name: pylint
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: shared-workspace
+        params:
+          - name: args
+            value: ["-r", "y"]
+          - name: path
+            value: "src/"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Mi


### PR DESCRIPTION
Add new pylint task

- Bump a new pylint task to 0.2
- Use an image which already has pylint and not auto install it every time we
  run the task.
- Do not try to install requirements.txt modules since pylint doesn't need it.
- Remove the ability to choose another python version since you probaby would
  not need it for a static analyzer. If you really need it you can redefine the
  image params targetting a custom container image.
