### PR TITLE
Skipping maven tests in CI

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -49,7 +49,7 @@ TEST_YAML_IGNORES=${TEST_YAML_IGNORES:-""}
 
 # Allow ignoring some yaml tests, space separated, should be the basename of the
 # test for example "s2i"
-TEST_TASKRUN_IGNORES=${TEST_TASKRUN_IGNORES:-""}
+TEST_TASKRUN_IGNORES=${TEST_TASKRUN_IGNORES:-"maven"}
 
 # Define this variable if you want to run all tests and not just the modified one.
 TEST_RUN_ALL_TESTS=${TEST_RUN_ALL_TESTS:-""}


### PR DESCRIPTION
# Changes

Since maven task is being flaky thus skipping that in the e2e tests for now.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
