### PR TITLE
Add add_task helper function for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,7 @@ some environment variables to it that would be applied :
 We have some helper functions you can use from your `hook` scripts :
 
 * **add_sidecar_registry**: This will add a registry as a sidecar to allow the builder tasks to upload image directly to this sidecar registry instead of having to rely on external registries.
-* **add_git_clone_task**: This will add the git clone task to your temporary namespace.
-
+* **add_task**: Install a task into the testing namespace, the first argument is the name of the task, the second argument is the version of the task. If the version is equal to `latest` it will install the latest version of the task.
 
 What can you run from those scripts is whatever defined in the test-runner
 image, if you need to have another binary available feel free to make a PR to this Dockerfile :

--- a/task/ansible-runner/0.1/tests/pre-apply-task-hook.sh
+++ b/task/ansible-runner/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/black/0.1/tests/pre-apply-task-hook.sh
+++ b/task/black/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/buildah/0.1/tests/pre-apply-task-hook.sh
+++ b/task/buildah/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/buildpacks-phases/0.1/tests/pre-apply-task-hook.sh
+++ b/task/buildpacks-phases/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/buildpacks/0.1/tests/pre-apply-task-hook.sh
+++ b/task/buildpacks/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/check-make/0.1/tests/pre-apply-task-hook.sh
+++ b/task/check-make/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/docker-build/0.1/tests/pre-apply-task-hook.sh
+++ b/task/docker-build/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Add git-clone
-kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+add_task git-clone latest

--- a/task/golang-build/0.1/tests/pre-apply-task-hook.sh
+++ b/task/golang-build/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/golang-test/0.1/tests/pre-apply-task-hook.sh
+++ b/task/golang-test/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/golangci-lint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/golangci-lint/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/helm-upgrade-from-repo/0.1/tests/pre-apply-task-hook.sh
+++ b/task/helm-upgrade-from-repo/0.1/tests/pre-apply-task-hook.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest
 
 # Add service account
 kubectl -n ${tns} create serviceaccount helm-pipeline-run-sa -o yaml --dry-run=client | kubectl apply -f -

--- a/task/helm-upgrade-from-source/0.1/tests/pre-apply-task-hook.sh
+++ b/task/helm-upgrade-from-source/0.1/tests/pre-apply-task-hook.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest
 
 # Add service account
 kubectl -n ${tns} create serviceaccount helm-pipeline-run-sa -o yaml --dry-run=client | kubectl apply -f -

--- a/task/jib-gradle/0.1/tests/pre-apply-task-hook.sh
+++ b/task/jib-gradle/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/jib-maven/0.1/tests/pre-apply-task-hook.sh
+++ b/task/jib-maven/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/kaniko/0.1/tests/pre-apply-task-hook.sh
+++ b/task/kaniko/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/markdown-lint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/markdown-lint/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/maven/0.1/tests/pre-apply-task-hook.sh
+++ b/task/maven/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/maven/0.2/tests/pre-apply-task-hook.sh
+++ b/task/maven/0.2/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/mypy-lint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/mypy-lint/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/prettier/0.1/tests/pre-apply-task-hook.sh
+++ b/task/prettier/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/pylint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/pylint/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/pytest/0.1/tests/pre-apply-task-hook.sh
+++ b/task/pytest/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/python-coverage/0.1/tests/pre-apply-task-hook.sh
+++ b/task/python-coverage/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/replace-tokens/0.1/tests/pre-apply-task-hook.sh
+++ b/task/replace-tokens/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/ruby-lint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/ruby-lint/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/s2i/0.1/tests/pre-apply-task-hook.sh
+++ b/task/s2i/0.1/tests/pre-apply-task-hook.sh
@@ -5,4 +5,4 @@
 add_sidecar_registry ${TMPF}
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/shellcheck/0.1/tests/pre-apply-task-hook.sh
+++ b/task/shellcheck/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/ts-lint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/ts-lint/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/task/yaml-lint/0.1/tests/pre-apply-task-hook.sh
+++ b/task/yaml-lint/0.1/tests/pre-apply-task-hook.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Add git-clone
-add_git_clone_task
+add_task git-clone latest

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -32,9 +32,20 @@ function add_sidecar_registry() {
     rm -f ${TMPF}.read
 }
 
-# Add the git_clone task
-function add_git_clone_task() {
-    kubectl -n ${tns} apply -f ./task/git-clone/0.1/git-clone.yaml
+function add_task() {
+    local array path_version task
+    task=${1}
+    if [[ "${2}" == "latest" ]];then
+        array=($(echo task/${task}/*|sort -u))
+        path_version=${array[-1]}
+	else
+		path_version=task/${task}/${2}
+        if [[ ! -d ${path_version} ]];then
+            echo "I could not find version '${2}' for the task '${task}' in ./task/"
+            exit 1
+        fi
+	fi
+    kubectl -n "${tns}" apply -f "${path_version}"/"${task}".yaml
 }
 
 function install_pipeline_crd() {
@@ -93,7 +104,7 @@ function show_failure() {
 
 }
 function test_task_creation() {
-    for runtest in ${@};do
+    for runtest in "${@}";do
         # remove task/ from beginning
         local runtestdir=${runtest#*/}
         # remove /0.1/tests from end


### PR DESCRIPTION
We were previously using the outdated git_clone version 0.1 in the
add_git_clone_task function.

So let's introduce a more generic function :

```
add_task ${task} ${version}
```

if version is 'latest' it will always install the latest version of the task.

Change all pre-apply-task-hook to use that function instead.
