### PR TITLE
buildah: add a new 0.3 version removing privileged

### DIFF
--- a/task/buildah/0.3/README.md
+++ b/task/buildah/0.3/README.md
@@ -1,0 +1,63 @@
+# Buildah
+
+This Task builds source into a container image using Project Atomic's
+[Buildah](https://github.com/projectatomic/buildah) build tool. It uses
+Buildah's support for building from
+[`Dockerfile`](https://docs.docker.com/engine/reference/builder/)s, using its
+`buildah bud` command. This command executes the directives in the `Dockerfile`
+to assemble a container image, then pushes that image to a container registry.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/buildah/0.3/buildah.yaml
+```
+
+## Parameters
+
+* **IMAGE**: The name (reference) of the image to build.
+* **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
+  note below.  (_default:_ quay.io/buildah/stable:v1.15.1)
+* **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
+  `./Dockerfile`)
+* **CONTEXT**: Path to the directory to use as context (_default:_
+  `.`)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+* **FORMAT**: The format of the built container, oci or docker (_default:_
+ `oci`)
+* **BUILD_EXTRA_ARGS**: Extra parameters passed for the build command when
+  building images. (_default:_ `""`)
+* **PUSH_EXTRA_ARGS**: Extra parameters passed for the push command when
+  pushing images. (_default:_ `""`)
+* **STORAGE_DRIVER**: Set build storage driver to use (_default:_ `"vfs"`_)
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing the source to build.
+* **sslcertdir**: An [*optional* Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry. Buildah will look for files ending with *.crt, *.cert, *.key into this workspace. See [this sample](./samples/openshift-internal-registry.yaml) for a complete example on how to use it with OpenShift internal registry.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Buildah.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: buildah-build-my-repo
+spec:
+  taskRef:
+    name: buildah
+  params:
+  - name: IMAGE
+    value: gcr.io/my-repo/my-image
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+In this example, the Git repo being built is expected to have a `Dockerfile` at
+the root of the repository.

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+spec:
+  description: >-
+    Buildah task builds source into a container image and
+    then pushes it to a container registry.
+
+    Buildah Task builds source into a container image using Project Atomic's
+    Buildah build tool.It uses Buildah's support for building from Dockerfiles,
+    using its buildah bud command.This command executes the directives in the
+    Dockerfile to assemble a container image, then pushes that image to a
+    container registry.
+
+  params:
+  - name: IMAGE
+    description: Reference of the image buildah will produce.
+  - name: BUILDER_IMAGE
+    description: The location of the buildah builder image.
+    default: quay.io/buildah/stable:v1.21.0
+  - name: STORAGE_DRIVER
+    description: Set buildah storage driver
+    default: vfs
+  - name: DOCKERFILE
+    description: Path to the Dockerfile to build.
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: Path to the directory to use as context.
+    default: .
+  - name: TLSVERIFY
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    default: "true"
+  - name: FORMAT
+    description: The format of the built container, oci or docker
+    default: "oci"
+  - name: BUILD_EXTRA_ARGS
+    description: Extra parameters passed for the build command when building images.
+    default: ""
+  - name: PUSH_EXTRA_ARGS
+    description: Extra parameters passed for the push command when pushing images.
+    type: string
+    default: ""
+  workspaces:
+  - name: source
+  - name: sslcertdir
+    optional: true
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+  steps:
+  - name: build
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)
+    script: |
+      [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+      buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) bud \
+        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+        --tls-verify=$(params.TLSVERIFY) --no-cache \
+        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    # buildah assumes needs to be running as root, which means this example fails on platforms
+    # that default to run containers as random uid (like OpenShift). Adding this securityContext
+    # makes it explicit that it needs to run as root.
+    securityContext:
+      runAsUser: 0
+  - name: push
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)
+    script: |
+      [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+      buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) push \
+        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+        docker://$(params.IMAGE)
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    # buildah assumes needs to be running as root, which means this example fails on platforms
+    # that default to run containers as random uid (like OpenShift). Adding this securityContext
+    # makes it explicit that it needs to run as root.
+    securityContext:
+      runAsUser: 0
+  - name: digest-to-results
+    image: $(params.BUILDER_IMAGE)
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+  volumes:
+  - name: varlibcontainers
+    emptyDir: {}

--- a/task/buildah/0.3/samples/openshift-internal-registry.yaml
+++ b/task/buildah/0.3/samples/openshift-internal-registry.yaml
@@ -1,0 +1,86 @@
+# Your custom CA, on OpenShift to be able to get the internal registry custom
+# certificates you can just import it to your namespace with :
+# oc get configmaps \
+#   -n openshift-controller-manager openshift-service-ca -o yaml | \
+#   sed '/namespace/d'|kubectl apply -f-
+---
+kind: ConfigMap
+metadata:
+  name: openshift-service-ca
+apiVersion: v1
+data:
+  service-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDUTCCAjmgAwIBAgIIUaNbmFRnX2gwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UE
+    Awwrb3BlbnNoaWZ0LXNlcnZpY2Utc2VydmluZy1zaWduZXJAMTYwMzczMDU0MTAe
+    Fw0yMDEwMjYxNjQyMjFaFw0yMjEyMjUxNjQyMjJaMDYxNDAyBgNVBAMMK29wZW5z
+    aGlmdC1zZXJ2aWNlLXNlcnZpbmctc2lnbmVyQDE2MDM3MzA1NDEwggEiMA0GCSqG
+    SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHNbOTMqKCISgRiq2LW2SPFBUcg9etDLqP
+    A9fwOVJPxRW5FpyRS9k9g28WpCi7jjf/Um5sid+AO4QkZ2bnHcGAtSq75bIHkYsh
+    sNVlfeQlJ1pcxAyxspUr/SFyQ63HmVcH/Xw9MRASE3TmPp/KYRNMT3Yz+sZOzhiz
+    mczxvzpxF26Vz/YzlSfzDDe6B8lT8Dv+s/Hnx/cBKFw53Q0U5VbBpbCuGLMG9VoQ
+    kog79skdY9aNF83wNH9V2DMb9Yzqf3IFFgfBlQQbqc6C2AutWDLzzyHWXs+Oa4E3
+    /ovdskwGP9/TKgF7zgbqAZLKhtch24m/SVY7cuJpzKRJ4gQ7ff21AgMBAAGjYzBh
+    MA4GA1UdDwEB/wQEAwICpDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT1jpOw
+    4Tz/bifAgNYCP6JH3J3tyjAfBgNVHSMEGDAWgBT1jpOw4Tz/bifAgNYCP6JH3J3t
+    yjANBgkqhkiG9w0BAQsFAAOCAQEAqYZqX/qMXxOUuiBcd+LawuL8eCYyvcbV6jWW
+    /j3Evko1WznrXyHnTeDLsOUt4gS9VeftqzIBFdWMJ58pmX68/dZxuZJNZq+GOMQn
+    Pxjz7s+xoHPqE6YH+YPMLJfCbHzuqfKH872jN+dilxR4gUCSrCFQMOdkAz5cy5JX
+    Ktor0wWhOTJuioC2RfOuh1PG+7jOTUf/6H5fnxzRN7aAyAd0sA4n3r2jN7ypfRKg
+    jOBL06I4xPicJJAH/K2Uq03Y8dT7xVJY2WAKg/+K4uxRgQlbCKT9oj7An4zyheMP
+    0MFG1w4cfO/2p/IVZMG7QZyIfCywuhFH9L3x9q1C5qrw0RGSsw==
+    -----END CERTIFICATE-----
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: buildah-custom-ca-
+spec:
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  # Make sure the path ends up as ca.crt or buildah would not be able to find
+  # it.
+  - name: sslcertdir
+    configMap:
+      name: openshift-service-ca
+      defaultMode: 420
+      items:
+      - key: service-ca.crt
+        path: ca.crt
+      namespace: openshift-controller-manager
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+        - name: output
+          workspace: shared-workspace
+        params:
+        - name: url
+          value: https://github.com/kelseyhightower/nocode
+      - name: buildah
+        taskRef:
+          name: buildah
+        runAfter:
+        - fetch-repository
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: sslcertdir
+          workspace: sslcertdir
+        params:
+        # This will push to the openshift internal registry
+        - name: IMAGE
+          value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(context.pipelineRun.name)

--- a/task/buildah/0.3/tests/internal-registry/internal-registry.yaml
+++ b/task/buildah/0.3/tests/internal-registry/internal-registry.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+spec:
+  selector:
+    matchLabels:
+      run: registry
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: registry
+    spec:
+      containers:
+      - name: registry
+        image: docker.io/registry:2
+        ports:
+        - containerPort: 5000
+        volumeMounts:
+          - name: sslcert
+            mountPath: /certs
+        env:
+          - name: REGISTRY_HTTP_TLS_CERTIFICATE
+            value: "/certs/ca.crt"
+          - name: REGISTRY_HTTP_TLS_KEY
+            value: "/certs/ca.key"
+          - name: REGISTRY_HTTP_SECRET
+            value: "tekton"
+      volumes:
+        - name: sslcert
+          configMap:
+            defaultMode: 420
+            items:
+            - key: ca.crt
+              path: ca.crt
+            - key: ca.key
+              path: ca.key
+            name: sslcert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+spec:
+  ports:
+  - port: 5000
+  selector:
+    run: registry

--- a/task/buildah/0.3/tests/pre-apply-task-hook.sh
+++ b/task/buildah/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+TMD=$(mktemp -d)
+
+# Generate SSL Certificate
+openssl req -newkey rsa:4096 -nodes -sha256 -keyout "${TMD}"/ca.key -x509 -days 365 \
+        -out "${TMD}"/ca.crt -subj "/C=FR/ST=IDF/L=Paris/O=Tekton/OU=Catalog/CN=registry"
+
+# Create a configmap from these certs
+kubectl create -n "${tns}" configmap sslcert \
+        --from-file=ca.crt="${TMD}"/ca.crt --from-file=ca.key="${TMD}"/ca.key
+
+# Add a secure internal registry as sidecar
+kubectl create -n "${tns}" -f task/buildah/0.2/tests/internal-registry/internal-registry.yaml
+
+# Add git-clone
+add_task git-clone latest

--- a/task/buildah/0.3/tests/run.yaml
+++ b/task/buildah/0.3/tests/run.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildah-test-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    - name: buildah
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: sslcertdir
+        workspace: sslcertdir
+      params:
+      - name: IMAGE
+        value: registry:5000/nocode
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: sslcertdir
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+      - key: ca.crt
+        path: ca.crt


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Using the `vfs` storage driver in a container is similar to using
`overlay` but has the benefit to not require the `privileged`
securityContext.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
