### PR TITLE
Add orka-full task for MacStadium Orka integration

### DIFF
--- a/task/orka-full/0.1/README.md
+++ b/task/orka-full/0.1/README.md
@@ -1,0 +1,144 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task` is for utilizing a single macOS build agent in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-full`
+
+A `Task` that creates a VM template with the specified configuration, deploys a VM instance from it, and then cleans up the environment. All operations in this `Task` are performed against an Orka environment.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image). 
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster.
+
+You can use the following sample `orka-configuration.yaml`. Make sure to provide the correct Orka API endpoint for your Orka environment.
+
+```yaml
+# orka-configuration.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://10.221.188.100
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-configuration.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/orka-0.1/task/orka-full/0.1/orka-full.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+> **TIP:** Did you know you could use a script for easier install?
+> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/master/task/orka-full/0.1/SCRIPTS.md#install-the-task)
+
+## Storing your credentials
+
+The provided `Task` looks for two Kubernetes secrets that store your credentials: `orka-creds` for the Orka user and `orka-ssh-creds` for the SSH credentials.
+  * `orka-creds` has the following keys: `email` and `password`
+  * `orka-ssh-creds` has the following keys: `username` and `password`
+
+These defaults exist for convenience, and you can change them using the available [`Task` parameters](#Configuring-Secrets).
+
+You can use the following sample `credentials.yaml`. Make sure to provide the correct credentials for your Orka environment and the correct SSH credentials for the base image you intend to use.
+
+```yaml
+# credentials.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f credentials.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+> **TIP:** Did you know you could use a script for easier setup?
+>
+> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/master/task/orka-full/0.1/SCRIPTS.md#store-the-orka-environment-credentials)
+
+### Using an SSH key
+
+If using an SSH key to connect to the VM instead of an SSH username and password, complete the following:
+
+1. Copy the public key to the VM and commit the base image.
+2. Store the username and private key in a Kubernetes secret:
+
+```sh
+kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+```
+
+See also: [`use-ssh-key`](https://github.com/tektoncd/catalog/blob/master/task/orka-full/0.1/samples/use-ssh-key.yaml) example
+
+## Workspaces
+
+* **orka**: An Orka environment against which to perform all operations. The environment parameters are configured with the `Task` parameters.
+
+## Parameters
+
+### Common parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `base-image` | The Orka base image to use for the VM config. | --- |
+| `cpu-count` | The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24. | 3 |
+| `vcpu-count` | The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3. Otherwise, must equal half of or exactly the number of CPUs specified. | 3 |
+| `vnc-console` | Enables or disables VNC for the VM. | false |
+| `script` | The script to run inside of the VM. The script will be prepended with `#!/bin/sh` and `set -ex` if no shebang is present. You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby). | --- |
+| `copy-build` | Specifies whether to copy build artifacts from the Orka VM back to the workspace. Disable when there is no need to copy build artifacts (e.g., when running tests or linting code). | true |
+| `verbose` | Enables verbose logging for all connection activity to the VM. | false |
+| `ssh-key` | Specifies whether the SSH credentials secret contains an [SSH key](#using-an-ssh-key), as opposed to a password. | false |
+
+### Configuring secrets
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `orka-creds-secret` | The name of the secret holding your Orka credentials. | orka-creds |
+| `orka-creds-email-key` | The name of the key in the Orka user credentials secret for the email address associated with the Orka user. | email |
+| `orka-creds-password-key` | The name of the key in the Orka credentials secret for the password associated with the Orka user. | password |
+| `ssh-secret` | The name of the secret holding your VM SSH credentials. | orka-ssh-creds |
+| `ssh-username-key` | The name of the key in the VM SSH credentials secret for the username associated with the macOS VM. | username |
+| `ssh-password-key` | The name of the key in the VM SSH credentials secret for the password associated with the macOS VM. If `ssh-key` is true, this parameter should specify the name of the key in the VM SSH credentials secret that holds the private SSH key. | password |
+
+## Samples
+
+[dump-disk-info.yaml](https://github.com/tektoncd/catalog/blob/master/task/orka-full/0.1/samples/dump-disk-info.yaml) is a sample `TaskRun` that uses the `orka-full` `Task` to create a VM, run a script on it, and then clean up the environment.
+
+[build-audiokit-pipeline.yaml](https://github.com/tektoncd/catalog/blob/master/task/orka-full/0.1/samples/build-audiokit-pipeline.yaml) is a  sample `Pipeline` that uses the `orka-full` `Task` and performs the following operations:
+1. Clones a git repository.
+2. Passes it to the Orka build agent.
+3. Stores build artifacts on a persistent volume.
+4. Cleans up the Orka environment.

--- a/task/orka-full/0.1/README.md
+++ b/task/orka-full/0.1/README.md
@@ -40,7 +40,7 @@ data:
 
 ```sh
 kubectl apply --namespace=<namespace> -f orka-configuration.yaml
-kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/orka-0.1/task/orka-full/0.1/orka-full.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-full/0.1/orka-full.yaml
 ```
 
 Omit `--namespace` if installing in the `default` namespace.

--- a/task/orka-full/0.1/SCRIPTS.md
+++ b/task/orka-full/0.1/SCRIPTS.md
@@ -1,0 +1,121 @@
+# Install & Configure with Scripts
+
+For easier install and configuration of the Orka Tekton `Tasks`, you can use the provided scripts.
+
+* [TL;DR](#tldr)
+* [How to install the task](#how-to-install-the-task)
+* [How to store your credentials](#how-to-store-your-credentials)
+
+## TL;DR
+
+Omit `NAMESPACE` if installing in the `default` Kubernetes namespace.
+
+#### Install the task
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1/install.sh && chmod 755 install.sh
+
+NAMESPACE=<namespace> ORKA_API=<endpoint> ./install.sh --apply
+```
+
+#### Store the Orka environment credentials
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1/add-orka-creds.sh && chmod 755 add-orka-creds.sh
+
+NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --apply
+```
+
+#### Store the SSH credentials for the base image
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
+
+NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh --apply
+```
+
+## How to install the task
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster.
+
+### Get install.sh
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1/install.sh && chmod 755 install.sh
+```
+
+### Default namespace installation
+
+To install in your Kubernetes cluster's `default` namespace, run the following command against your actual Orka API endpoint.
+
+```sh
+ORKA_API=http://10.221.188.100 ./install.sh --apply
+```
+
+To uninstall from the `default` namespace, run the script with the `-d` or `--delete` flag:
+
+```sh
+./install.sh --delete
+```
+
+### Custom namespace installation
+
+To install in a custom namespace, run the following command against your preferred namespace and your actual Orka API endpoint:
+
+```sh
+NAMESPACE=<namespace> ORKA_API=<endpoint> ./install.sh --apply
+```
+
+To uninstall from a selected namespace, run the script with the `-d` or `--delete` flag against the namespace:
+
+```sh
+NAMESPACE=<namespace> ./install.sh --delete
+```
+
+## How to store your credentials
+
+The provided `Task` looks for two Kubernetes secrets that store your credentials: `orka-creds` for the Orka user and `orka-ssh-creds` for the SSH credentials.
+  * `orka-creds` has the following keys: `email` and `password`
+  * `orka-ssh-creds` has the following keys: `username` and `password`
+
+You need to create Kubernetes secrets to store the Orka user credentials and the base image's SSH credentials.
+
+### Get the credentials scripts
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1/add-orka-creds.sh && chmod 755 add-orka-creds.sh
+
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
+```
+
+### Store in the default namespace
+
+To create a Kubernetes secret in the `default` namespace of your cluster, run the following commands:
+
+```sh
+EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --apply
+SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh --apply
+```
+
+To remove the secrets from the `default` namespace, run:
+
+```sh
+./add-orka-creds.sh --delete
+./add-ssh-creds.sh --delete
+```
+
+### Store in a custom namespace
+
+To create a Kubernetes secret in a custom namespace, run the following commands against your preferred namespace:
+
+```sh
+NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --apply
+NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh --apply
+```
+
+To remove the secrets from the custom specify, run the following commands against the namespace:
+
+```sh
+NAMESPACE=<namespace> ./add-orka-creds.sh --delete
+NAMESPACE=<namespace> ./add-ssh-creds.sh --delete
+```

--- a/task/orka-full/0.1/add-orka-creds.sh
+++ b/task/orka-full/0.1/add-orka-creds.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+: ${NAMESPACE:="default"}
+
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1"
+USAGE=$(cat <<EOF
+Usage:
+  NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh [-a|-d|--apply|--delete]
+Options:
+  -a, --apply : Install secret with Orka credentials.
+  -d, --delete : Uninstall secret with Orka credentials.
+  --help : Display this message
+Environment:
+  NAMESPACE : Kubernetes namespace. Defaults to "default"
+  EMAIL (required) : Username for Orka service account, e.g. tekton-svc@macstadium.com
+  PASSWORD (required) : Password for Orka service account
+EOF
+)
+
+if [ -n "$1" ]; then
+  if [[ "$1" == "-a" || "$1" == "--apply" ]]; then
+    ACTION="apply"
+  elif [[ "$1" == "-d" || "$1" = "--delete" ]]; then
+    ACTION="delete"
+    kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/resources/orka-creds.yaml.tmpl
+    exit 0
+  elif [[ "$1" == "--help" ]]; then
+    echo "$USAGE"
+    exit 0
+  else
+    echo -e "Unkown argument: $1\n"
+    echo "$USAGE"
+    exit 1
+  fi
+else
+  ACTION="apply"
+fi
+
+if [[ ! $EMAIL || ! $PASSWORD ]]; then
+  echo -e "Email and password required!\n"
+  echo "$USAGE"
+  exit 1
+fi
+
+YAML_TEMPLATE=$(mktemp)
+trap "rm -f $YAML_TEMPLATE" EXIT
+
+curl --fail --location ${BASE_URL}/resources/orka-creds.yaml.tmpl --output $YAML_TEMPLATE
+sed -e 's|$(email)|'"$EMAIL"'|' \
+  -e 's|$(password)|'"$PASSWORD"'|' $YAML_TEMPLATE \
+  > ${YAML_TEMPLATE}.new
+mv ${YAML_TEMPLATE}.new $YAML_TEMPLATE
+kubectl $ACTION --namespace=$NAMESPACE -f $YAML_TEMPLATE

--- a/task/orka-full/0.1/add-ssh-creds.sh
+++ b/task/orka-full/0.1/add-ssh-creds.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+: ${NAMESPACE:="default"}
+
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1"
+USAGE=$(cat <<EOF
+Usage:
+  NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh [-a|-d|--apply|--delete]
+Options:
+  -a, --apply : Install secret with VM SSH credentials.
+  -d, --delete : Uninstall secret with VM SSH credentials.
+  --help : Display this message
+Environment:
+  NAMESPACE : Kubernetes namespace. Defaults to "default"
+  SSH_USERNAME (required) : Username for SSH access to VM
+  SSH_PASSWORD (required) : Password for SSH access to VM
+EOF
+)
+
+if [ -n "$1" ]; then
+  if [[ "$1" == "-a" || "$1" == "--apply" ]]; then
+    ACTION="apply"
+  elif [[ "$1" == "-d" || "$1" = "--delete" ]]; then
+    ACTION="delete"
+    kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/resources/orka-ssh-creds.yaml.tmpl
+    exit 0
+  elif [[ "$1" == "--help" ]]; then
+    echo "$USAGE"
+    exit 0
+  else
+    echo -e "Unkown argument: $1\n"
+    echo "$USAGE"
+    exit 1
+  fi
+else
+  ACTION="apply"
+fi
+
+if [[ ! $SSH_USERNAME || ! $SSH_PASSWORD ]]; then
+  echo -e "Username and password required!\n"
+  echo "$USAGE"
+  exit 1
+fi
+
+YAML_TEMPLATE=$(mktemp)
+trap "rm -f $YAML_TEMPLATE" EXIT
+
+curl --fail --location ${BASE_URL}/resources/orka-ssh-creds.yaml.tmpl --output $YAML_TEMPLATE
+sed -e 's|$(username)|'"$SSH_USERNAME"'|' \
+  -e 's|$(password)|'"$SSH_PASSWORD"'|' $YAML_TEMPLATE \
+  > ${YAML_TEMPLATE}.new
+mv ${YAML_TEMPLATE}.new $YAML_TEMPLATE
+kubectl $ACTION --namespace=$NAMESPACE -f $YAML_TEMPLATE

--- a/task/orka-full/0.1/install.sh
+++ b/task/orka-full/0.1/install.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+: ${NAMESPACE:="default"}
+: ${ORKA_API:="http://10.221.188.100"}
+
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/master/task/orka-full/0.1"
+USAGE=$(cat <<EOF
+Usage:
+  NAMESPACE=<namespace> ORKA_API=<url> ./install.sh [-a|-d|--apply|--delete]
+Options:
+  -a, --apply : Install orka-full task and config map
+  -d, --delete : Uninstall orka-full task and config map
+  --help : Display this message
+Environment:
+  NAMESPACE : Kubernetes namespace. Defaults to "default"
+  ORKA_API : Orka API endpoint. Defaults to "http://10.221.188.100"
+EOF
+)
+
+if [ -n "$1" ]; then
+  if [[ "$1" == "-a" || "$1" == "--apply" ]]; then
+    ACTION="apply"
+  elif [[ "$1" == "-d" || "$1" = "--delete" ]]; then
+    ACTION="delete"
+    kubectl $ACTION --namespace=$NAMESPACE \
+      -f ${BASE_URL}/resources/orka-tekton-config.yaml.tmpl \
+      --ignore-not-found
+    kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/orka-full.yaml
+    exit 0
+  elif [[ "$1" == "--help" ]]; then
+    echo "$USAGE"
+    exit 0
+  else
+    echo -e "Unkown argument: $1\n"
+    echo "$USAGE"
+    exit 1
+  fi
+else
+  ACTION="apply"
+fi
+
+# Install config map
+YAML_TEMPLATE=$(mktemp)
+trap "rm -f $YAML_TEMPLATE" EXIT
+
+curl --fail --location ${BASE_URL}/resources/orka-tekton-config.yaml.tmpl --output $YAML_TEMPLATE
+sed -e 's|$(url)|'"$ORKA_API"'|' $YAML_TEMPLATE \
+  > ${YAML_TEMPLATE}.new
+mv ${YAML_TEMPLATE}.new $YAML_TEMPLATE
+kubectl $ACTION --namespace=$NAMESPACE -f $YAML_TEMPLATE
+
+# Install tasks
+kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/orka-full.yaml

--- a/task/orka-full/0.1/orka-full.yaml
+++ b/task/orka-full/0.1/orka-full.yaml
@@ -1,0 +1,159 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-full
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.16.0"
+spec:
+  description: >-
+    With this Task, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task creates a VM template with the specified configuration,
+    deploys a VM instance from it, and then cleans up the environment.
+    All operations in this `Task` are performed against an Orka environment.
+  params:
+    - name: base-image
+      type: string
+      description: The Orka base image to use for the VM config.
+    - name: cpu-count
+      type: string
+      description: |
+        The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24.
+      default: "3"
+    - name: vcpu-count
+      type: string
+      description: |
+        The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3.
+        Otherwise, must equal half of or exactly the number of CPUs specified.
+      default: "3"
+    - name: vnc-console
+      type: string
+      description: Enables or disables VNC for the VM.
+      default: "false"
+    - name: script
+      type: string
+      description: |
+        The script to run inside of the VM. The script will be prepended with the following
+        if no shebang is present:
+
+        #!/bin/sh
+        set -ex
+
+        You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby).
+    - name: copy-build
+      type: string
+      description: |
+        Specifies whether to copy build artifacts from the Orka VM back to the workspace.
+        Disable when there is no need to copy build artifacts (e.g., when running tests or linting code).
+      default: "true"
+    - name: verbose
+      type: string
+      description: Enables verbose logging for all connection activity to the VM.
+      default: "false"
+    - name: orka-creds-secret
+      type: string
+      description: The name of the secret holding your Orka credentials.
+      default: orka-creds
+    - name: orka-creds-email-key
+      type: string
+      description: |
+        The name of the key in the Orka user credentials secret for the email address associated with the Orka user.
+      default: email
+    - name: orka-creds-password-key
+      type: string
+      description: |
+        The name of the key in the Orka credentials secret for the password associated with the Orka user.
+      default: password
+    - name: ssh-key
+      type: string
+      description: |
+        Specifies whether the SSH credentials secret contains an SSH key, as opposed to a password.
+      default: "false"
+    - name: ssh-secret
+      type: string
+      description: The name of the secret holding your VM SSH credentials.
+      default: orka-ssh-creds
+    - name: ssh-username-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the username associated with the macOS VM.
+      default: username
+    - name: ssh-password-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the password
+        associated with the macOS VM.
+
+        If ssh-key is true, this parameter should specify the name of the key in
+        the VM SSH credentials secret that holds the private SSH key.
+      default: password
+  steps:
+    - name: copy-script
+      image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      script: |
+        #!/bin/sh
+        SCRIPT=$(mktemp)
+        # Safeguard against having to escape quotes / vars in script
+        cat > $SCRIPT << 'EOF'
+        $(params.script)
+        EOF
+        copy-script $SCRIPT
+    - name: build
+      image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: BASE_IMAGE
+          value: $(params.base-image)
+        - name: CPU_COUNT
+          value: $(params.cpu-count)
+        - name: VCPU_COUNT
+          value: $(params.vcpu-count)
+        - name: VNC_CONSOLE
+          value: $(params.vnc-console)
+        - name: VERBOSE
+          value: $(params.verbose)
+        - name: COPY_BUILD
+          value: $(params.copy-build)
+        - name: SSH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.ssh-secret)
+              key: $(params.ssh-username-key)
+        - name: SSH_PASSFILE
+          value: /etc/$(params.ssh-secret)/$(params.ssh-password-key)
+        - name: SSH_KEY
+          value: $(params.ssh-key)
+        - name: SVC_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-email-key)
+        - name: SVC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-password-key)
+      volumeMounts:
+        - name: ssh-creds
+          readOnly: true
+          mountPath: /etc/$(params.ssh-secret)
+      command:
+        - orka-full
+  volumes:
+    - name: ssh-creds
+      secret:
+        secretName: $(params.ssh-secret)
+        items:
+          - key: $(params.ssh-password-key)
+            path: $(params.ssh-password-key)
+            mode: 256
+  workspaces:
+    - name: orka

--- a/task/orka-full/0.1/resources/orka-creds.yaml.tmpl
+++ b/task/orka-full/0.1/resources/orka-creds.yaml.tmpl
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: $(email)
+  password: $(password)

--- a/task/orka-full/0.1/resources/orka-ssh-creds.yaml.tmpl
+++ b/task/orka-full/0.1/resources/orka-ssh-creds.yaml.tmpl
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: $(username)
+  password: $(password)

--- a/task/orka-full/0.1/resources/orka-tekton-config.yaml.tmpl
+++ b/task/orka-full/0.1/resources/orka-tekton-config.yaml.tmpl
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: $(url)

--- a/task/orka-full/0.1/samples/build-audiokit-pipeline.yaml
+++ b/task/orka-full/0.1/samples/build-audiokit-pipeline.yaml
@@ -1,0 +1,91 @@
+# ###
+# This example relies on the git-clone Task:
+# https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.2
+#
+# ###
+#
+# This Pipeline will first clone a git repository into a shared workspace.
+# The workspace will then be copied to the Orka VM, and the supplied build
+# script will be executed inside the VM.
+# Build artifacts will then be transferred back to the Tekton workspace,
+# which can be consumed by a later Task in the Pipeline, or simply
+# saved to a cloud storage bucket.
+#
+# ###
+# Install the git-clone task:
+# kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-clone/0.2/git-clone.yaml
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-audiokit-pipeline
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-data
+      params:
+        - name: url
+          value: https://github.com/audiokit/AudioKit.git
+    - name: build-audiokit
+      runAfter:
+        - fetch-repo
+      taskRef:
+        name: orka-full
+      params:
+        - name: base-image
+          value: catalina-buildtools-90G.img
+        - name: cpu-count
+          value: "6"
+        - name: vcpu-count
+          value: "6"
+        - name: verbose
+          value: "true"
+        - name: script
+          value: |
+            cd AudioKit/iOS
+            time xcodebuild
+      workspaces:
+        - name: orka
+          workspace: shared-data
+    - name: show-build
+      runAfter:
+        - build-audiokit
+      workspaces:
+        - name: source
+          workspace: shared-data
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: list
+            image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+            script: |
+              #!/bin/sh
+              set -ex
+              ls -al $(workspaces.source.path)/AudioKit/iOS
+              ls -al $(workspaces.source.path)/AudioKit/iOS/build
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-build-audiokit-pipeline
+spec:
+  pipelineRef:
+    name: build-audiokit-pipeline
+  workspaces:
+    - name: shared-data
+      volumeClaimTemplate:
+        spec:
+          storageClassName: manual
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/task/orka-full/0.1/samples/dump-disk-info.yaml
+++ b/task/orka-full/0.1/samples/dump-disk-info.yaml
@@ -1,0 +1,28 @@
+# ###
+# This example shows how to use the orka-full Task to create a single macOS VM.
+# The script provided in the params will be executed inside the VM.
+#
+# You will need to have a secret containing the Orka credentials as well as a
+# secret containing the VM SSH credentials as described in the README.
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: dump-disk-info
+spec:
+  taskRef:
+    name: orka-full
+  params:
+    - name: base-image
+      value: catalina-ssh-30G.img
+    - name: copy-build
+      value: "false"
+    - name: script
+      value: |
+        DISK_INFO=$(mktemp)
+        diskutil info / > $DISK_INFO
+        cat $DISK_INFO
+  workspaces:
+    - name: orka
+      emptyDir: {}

--- a/task/orka-full/0.1/samples/use-ssh-key.yaml
+++ b/task/orka-full/0.1/samples/use-ssh-key.yaml
@@ -1,0 +1,40 @@
+# ###
+# This example demonstrates how to use an SSH key to connect to the Orka VM.
+# You will first need to copy the public key to the VM and commit or save an
+# image using `orka image commit` or `orka image save` and specify that base image.
+# in the TaskRun or Pipeline as a param.
+#
+# You must specify the Task param ssh-key="true" in order to use an SSH key.
+#
+# ###
+# You can create a Kubernetes secret with the SSH credentials as follows:
+# kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: use-ssh-key
+spec:
+  taskRef:
+    name: orka-full
+  params:
+    - name: base-image
+      value: catalina-ssh-key-30G.img
+    - name: ssh-secret
+      value: orka-ssh-key
+    - name: ssh-password-key
+      value: id_rsa
+    - name: ssh-key
+      value: "true"
+    - name: verbose
+      value: "true"
+    - name: copy-build
+      value: "false"
+    - name: script
+      value: |
+        #!/usr/bin/env ruby
+        puts "Hello macOS"
+  workspaces:
+    - name: orka
+      emptyDir: {}

--- a/task/orka-full/0.1/tests/mocks/orka.yaml
+++ b/task/orka-full/0.1/tests/mocks/orka.yaml
@@ -1,0 +1,40 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/deploy
+response:
+  status: 200
+  output: '{"ip": "localhost", "ssh_port": "22"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/purge
+response:
+  status: 200
+  output: '{"message": "Successfully purged VM"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /token
+response:
+  status: 200
+  output: '{"tokensRevoked": 1}'
+  content-type: text/json

--- a/task/orka-full/0.1/tests/mods/mod_task.py
+++ b/task/orka-full/0.1/tests/mods/mod_task.py
@@ -1,0 +1,38 @@
+import os, sys, yaml
+
+def str_presenter(dumper, data):
+  scalar_style = "|" if len(data.splitlines()) > 1 else None
+  return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=scalar_style)
+
+yaml.add_representer(str, str_presenter)
+
+if __name__ == "__main__":
+    # Load YAML files
+    with open(os.path.join(sys.path[0], "..", "mocks", "orka.yaml"), "r", encoding="utf-8") as f:
+        mocks = f.read()
+
+    with open(os.path.join(sys.path[0], "sidecars.yaml"), "r", encoding="utf-8") as f:
+        sidecars = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    with open(os.path.join(sys.path[0], "volumes.yaml"), "r", encoding="utf-8") as f:
+        volumes = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    # Modify Task YAML
+    sidecars.append({
+        "name": "go-rest-api",
+        "image": "quay.io/chmouel/go-rest-api-test",
+        "env": [
+            {
+                "name": "CONFIG",
+                "value": mocks
+            }
+        ]
+    })
+    data["spec"]["sidecars"] = sidecars
+    data["spec"]["volumes"] += volumes
+
+    # Dump YAML
+    print(yaml.dump(data, default_flow_style=False))

--- a/task/orka-full/0.1/tests/mods/sidecars.yaml
+++ b/task/orka-full/0.1/tests/mods/sidecars.yaml
@@ -1,0 +1,12 @@
+---
+- name: ssh-server
+  image: panubo/sshd:1.3.0
+  env:
+    - name: "SSH_USERS"
+      value: "admin:1000:1000"
+    - name: "SSH_ENABLE_PASSWORD_AUTH"
+      value: "true"
+  volumeMounts:
+    - name: startup-script
+      mountPath: "/etc/entrypoint.d"
+      readOnly: true

--- a/task/orka-full/0.1/tests/mods/volumes.yaml
+++ b/task/orka-full/0.1/tests/mods/volumes.yaml
@@ -1,0 +1,8 @@
+---
+- name: startup-script
+  configMap:
+    name: ssh-scripts
+    items:
+      - key: "startup-script"
+        path: "startup.sh"
+        mode: 448

--- a/task/orka-full/0.1/tests/pre-apply-task-hook.sh
+++ b/task/orka-full/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp ${TMPF} ${TMPF}.mod
+python3 ${taskdir}/tests/mods/mod_task.py ${TMPF}.mod > ${TMPF}
+rm -f ${TMPF}.mod

--- a/task/orka-full/0.1/tests/resources.yaml
+++ b/task/orka-full/0.1/tests/resources.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssh-scripts
+data:
+  startup-script: |
+    #!/usr/bin/env bash
+    set -e
+    echo "admin:admin" | chpasswd
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin

--- a/task/orka-full/0.1/tests/run.yaml
+++ b/task/orka-full/0.1/tests/run.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: orka-full-test-run
+spec:
+  taskRef:
+    name: orka-full
+  params:
+    - name: base-image
+      value: base-image.img
+    - name: copy-build
+      value: "false"
+    - name: verbose
+      value: "true"
+    - name: script
+      value: |
+        echo "Hello from TektonCD test"
+  workspaces:
+    - name: orka
+      emptyDir: {}

--- a/task/orka-full/OWNERS
+++ b/task/orka-full/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- spikeburton
+- Tmoss11
+- ispasov
+reviewers:
+- spikeburton
+- Tmoss11
+- ispasov


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR aims to add a Task in order to integrate Tekton with [Orka by MacStadium](https://www.macstadium.com/orka). Orka allows users to run macOS builds and workloads on real Apple hardware. An Orka / Tekton integration will allow the utilization of macOS build agents for CI jobs that run on Tekton pipelines.

The `orka-full` Task will allow the utilization of a single macOS build agent, allowing the user to provide a build script as a parameter, and will allow the user to store build artifacts in a Tekton workspace. 

> **NOTE**: In order to use this Task, an Orka environment is required. Orka runs in a self-contained Kubernetes cluster and a VPN connection must be established between the Orka cluster and the Kubernetes cluster in which Tekton is installed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
