### PR TITLE
Improve e2e tests runner output

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -163,6 +163,10 @@ EOF
         local cnt=0
         local all_status=''
         local reason=''
+        # we temporary disable the debug output here since it fill up the
+        # logs a lot while waiting for the task to fail/succeed
+        set +x
+        echo "$(date '+%x %Hh%M:%S') Waiting for task ${testname} to finish successfully."
         while true;do
             [[ ${cnt} == ${maxloop} ]] && show_failure ${testname} ${tns}
 
@@ -197,14 +201,17 @@ EOF
             done
 
             if [[ ${breakit} == True ]];then
-                echo -n "SUCCESS: ${testname} pipelinerun has successfully executed" ;
+                echo "$(date '+%x %Hh%M:%S') SUCCESS: ${testname} pipelinerun has successfully executed" ;
                 break
             fi
 
             sleep 10
             cnt=$((cnt+1))
         done
+        set -x
 
-        kubectl delete ns ${tns}
+        # Delete namespace unless we specify the CATALOG_TEST_SKIP_CLEANUP env
+        # variable so we can debug in case the user needs it.
+        [[ -z ${CATALOG_TEST_SKIP_CLEANUP} ]] && kubectl delete ns ${tns}
     done
 }


### PR DESCRIPTION
We temporary disable the debug output while on the loop so we don't have the
gazillions debug messages while digging into the log. We have added the 'timing'
when it start and ends so we can easily spots the very slow tests (see #548 for investigation)

Aditionally we have introduced the new variable `CATALOG_TEST_SKIP_CLEANUP` if
set it will skip deleting the namespace. This is useful when running in
conjuncton with the `./test/run-test.sh` script to debug when there is a
failure.