### PR TITLE
Disable shell debug just before the ERROR/FAILURE check

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -165,7 +165,14 @@ function test_task_creation() {
             breakit=True
             for status in ${all_status};do
 
-                [[ ${status} == *ERROR || ${reason} == *Fail* || ${reason} == Couldnt* ]] && show_failure ${testname} ${tns}
+                set -x
+                if [[ ${status} == *ERROR ||
+                          ${reason} == *Fail* ||
+                          ${reason} == Couldnt* ]];then
+                    set +x
+                    show_failure ${testname} ${tns}
+                fi
+                set +x
 
                 if [[ ${status} != True ]];then
                     breakit=


### PR DESCRIPTION
We are running the script with `set -x` to be able to debug the runs.

Since we check for ERRORS, prow thinks we have an error and highlight as a
potential error while it isn't

Let just disable the shell debugging just for that part so we can have prow
showing us the relevant errors/failures.



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [NA] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [NA] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [NA] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [NA] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [NA] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [NA] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [NA] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413