### PR TITLE
Fix add_task common function

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -36,7 +36,7 @@ function add_task() {
     local array path_version task
     task=${1}
     if [[ "${2}" == "latest" ]];then
-        array=($(echo task/${task}/*|sort -u))
+        array=($(echo task/${task}/*/|sort -u))
         path_version=${array[-1]}
 	else
 		path_version=task/${task}/${2}


### PR DESCRIPTION
We were not getting properly the versions when there was files like OWNER in there

so make sure to grab only the directory

Before : 

```bash
$ task=golang-test;echo task/${task}/*
task/golang-test/0.1 task/golang-test/OWNERS
```

After : 

```bash
$ task=golang-test;echo task/${task}/*/
task/golang-test/0.1/
```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- ✅ Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- ✅ Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- ✅ Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- ✅ Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - ✅ File path follows  `<kind>/<name>/<version>/name.yaml`
  - ✅ Has `README.md` at `<kind>/<name>/<version>/README.md`
  - ✅ Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - ✅ Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - ✅ mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413