### PR TITLE
bumping up pipeline version

### DIFF
--- a/task/git-batch-merge/0.2/git-batch-merge.yaml
+++ b/task/git-batch-merge/0.2/git-batch-merge.yaml
@@ -72,7 +72,7 @@ spec:
       default: "false"
     - name: gitInitImage
       description: The image used where the git-init binary is.
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.17.3"
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.18.0"
       type: string
   results:
     - name: commit

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -71,7 +71,7 @@ spec:
     - name: gitInitImage
       description: the image used where the git-init binary is
       type: string
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.17.3"
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.18.0"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -16,7 +16,7 @@
 
 set -x
 
-export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.17.1/release.yaml
+export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.18.0/release.yaml
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tekton Pipeline [0.18.0](https://github.com/tektoncd/pipeline/releases/tag/v0.18.0) was just released and as part of the release [process](https://github.com/tektoncd/pipeline/pull/3258), bumping up the following images in the catalog tasks:

* (task - current images)
* git-batch-merge - v0.17.3
* git-clone - v0.17.3

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
