### PR TITLE
Change test repo to cli from pipeline in golang-test task

### DIFF
--- a/task/golang-test/0.1/tests/run.yaml
+++ b/task/golang-test/0.1/tests/run.yaml
@@ -15,7 +15,7 @@ spec:
           workspace: shared-workspace
       params:
         - name: url
-          value: https://github.com/tektoncd/pipeline
+          value: https://github.com/tektoncd/cli
         - name: subdirectory
           value: ""
         - name: deleteExisting
@@ -30,7 +30,7 @@ spec:
           workspace: shared-workspace
       params:
         - name: package
-          value: github.com/tektoncd/pipeline
+          value: github.com/tektoncd/cli
 
 ---
 apiVersion: tekton.dev/v1beta1


### PR DESCRIPTION
This will change the golang-test task tests to use cli repo for
unit test rather than pipeline repo as the test is failing there


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
