### PR TITLE
Fix e2e scripts to test modified tasks

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -134,7 +134,13 @@ function test_task_creation() {
 
         # remove /tests from end
         local taskdir=${runtest%/*}
+
+        # check whether test folder exists or not inside task dir
+        # if not then run the tests for next task (if any)
+        [ ! -d $runtest ] && skipit=True
+
         ls ${taskdir}/*.yaml 2>/dev/null >/dev/null || skipit=True
+
         cat ${taskdir}/*.yaml | grep 'tekton.dev/deprecated: \"true\"' && skipit=True
 
         [[ -n ${skipit} ]] && continue

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -56,12 +56,15 @@ set -o pipefail
 
 all_tests=$(echo task/*/*/tests)
 
-function detect_new_tasks() {
-    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep 'task/[^\/]*/[^\/]*/tests/[^/]*.yaml'|xargs -I {} dirname {}|sort -u
+function detect_new_changed_tasks() {
+    # detect for changes in tests dir of the task
+    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep 'task/[^\/]*/[^\/]*/tests/[^/]*.yaml'|xargs -I {} dirname {}
+    # detect for changes in the task manifest
+    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep 'task/[^\/]*/[^\/]*/*[^/]*.yaml'|xargs -I {} dirname {}|awk '{print $1"/tests"}'
 }
 
 if [[ -z ${TEST_RUN_ALL_TESTS} ]];then
-    all_tests=$(detect_new_tasks || true)
+    all_tests=$(detect_new_changed_tasks|sort -u || true)
     [[ -z ${all_tests} ]] && {
         echo "No tests has been detected in this PR. exiting."
         success


### PR DESCRIPTION
# Changes

Current e2e script is only able to run integration tests on those PRs which include tests.
With this fix, tests will run on those PRs also in which only task yaml is changed

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
