### PR TITLE
Readd requirements.txt install for pylint task

### DIFF
--- a/task/pylint/0.2/README.md
+++ b/task/pylint/0.2/README.md
@@ -17,6 +17,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 
 * **args**: The arguments to be passed to the pylint CLI. This parameter is required to run this task. (_Default_: `[""]`)
 * **path**: The path to the module which should be analysed by pylint. (_Default_: `"."`)
+* **requirements_file**: The path to the requirements file to pip install for your application to be checked. (_Default_: `"requirements.txt"`)
 
 ## Usage
 

--- a/task/pylint/0.2/pylint.yaml
+++ b/task/pylint/0.2/pylint.yaml
@@ -28,12 +28,17 @@ spec:
       description: The path to the module which should be analysed by pylint
       default: "."
       type: string
+    - name: requirements_file
+      description: The name of the requirements file inside the source location
+      default: "requirements.txt"
   steps:
     - name: pylint
       image: $(params.image)
       workingDir: $(workspaces.source.path)
-      command:
-        - pylint
-      args:
-        - $(params.args)
-        - $(params.path)
+      script: |
+        export HOME=/tmp/python
+        export PATH=$PATH:/tmp/python/.local/bin
+        if [ -n "$(inputs.params.requirements_file)" ] && [ -e "$(inputs.params.requirements_file)" ];then
+            python -mpip install --user -r $(inputs.params.requirements_file)
+        fi
+        pylint $(inputs.params.args) $(inputs.params.path)


### PR DESCRIPTION
the install of the requirements.txt dependences was wrongly (by me) removed from the 0.1 task but it is actually
needed for pylint, since it would error out if it can't find the dependences.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413