### PR TITLE
Add security context in create step of buildpacks

### DIFF
--- a/task/buildpacks-phases/0.1/tests/run.yaml
+++ b/task/buildpacks-phases/0.1/tests/run.yaml
@@ -35,7 +35,7 @@ spec:
     - name: SOURCE_SUBPATH
       value: apps/java-maven
     - name: BUILDER_IMAGE
-      value: cnbs/sample-builder:alpine-p0.3
+      value: cnbs/sample-builder:alpine-p0.3@sha256:37a46f94c6b1d2dca907542e11191885adcd365e7b0c176ec19e2969880ebb61
     - name: CACHE
       value: buildpacks-cache
     resources:

--- a/task/buildpacks/0.1/buildpacks.yaml
+++ b/task/buildpacks/0.1/buildpacks.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: image-build
+    tekton.dev/deprecated: "true"
     tekton.dev/displayName: "buildpacks"
 spec:
   description: >-

--- a/task/buildpacks/0.2/buildpacks.yaml
+++ b/task/buildpacks/0.2/buildpacks.yaml
@@ -106,6 +106,9 @@ spec:
           mountPath: /cache
         - name: $(params.PLATFORM_DIR)
           mountPath: /platform
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
 
   volumes:
     - name: empty-dir

--- a/task/buildpacks/0.2/tests/run.yaml
+++ b/task/buildpacks/0.2/tests/run.yaml
@@ -35,7 +35,7 @@ spec:
     - name: SOURCE_SUBPATH
       value: apps/java-maven
     - name: BUILDER_IMAGE
-      value: cnbs/sample-builder:alpine
+      value: cnbs/sample-builder:alpine@sha256:329dd975bed06758c891d29014b98a3baaf381afb36d7375c3140bfbbb94fb08
     - name: CACHE
       value: buildpacks-cache
     resources:

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -135,6 +135,7 @@ function test_task_creation() {
         # remove /tests from end
         local taskdir=${runtest%/*}
         ls ${taskdir}/*.yaml 2>/dev/null >/dev/null || skipit=True
+        cat ${taskdir}/*.yaml | grep 'tekton.dev/deprecated: \"true\"' && skipit=True
 
         [[ -n ${skipit} ]] && continue
 


### PR DESCRIPTION
# Changes

- Modified e2e script to check for deprecated labels and skip the tests for that task
- Added `securityContext` in buildpacks 0.2 task
- Added digest in `buildpacks-phases run.yaml` and `buildpacks 0.2 run.yaml` so that in future CI doesn't fails

fixes #575 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
