### PR TITLE
tekton-prune: prune tekton objects by age or by number

### DIFF
--- a/task/tekton-prune/0.1/README.md
+++ b/task/tekton-prune/0.1/README.md
@@ -1,0 +1,54 @@
+# tekton-prune
+
+This task helps you prune tekton objects. This task is typically run in a scheduled jobs via [kubernetes cron](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) or other [traditional crons](https://en.wikipedia.org/wiki/Cron).
+
+## Install the task
+
+### Install the tekton-prune task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/tekton-prune/0.1/tekton-prune.yaml
+```
+
+## Parameters
+
+* **object**: The type of the kubernetes object to clean.  (i.e: `PipelineRun`, `TaskRuns`).
+* **namespace**: The target namespace, if no target namespace is specified it would use the one where this taks is run (_Default_: `""`)
+* **max_days**: Maximum number of days to keep. This accepts only an integer (_Default_: `""`)
+* **max_number**: Maximum number of objects to keep. This accepts only an integer (_Default_: `""`)
+* **labels**: The kubernetes labels to filter tekton objects. Multiple labels can separated by a comma. (_Default_: `""`)
+* **no_execute**: Wether to execute the actual deletion or just print the object to delete. This accept a `yes` or `true` for positives or `no` or `false` for negative (_Default_: `""`)
+
+## Usage
+
+You need to make sure to have either `max_days` or `max_number` set or this task would fail.
+
+You need to make sure that the `serviceAccount` that runs this task has the right to list tekton objects, see [the role](./tests/roles.yaml) of this test task for a `serviceAccount` with a `roleBinding` rights to list and delete `tekton` objects.
+
+This kubernetes `CronJob` will cleanup the `PipelineRun` older than 5 days belonging to the Pipeline `pipeline`, this assume you have preinstalled the task where this cron is run and that you  have installed the `roleBindings` from `./test/roles.yaml` :
+
+```yaml
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cron-openshift-ci-build-images
+spec:
+  schedule: "0 0 * * 1"  # every Sunday night !
+  concurrencyPolicy: "Forbid"
+  startingDeadlineSeconds: 200
+  suspend: false
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccount: tekton-object-role-binding
+          containers:
+          - name: use-tkn-for-cleanup
+            image: gcr.io/tekton-releases/dogfooding/tkn
+            command: ["/bin/sh"]
+            args: ["-c", "tkn task start tekton-prune --serviceaccount tekton-object-role-binding --param  object=pipelinerun --param max_number=5 --param labels=tekton.dev/pipeline=pipeline --showlog"]
+          restartPolicy: OnFailure
+```

--- a/task/tekton-prune/0.1/tekton-prune.yaml
+++ b/task/tekton-prune/0.1/tekton-prune.yaml
@@ -1,0 +1,187 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: tekton-prune
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: tekton, misc
+    tekton.dev/displayName: "tekton prune"
+spec:
+  description: >-
+    This task help you cleanup old tekton objects.
+    .
+    This usually used to cleanup the Tekton *Runs objects but it can be used for
+    any other kubernetes objects.
+  params:
+    - name: object
+      type: string
+      description: The type of the tekton object to clean
+      default: ""
+    - name: max_days
+      type: string
+      description: Maximum number of days to keep.
+      default: ""
+    - name: max_numbers
+      type: string
+      description: Maximum number of object to keep.
+      default: ""
+    - name: labels
+      description: Labels to filter the tekton objects separated by a comma.
+      default: ""
+    - name: no_execute
+      type: string
+      description: Wether to execute the actual deletion, (yes or no)
+      default: "no"
+    - name: namespace
+      type: string
+      description: The target namespace
+      default: ""
+  steps:
+    - name: tekton-object-cleanups
+      image: docker.io/alpine/k8s:1.18.2@sha256:aea8eec2057c752b5d956041f160c8ff18c191576d881fb757743a80bfa48fab
+      script: |
+        #!/usr/bin/env python3
+        import argparse
+        import datetime
+        import json
+        import subprocess
+        import sys
+
+
+        def execute(command):
+            """Execute commmand"""
+            result = ""
+            try:
+                result = subprocess.run(["/bin/sh", "-c", command],
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.STDOUT,
+                                        check=True)
+            except subprocess.CalledProcessError as exception:
+                print(
+                    f"Status code: {exception.returncode}: Output: \n{exception.output}"
+                )
+                raise exception
+            return result
+
+
+        def parse_args(args):
+            parser = argparse.ArgumentParser(description='Tekton object cleaners', )
+
+            parser.add_argument(
+                "--labels",
+                type=str,
+                help=
+                "Labels to filter objects with, multiple labels can be separated by comma."
+            )
+
+            parser.add_argument(
+                "--no-execute",
+                type=str,
+                choices=["yes", "true", "false", "no"],
+                help=
+                "Do not delete just print the kubectl command line (to check what will be deleted)."
+            )
+
+            parser.add_argument("--object",
+                                required=True,
+                                type=str,
+                                help="The type of the tekton object to clean.")
+
+            parser.add_argument("--namespace", type=str, help="The target namespace.")
+
+            parser.add_argument(
+                "--max_days",
+                type=str,
+                help="Maximum number of days to keep before deleting the older ones.")
+
+            parser.add_argument("--max_number",
+                                type=str,
+                                help="Maximum number of objects to keep.")
+
+            if len(args) == 0:
+                parser.print_help()
+                sys.exit(1)
+
+            args = parser.parse_args(args)
+
+            if args.max_days and args.max_number:
+                sys.stderr.write(
+                    "--max_number and --max_days are exclusive and cannot be specified at the same time."
+                )
+                sys.exit(1)
+
+            if not args.max_days and not args.max_number:
+                sys.stderr.write(
+                    "neither --max_number or --max_days has been specified.")
+                sys.exit(1)
+
+            if args.max_days and not args.max_days.isdigit():
+                sys.stderr.write(f"{args.max_days} should be a number")
+                sys.exit(1)
+            elif args.max_number and not args.max_number.isdigit():
+                sys.stderr.write(f"{args.max_number} should be a number.")
+                sys.exit(1)
+
+            if args.labels:
+                for label in args.labels.split(","):
+                    if "=" not in label:
+                        sys.stderr.write(
+                            f"label '{label}' does not have an assignment it should be `label=value`"
+                        )
+                        sys.exit(1)
+
+            return args
+
+
+        def main():
+            args = parse_args(sys.argv[1:])
+            labels = [f"-l {k}" for k in args.labels.split(",")] if args.labels else []
+            namespace_str = f"-n {args.namespace}" if args.namespace else ""
+
+            cmdline = f"kubectl {namespace_str} get {args.object} {' '.join(labels)} -o json"
+            output = json.loads(execute(cmdline).stdout.decode())
+
+            def parse_ts(timest):
+                return datetime.datetime.strptime(timest, '%Y-%m-%dT%H:%M:%SZ')
+
+            if args.max_days:
+                results = [
+                    i['metadata']['name'] for i in output['items']
+                    if datetime.datetime.now() >
+                    parse_ts(i['metadata']['creationTimestamp']) +
+                    datetime.timedelta(days=int(args.max_days))
+                ]
+                print(
+                    f"Deleting {len(results)} {args.object} older than {args.max_days} days"
+                )
+            elif args.max_number:
+                allp = {
+                    i['metadata']['name']: parse_ts(i['metadata']['creationTimestamp'])
+                    for i in output['items']
+                }
+                results = sorted(allp, key=allp.get,
+                                 reverse=True)[int(args.max_number):]
+                print(
+                    f"Keeping the {args.max_number} newest {args.object} and deleting the {len(results)} others: {','.join(results)}"
+                )
+            else:
+                raise Exception("This should not happen?")
+
+            cmdline = f'kubectl {namespace_str} delete {args.object} {" ".join(results)}'
+            if args.no_execute and args.no_execute.lower() in ("yes", "true"):
+                print(cmdline)
+            else:
+                execute(cmdline)
+
+
+        if __name__ == '__main__':
+            main()
+      args:
+        - --labels=$(params.labels)
+        - --max_days=$(params.max_days)
+        - --max_number=$(params.max_number)
+        - --object=$(params.object)
+        - --no-execute=$(params.no_execute)
+        - --namespace=$(params.namespace)

--- a/task/tekton-prune/0.1/tests/pre-apply-task-hook.sh
+++ b/task/tekton-prune/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ex
+
+for i in {1..2};do
+    cat <<EOF| kubectl apply -f-
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: scratch-test-${i}
+  labels:
+    testme: please
+spec:
+  taskSpec:
+    steps:
+    - image: hello-world:linux
+EOF
+    kubectl wait --timeout=180s --for=condition=Succeeded taskrun/scratch-test-${i}
+done

--- a/task/tekton-prune/0.1/tests/roles.yaml
+++ b/task/tekton-prune/0.1/tests/roles.yaml
@@ -1,0 +1,28 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-object-role
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns", "taskruns"]
+    verbs: ["get", "list", "watch", "delete", "create", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-object-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: tekton-object-role-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-object-role
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-object-role-sa

--- a/task/tekton-prune/0.1/tests/taskrun.yaml
+++ b/task/tekton-prune/0.1/tests/taskrun.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tekton-prune-test-run
+spec:
+  params:
+    - name: max_number
+      value: "1"
+    - name: no_execute
+      value: "true"
+    - name: object
+      value: "taskrun"
+    - name: labels
+      value: "testme=please"
+  serviceAccountName: tekton-object-role-sa
+  taskRef:
+    kind: Task
+    name: tekton-prune


### PR DESCRIPTION
This is a task that wrap a python script to let to schedule a cleanup of old
tekton objects (usually runs).

It can works via age (keep the last 5 days) or via a limit number (keep the last
5 task/pipelineruns) and if you have the rights let you pass a target namespace or do
some filtering by labels.

This task can be run via kubernetes or 'vixie' style cron.


/hold

(still need to finish to write the documentation)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- 👍🏼 Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- 👍🏼 Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- 👍🏼 Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- 👍🏼 Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - 👍🏼 File path follows  `<kind>/<name>/<version>/name.yaml`
  - 👍🏼 Has `README.md` at `<kind>/<name>/<version>/README.md`
  - 👍🏼 Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - 👍🏼 Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - 👍🏼 mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413