### PR TITLE
Fix helm-upgrade-from-repo tests

### DIFF
--- a/task/helm-upgrade-from-repo/0.1/samples/helm-upgrade-from-repo-task-run.yaml.tmpl
+++ b/task/helm-upgrade-from-repo/0.1/samples/helm-upgrade-from-repo-task-run.yaml.tmpl
@@ -7,7 +7,7 @@ spec:
     name: helm-upgrade-from-repo
   params:
   - name: helm_repo
-    value: https://kubernetes-charts.storage.googleapis.com
+    value: https://charts.helm.sh/stable
   - name: chart_name
     value: stable/envoy
   - name: release_version

--- a/task/helm-upgrade-from-repo/0.1/tests/run.yaml
+++ b/task/helm-upgrade-from-repo/0.1/tests/run.yaml
@@ -12,7 +12,7 @@ spec:
         name: helm-upgrade-from-repo
       params:
         - name: helm_repo
-          value: https://kubernetes-charts.storage.googleapis.com
+          value: https://charts.helm.sh/stable
         - name: chart_name
           value: stable/envoy
         - name: release_version


### PR DESCRIPTION
# Changes

repo "https://kubernetes-charts.storage.googleapis.com" is no longer available
so changing to "https://charts.helm.sh/stable"

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
