### PR TITLE
Fix golang-test and build issue where src is put in literal directory "$(params.package)"

### DIFF
--- a/task/golang-build/0.1/golang-build.yaml
+++ b/task/golang-build/0.1/golang-build.yaml
@@ -35,16 +35,16 @@ spec:
     default: auto
   workspaces:
   - name: source
-    mountPath: /workspace/src/$(params.package)
   steps:
   - name: build
     image: golang:$(params.version)
-    workingDir: $(workspaces.source.path)
     script: |
+      SRC_PATH="$GOPATH/src/$(params.package)"
+      mkdir -p $SRC_PATH
+      cp -R "$(workspaces.source.path)"/* $SRC_PATH
+      cd $SRC_PATH
       go build $(params.flags) $(params.packages)
     env:
-    - name: GOPATH
-      value: /workspace
     - name: GOOS
       value: "$(params.GOOS)"
     - name: GOARCH

--- a/task/golang-test/0.1/golang-test.yaml
+++ b/task/golang-test/0.1/golang-test.yaml
@@ -35,16 +35,16 @@ spec:
     default: auto
   workspaces:
   - name: source
-    mountPath: /workspace/src/$(params.package)
   steps:
   - name: unit-test
     image: golang:$(params.version)
-    workingDir: $(workspaces.source.path)
     script: |
+      SRC_PATH="$GOPATH/src/$(params.package)"
+      mkdir -p $SRC_PATH
+      cp -R "$(workspaces.source.path)"/* $SRC_PATH
+      cd $SRC_PATH
       go test $(params.flags) $(params.packages)
     env:
-    - name: GOPATH
-      value: /workspace
     - name: GOOS
       value: "$(params.GOOS)"
     - name: GOARCH


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes https://github.com/tektoncd/catalog/issues/461

# Changes

Also reported here: https://github.com/tektoncd/pipeline/issues/3152

The golang-test and build tasks attempts to use variable interpolation in a workspaces.mountPath field where it isn't supported. This results in the source code being mounted in a directory called literally, "$(params.package)".

This commit updates the golang-test and build tasks to make the package directory and copy the source code into it, then cd into it and run `go test`. This should result in better expected outcome - the source will be in the package directory that it expects to be.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

/kind bug