### PR TITLE
Rework the triggers-jenkins-job

### DIFF
--- a/task/trigger-jenkins-job/0.1/tests/pre-apply-task-hook.sh
+++ b/task/trigger-jenkins-job/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# This will create a Jenkins deployment, a jenkins service, grab the password,
+# gets a 'crumb' and generate a secret out of it for our task to run against to.
+
+cat <<EOF | kubectl apply -f- -n "${tns}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins
+spec:
+  selector:
+    matchLabels:
+      run: jenkins
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: jenkins
+    spec:
+      containers:
+      - name: jenkins
+        image: jenkins/jenkins:lts
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+          - name: jenkins-home
+            mountPath: /var/jenkins_home
+      volumes:
+        - name: jenkins-home
+          emptyDir: {}
+EOF
+
+kubectl -n "${tns}" wait --for=condition=available --timeout=600s deployment/jenkins
+kubectl -n "${tns}" expose deployment jenkins --target-port=8080
+
+set +e
+lock=0
+while true;do
+    apitoken="$(kubectl -n "${tns}" exec deployment/jenkins -- cat /var/jenkins_home/secrets/initialAdminPassword 2>/dev/null)"
+    [[ -n "${apitoken}" ]] && break
+    sleep 5
+    lock=$((lock+1))
+    if [[ "${lock}" == 60 ]];then
+        echo "Error waiting for jenkins to generate a password"
+        exit 1
+    fi
+done
+set -e
+
+
+# We need to execute the script on the pods, since it's too painful with direct exec the commands
+cat <<EOF>/tmp/script.sh
+#!/bin/bash
+set -x
+cookiejar=\$(mktemp)
+apitoken=\$(cat /var/jenkins_home/secrets/initialAdminPassword)
+while [[ -z "\${crumb}" ]];do
+      crumb=\$(curl --fail -s -u "admin:${apitoken}" --cookie-jar "\${cookiejar}" 'jenkins:8080/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)')
+      sleep 2
+done
+set -e
+curl -f -s -X POST -H "\${crumb}" --cookie "\${cookiejar}" -u "admin:${apitoken}" -X POST -H "Content-Type:application/xml" -d "<project><builders/><publishers/><buildWrappers/></project>" "jenkins:8080/createItem?name=test"
+echo \${crumb}|sed 's/Jenkins-Crumb://'
+EOF
+tar cf - /tmp/script.sh|kubectl -n "${tns}" exec -i deployment/jenkins -- tar xf - -C /
+crumb=$(kubectl -n "${tns}" exec -i deployment/jenkins -- /bin/bash /tmp/script.sh)
+
+kubectl create secret generic -n "${tns}" jenkins-credentials --from-literal=apitoken="${apitoken}" --from-literal=username="admin" --from-literal=crumb="${crumb}"

--- a/task/trigger-jenkins-job/0.1/tests/run.yaml
+++ b/task/trigger-jenkins-job/0.1/tests/run.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: trigger-jenkins-job-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: source
+    tasks:
+      - name: trigger-jenkins-job-test
+        taskRef:
+          name: trigger-jenkins-job
+        workspaces:
+          - name: source
+            workspace: source
+        params:
+          - name: JENKINS_HOST_URL
+            value: http://jenkins:8080
+          - name: JOB_NAME
+            value: "test"
+  workspaces:
+  - name: source
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Mi

--- a/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml
+++ b/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml
@@ -40,57 +40,66 @@ spec:
         - $(params.JOB_PARAMS)
       script: |
         #!/usr/libexec/platform-python
-
-        import os
-        import json
-        import sys
         import base64
-        import urllib
+        import http.cookiejar
+        import os
+        import sys
         import urllib.request
 
-        args = sys.argv[1:]
+        JENKINS_URL = """$(params.JENKINS_HOST_URL)"""
+        JOB_NAME = """$(params.JOB_NAME)"""
+        USERNAME = os.getenv("USERNAME")
+        APITOKEN = os.getenv("API_TOKEN")
 
