### PR TITLE
Bump git-init version to v0.17.3

### DIFF
--- a/task/git-batch-merge/0.2/git-batch-merge.yaml
+++ b/task/git-batch-merge/0.2/git-batch-merge.yaml
@@ -72,7 +72,7 @@ spec:
       default: "false"
     - name: gitInitImage
       description: The image used where the git-init binary is.
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.17.1"
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.17.3"
       type: string
   results:
     - name: commit

--- a/task/git-clone/0.2/README.md
+++ b/task/git-clone/0.2/README.md
@@ -39,6 +39,7 @@ as well as
 * **httpsProxy**: git HTTPS proxy server for SSL requests (_default_: "")
 * **noProxy**: git no proxy - opt out of proxying HTTP/HTTPS requests (_default_: "")
 * **verbose**: log the commands that are executed during `git-clone`'s operation (_default_: true)
+* **gitInitImage**: the image used where the git-init binary is (_default_: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.17.3")
 
 ### Results
 

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -68,6 +68,10 @@ spec:
       description: log the commands used during execution
       type: string
       default: "true"
+    - name: gitInitImage
+      description: the image used where the git-init binary is
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.17.3"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task
@@ -75,7 +79,7 @@ spec:
       description: The precise URL that was fetched by this Task
   steps:
     - name: clone
-      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.17.1
+      image: $(params.gitInitImage)
       script: |
         #!/bin/sh
         set -eu -o pipefail


### PR DESCRIPTION
# Changes

- Bump git-init version to v0.17.3 which contains bug-fixes for `git-init` ([Release Note](https://github.com/tektoncd/pipeline/releases/tag/v0.17.3))
  - Also, make git-init image in git-clone/clone as configurable value

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```