### PR TITLE
Fix e2e script

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -57,7 +57,7 @@ set -o pipefail
 all_tests=$(echo task/*/*/tests)
 
 function detect_new_tasks() {
-    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_SHA}"|grep 'task/[^\/]*/[^\/]*/tests/[^/]*.yaml'|xargs dirname|sort -u
+    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep 'task/[^\/]*/[^\/]*/tests/[^/]*.yaml'|xargs -I {} dirname {}|sort -u
 }
 
 if [[ -z ${TEST_RUN_ALL_TESTS} ]];then


### PR DESCRIPTION
# Changes

- While running integration tests we are getting `dirname: missing operand`.
- `git --no-pager diff --name-only 65dd35a5e8a7e63443b52df70ea5bbc0bc621dac..` Pull SHA is missing so fixed that

/cc @chmouel @vdemeester 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [n/a] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [n/a] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [n/a] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [n/a] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [n/a] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