-        queryType = "buildWithParameters"
-        finalArgs=""
-        data={}
-        filename=""
+        def build_args(args):
+            data = {}
+            filename = ""
+            for params in args:
+                if "@" in params:
+                    filename += params.split("=")[1][1:]
+                elif "=" in params:
+                    key_value = params.split("=")
+                    data[key_value[0]] = key_value[1]
+            if data:
+                data = urllib.parse.urlencode(data).encode("utf-8")
+            return (data, filename)
 
-        for params in args:
-          if '@' in params:
-            filename+=params.split("=")[1][1:]
-          elif len(params) != 0:
-            keyValue=params.split("=")
-            data[keyValue[0]]=keyValue[1]
-          else:
-            queryType = "build"
 
-        url = "$(params.JENKINS_HOST_URL)"+"/job/"+"$(params.JOB_NAME)"+"/"+queryType
+        def get_crumb(headers, cookiejar):
+            url = f"{JENKINS_URL}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)"
+            opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookiejar))
+            opener.addheaders = headers
+            return opener.open(url)
 
-        # creating Basic Authorization header
-        username=os.getenv('USERNAME')
-        apitoken=os.getenv('API_TOKEN')
-        credentials = ('%s:%s' % (username,apitoken))
-        base64string = base64.b64encode(credentials.encode('ascii'))
 
-        # Adding required Headers
-        requiredHeaders={
-          "Jenkins-Crumb": os.getenv('JENKINS_CRUMB'),
-          "Authorization": "Basic "+base64string.decode('ascii')
-        }
+        def main():
+            data, filename = build_args(sys.argv[1:])
 
-        data = urllib.parse.urlencode(data)
-        data = data.encode('utf-8') # data should be bytes
-        request = urllib.request.Request(url, data=data, headers=requiredHeaders)
+            if data:
+                query_type = "buildWithParameters"
+            else:
+                query_type = "build"
+            job_url = f"{JENKINS_URL}/job/{JOB_NAME}/{query_type}"
 
-        # Adding headers in case file is to be uploaded
-        if len(filename)!=0:
-          requiredHeaders['Content-Type']="multipart/form-data"
-          requiredHeaders['Content-Length']=os.stat(filename).st_size
-          request = urllib.request.Request(url, open(filename, 'rb'), headers=requiredHeaders)
+            jarhead = http.cookiejar.CookieJar()
+            base64string = base64.b64encode(f"{USERNAME}:{APITOKEN}".encode("utf-8"))
+            headers = [("Authorization", f"Basic {base64string.decode('utf-8')}")]
 
-        opener = urllib.request.build_opener()
-        with opener.open(request) as f:
-          f.read().decode('utf-8')
+            crumb = get_crumb(headers, jarhead).read().decode().replace("Jenkins-Crumb:", "")
+            headers.append(("Jenkins-Crumb", crumb))
+
+            request = urllib.request.Request(job_url, data=data)
+            if filename:
+                headers.append(("Content-Type", "multipart/form-data"))
+                headers.append(("Content-Length", os.stat(filename).st_size))
+                request = urllib.request.Request(job_url, open(filename, "rb"))
+
+            opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jarhead))
+            opener.addheaders = headers
+            with opener.open(request) as handle:
+                print(f"Job has started, status: {handle.status}")
+                handle.read().decode("utf-8")
+        main()
 
       env:
         - name: USERNAME


### PR DESCRIPTION
# Changes

Rewrite the triggers-jenkins-job, the arguments and params are about to same.

Starting from Jenkins LTS 2.176.2 we need to create a crumb and capture the
cookie jar to make the subsequent requests.

https://support.cloudbees.com/hc/en-us/articles/219257077-CSRF-Protection-Explained

Add tests :

We spins up a deployment with a jenkins lts and expose a service to it so our
task can access it.

We do some ninja execing into the pods to create a jenkins job in there and
setup the configmap secret.

We probably should drop the CRUMB setting since it will not work anymore but it
is harmless since we are regenerating it anyway.

Todo: need to test with jenkins image that is older than 2.176.2, but it
probably should work


# Submitter Checklist

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)