### PR TITLE
Add set of modular Orka tasks

### DIFF
--- a/task/orka-deploy/0.1/README.md
+++ b/task/orka-deploy/0.1/README.md
@@ -1,0 +1,108 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task`, along with `orka-init` and `orka-teardown`, allows you to utilize multiple macOS build agents in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-deploy`
+
+A `Task` that deploys a VM instance from a specified VM template. Usually, you would use the VM template created with `orka-init`.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/master/task/orka-init/0.1/README.md#installation) for more information on setting up the Orka API configuration.
+
+```sh
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-deploy/0.1/orka-deploy.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+## Storing SSH credentials
+
+The `orka-deploy` task looks for a Kubernetes secret that stores the SSH access credentials for your macOS base image. This secret is called `orka-ssh-creds` by default and is expected to have the keys `username` and `password`.
+
+These defaults exist for convenience, and you can change them using the available [`Task` parameters](#Configuring-Secrets-and-Config-Maps).
+
+You can use the following example configuration. Make sure to provide the correct credentials for your base image.
+
+```yaml
+# orka-ssh-creds.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-ssh-creds.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+### Using an SSH key
+
+If using an SSH key to connect to the VM instead of an SSH username and password, complete the following:
+
+1. Copy the public key to the VM and commit the base image.
+2. Store the username and private key in a Kubernetes secret:
+
+```sh
+kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+```
+
+See also: [use-ssh-key.yaml](https://github.com/tektoncd/catalog/blob/master/task/orka-deploy/0.1/samples/use-ssh-key.yaml) example
+
+## Workspaces
+
+* **orka**: The contents of this workspace will be copied to the deployed VM. All files present in the workspace will be available to the build script run inside the VM. For example, you could clone a git repository containing Objective-C or Swift code in a previous pipeline step and run a build with Xcode command line tools in your build script. If the `copy-build` parameter is set to true, all build artifacts will be copied from the VM back to the workspace.
+
+## Parameters
+
+### Common parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `script` | The script to run inside of the VM. The script will be prepended with `#!/bin/sh` and `set -ex` if no shebang is present. You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby). | --- |
+| `copy-build` | Specifies whether to copy build artifacts from the Orka VM back to the workspace. Disable when there is no need to copy build artifacts (e.g., when running tests or linting code). | true |
+| `verbose` | Enables verbose logging for all connection activity to the VM. | false |
+| `ssh-key` | Specifies whether the SSH credentials secret contains an [SSH key](#using-an-ssh-key), as opposed to a password. | false |
+| `delete-vm` | Specifies whether to delete the VM after use when run in a pipeline. You can discard build agents that are no longer needed to free up resources. Set to false if you intend to clean up VMs after use manually. | true |
+
+### Configuring secrets and config maps
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `ssh-secret` | The name of the secret holding your VM SSH credentials. | orka-ssh-creds |
+| `ssh-username-key` | The name of the key in the VM SSH credentials secret for the username associated with the macOS VM. | username |
+| `ssh-password-key` | The name of the key in the VM SSH credentials secret for the password associated with the macOS VM. If `ssh-key` is true, this parameter should specify the name of the key in the VM SSH credentials secret that holds the private SSH key. | password |
+| `orka-token-secret` | The name of the secret holding the authentication token used to access the Orka API. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-token |
+| `orka-token-secret-key` | The name of the key in the Orka token secret, which holds the authentication token. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | token |
+| `orka-vm-name-config` | The name of the config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-vm-name |
+| `orka-vm-name-config-key` | The name of the key in the VM name config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | vm-name |
+
+## Samples
+
+[parallel-deploy.yaml](https://github.com/tektoncd/catalog/blob/master/task/orka-deploy/0.1/samples/parallel-deploy.yaml) is a sample `Pipeline` that uses the `orka-init`, `orka-deploy`, and `orka-teardown` tasks and performs the following operations:
+1. Sets up an Orka job runner.
+2. Deploys 2 VMs in parallel and executes a different script on each VM.
+3. Cleans up the environment.

--- a/task/orka-deploy/0.1/orka-deploy.yaml
+++ b/task/orka-deploy/0.1/orka-deploy.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-deploy
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/tags: "orka, macstadium, deploy, build"
+    tekton.dev/displayName: "MacStadium Orka Deploy"
+spec:
+  description: >-
+    With this set of Tasks, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task deploys a VM instance from a specified VM template.
+    Usually, you would use the VM template created with `orka-init`.
+  params:
+    - name: script
+      type: string
+      description: |
+        The script to run inside of the VM. The script will be prepended with the following
+        if no shebang is present:
+
+        #!/bin/sh
+        set -ex
+
+        You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby).
+    - name: copy-build
+      type: string
+      description: |
+        Specifies whether to copy build artifacts from the Orka VM back to the workspace.
+        Disable when there is no need to copy build artifacts (e.g., when running tests or linting code).
+      default: "true"
+    - name: verbose
+      type: string
+      description: Enables verbose logging for all connection activity to the VM.
+      default: "false"
+    - name: delete-vm
+      type: string
+      description: |
+        Specifies whether to delete the VM after use when run in a pipeline.
+        You can discard build agents that are no longer needed to free up resources.
+
+        Set to false if you intend to clean up VMs after use manually.
+      default: "true"
+    - name: ssh-key
+      type: string
+      description: |
+        Specifies whether the SSH credentials secret contains an SSH key, as opposed to a password.
+      default: "false"
+    - name: ssh-secret
+      type: string
+      description: The name of the secret holding your VM SSH credentials.
+      default: orka-ssh-creds
+    - name: ssh-username-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the username associated with the macOS VM.
+      default: username
+    - name: ssh-password-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the password
+        associated with the macOS VM.
+
+        If ssh-key is true, this parameter should specify the name of the key in
+        the VM SSH credentials secret that holds the private SSH key.
+      default: password
+    - name: orka-token-secret
+      type: string
+      description: |
+        The name of the secret holding the authentication token used to access the Orka API.
+      default: orka-token
+    - name: orka-token-secret-key
+      type: string
+      description: |
+        The name of the key in the Orka token secret, which holds the authentication token.
+      default: token
+    - name: orka-vm-name-config
+      type: string
+      description: |
+        The name of the config map, which stores the name of the generated VM configuration.
+      default: orka-vm-name
+    - name: orka-vm-name-config-key
+      type: string
+      description: |
+        The name of the key in the VM name config map, which stores the name of the generated VM configuration.
+      default: vm-name
+  steps:
+    - name: copy-script
+      image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      script: |
+        #!/bin/sh
+        SCRIPT=$(mktemp)
+        # Safeguard against having to escape quotes / vars in script
+        cat > $SCRIPT << 'EOF'
+        $(params.script)
+        EOF
+        copy-script $SCRIPT
+    - name: build
+      image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: VERBOSE
+          value: $(params.verbose)
+        - name: DELETE_VM
+          value: $(params.delete-vm)
+        - name: COPY_BUILD
+          value: $(params.copy-build)
+        - name: SSH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.ssh-secret)
+              key: $(params.ssh-username-key)
+        - name: SSH_PASSFILE
+          value: /etc/$(params.ssh-secret)/$(params.ssh-password-key)
+        - name: SSH_KEY
+          value: $(params.ssh-key)
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-token-secret)
+              key: $(params.orka-token-secret-key)
+        - name: VM_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: $(params.orka-vm-name-config)
+              key: $(params.orka-vm-name-config-key)
+      volumeMounts:
+        - name: ssh-creds
+          readOnly: true
+          mountPath: /etc/$(params.ssh-secret)
+      script: |
+        #!/bin/sh
+        set -x
+        orka-deploy
+  volumes:
+    - name: ssh-creds
+      secret:
+        secretName: $(params.ssh-secret)
+        items:
+          - key: $(params.ssh-password-key)
+            path: $(params.ssh-password-key)
+            mode: 256
+  workspaces:
+    - name: orka

--- a/task/orka-deploy/0.1/samples/parallel-deploy.yaml
+++ b/task/orka-deploy/0.1/samples/parallel-deploy.yaml
@@ -1,0 +1,66 @@
+# ###
+# This example shows how to deploy multiple Orka VMs in a Pipeline.
+# In this scenario, the VMs will be run in parallel and run two different jobs.
+#
+# The orka-init and orka-teardown Tasks require a Kubernetes service account with
+# permission to create / delete secrets and config maps. See the README for more
+# information.
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: parallel-deploy
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: setup
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: catalina-ssh-30G.img
+    - name: diskinfo
+      retries: 1
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: copy-build
+          value: "false"
+        - name: script
+          value: |
+            diskutil info /
+      workspaces:
+        - name: orka
+          workspace: shared-data
+    - name: ruby
+      retries: 1
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: copy-build
+          value: "false"
+        - name: script
+          value: |
+            #!/usr/bin/env ruby
+            puts "Hello macOS"
+      workspaces:
+        - name: orka
+          workspace: shared-data
+  finally:
+    - name: cleanup
+      taskRef:
+        name: orka-teardown
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-parallel-deploy
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: parallel-deploy
+  workspaces:
+    - name: shared-data
+      emptyDir: {}

--- a/task/orka-deploy/0.1/samples/use-ssh-key.yaml
+++ b/task/orka-deploy/0.1/samples/use-ssh-key.yaml
@@ -1,0 +1,65 @@
+# ###
+# This example demonstrates how to use an SSH key to connect to the Orka VM.
+# You will first need to copy the public key to the VM and commit or save an
+# image using `orka image commit` or `orka image save` and specify that base image.
+# in the TaskRun or Pipeline as a param.
+#
+# You must specify the Task param ssh-key="true" in order to use an SSH key.
+#
+# ###
+# You can create a Kubernetes secret with the SSH credentials as follows:
+# kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: use-ssh-key
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: setup
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: catalina-ssh-key-30G.img
+    - name: hello-macos
+      retries: 1
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: ssh-secret
+          value: orka-ssh-key
+        - name: ssh-password-key
+          value: id_rsa
+        - name: ssh-key
+          value: "true"
+        - name: verbose
+          value: "true"
+        - name: copy-build
+          value: "false"
+        - name: script
+          value: |
+            #!/usr/bin/env ruby
+            puts "Hello macOS"
+      workspaces:
+        - name: orka
+          workspace: shared-data
+  finally:
+    - name: cleanup
+      taskRef:
+        name: orka-teardown
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-use-ssh-key
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: use-ssh-key
+  workspaces:
+    - name: shared-data
+      emptyDir: {}

--- a/task/orka-deploy/0.1/tests/mocks/orka.yaml
+++ b/task/orka-deploy/0.1/tests/mocks/orka.yaml
@@ -1,0 +1,32 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/deploy
+response:
+  status: 200
+  output: '{"ip": "localhost", "ssh_port": "22", "vm_id": "wxyz"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/delete
+response:
+  status: 200
+  output: '{"message": "Successfully deleted VM"}'
+  content-type: text/json

--- a/task/orka-deploy/0.1/tests/mods/mod_task.py
+++ b/task/orka-deploy/0.1/tests/mods/mod_task.py
@@ -1,0 +1,45 @@
+import os, sys, yaml
+
+def str_presenter(dumper, data):
+  scalar_style = "|" if len(data.splitlines()) > 1 else None
+  return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=scalar_style)
+
+yaml.add_representer(str, str_presenter)
+
+if __name__ == "__main__":
+    # Load YAML files
+    with open(os.path.join(sys.path[0], "..", "mocks", "orka.yaml"), "r", encoding="utf-8") as f:
+        mocks = f.read()
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    go_rest_api = [
+        {
+            "name": "go-rest-api",
+            "image": "quay.io/chmouel/go-rest-api-test",
+            "env": [
+                {
+                    "name": "CONFIG",
+                    "value": mocks
+                }
+            ]
+        }
+    ]
+
+    # Modify Task YAML
+    if data["metadata"]["name"] == "orka-deploy":
+        # Load YAML files
+        with open(os.path.join(sys.path[0], "sidecars.yaml"), "r", encoding="utf-8") as f:
+            sidecars = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+        with open(os.path.join(sys.path[0], "volumes.yaml"), "r", encoding="utf-8") as f:
+            volumes = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+        data["spec"]["volumes"] += volumes
+        data["spec"]["sidecars"] = sidecars + go_rest_api
+    else:
+        data["spec"]["sidecars"] = go_rest_api
+
+    # Dump YAML
+    print(yaml.dump(data, default_flow_style=False))

--- a/task/orka-deploy/0.1/tests/mods/sidecars.yaml
+++ b/task/orka-deploy/0.1/tests/mods/sidecars.yaml
@@ -1,0 +1,12 @@
+---
+- name: ssh-server
+  image: panubo/sshd:1.3.0
+  env:
+    - name: "SSH_USERS"
+      value: "admin:1000:1000"
+    - name: "SSH_ENABLE_PASSWORD_AUTH"
+      value: "true"
+  volumeMounts:
+    - name: startup-script
+      mountPath: "/etc/entrypoint.d"
+      readOnly: true

--- a/task/orka-deploy/0.1/tests/mods/volumes.yaml
+++ b/task/orka-deploy/0.1/tests/mods/volumes.yaml
@@ -1,0 +1,8 @@
+---
+- name: startup-script
+  configMap:
+    name: ssh-scripts
+    items:
+      - key: "startup-script"
+        path: "startup.sh"
+        mode: 448

--- a/task/orka-deploy/0.1/tests/pre-apply-task-hook.sh
+++ b/task/orka-deploy/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Modify orka-init
+ORKA_INIT=$(mktemp /tmp/.mm.XXXXXX)
+MOD_SCRIPT=${taskdir}/tests/mods/mod_task.py
+cp task/orka-init/0.1/orka-init.yaml ${ORKA_INIT}
+python3 ${MOD_SCRIPT} ${ORKA_INIT} > ${ORKA_INIT}.mod
+
+# Add orka-init
+${KUBECTL_CMD} -n "${tns}" apply -f ${ORKA_INIT}.mod
+rm -f ${ORKA_INIT} ${ORKA_INIT}.mod
+
+# Modify task
+cp ${TMPF} ${TMPF}.read
+python3 ${MOD_SCRIPT} ${TMPF}.read > ${TMPF}
+rm -f ${TMPF}.read

--- a/task/orka-deploy/0.1/tests/resources.yaml
+++ b/task/orka-deploy/0.1/tests/resources.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssh-scripts
+data:
+  startup-script: |
+    #!/usr/bin/env bash
+    set -e
+    echo "admin:admin" | chpasswd
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: orka-deploy-0-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner-deploy
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner-deploy
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: orka-deploy-0-1
+roleRef:
+  kind: ClusterRole
+  name: orka-runner-deploy
+  apiGroup: rbac.authorization.k8s.io

--- a/task/orka-deploy/0.1/tests/run.yaml
+++ b/task/orka-deploy/0.1/tests/run.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: orka-deploy-test
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: init
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: base-image.img
+    - name: deploy
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: copy-build
+          value: "false"
+        - name: verbose
+          value: "true"
+        - name: script
+          value: |
+            echo "Hello from TektonCD test"
+      workspaces:
+        - name: orka
+          workspace: shared-data
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: orka-deploy-test-run
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: orka-deploy-test
+  workspaces:
+    - name: shared-data
+      emptyDir: {}

--- a/task/orka-deploy/OWNERS
+++ b/task/orka-deploy/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- spikeburton
+- Tmoss11
+- ispasov
+reviewers:
+- spikeburton
+- Tmoss11
+- ispasov

--- a/task/orka-init/0.1/README.md
+++ b/task/orka-init/0.1/README.md
@@ -1,0 +1,148 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task`, along with `orka-deploy` and `orka-teardown`, allows you to utilize multiple macOS build agents in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-init`
+
+A `Task` that creates a VM template with the specified configuration. All operations in this `Task` are performed against an Orka environment.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+* For the `orka-init` and `orka-teardown` tasks, you need a Kubernetes service account, a cluster role, and a cluster role binding. See [Kubernetes service account setup](#kubernetes-service-account-setup).
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster.
+
+You can use the following sample `orka-configuration.yaml`. Make sure to provide the correct Orka API endpoint for your Orka environment.
+
+```yaml
+# orka-configuration.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://10.221.188.100
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-configuration.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-init/0.1/orka-init.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+## Kubernetes service account setup
+
+To use the `orka-init` and `orka-teardown` tasks, you need to configure a Kubernetes service account, a cluster role, and a cluster role binding.
+
+You can use the following sample:
+
+```yaml
+# orka-runner.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: orka-runner
+  apiGroup: rbac.authorization.k8s.io
+```
+
+```sh
+kubectl apply -f orka-runner.yaml
+```
+
+Make sure to specify the namespace in which the `orka-init` and `orka-teardown` tasks are installed when declaring the `ServiceAccount` and `ClusterRoleBinding`.
+
+## Storing your credentials
+
+The `orka-init` task looks for a Kubernetes secret that stores your Orka user credentials. This secret is called `orka-creds` by default and is expected to have the keys `email` and `password`.
+
+These defaults exist for convenience, and you can change them using the available [`Task` parameters](#Configuring-Secrets-and-Config-Maps).
+
+You can use the following example configuration. Make sure to provide the correct credentials for your Orka environment.
+
+```yaml
+# orka-creds.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-creds.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+> **NOTE:** These credentials are used by the `orka-init` task to generate an authentication token to access the Orka API. This authentication token is then used by the `orka-deploy` and `orka-teardown` tasks for all API calls.
+
+## Parameters
+
+### Common parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `base-image` | The Orka base image to use for the VM config. | --- |
+| `cpu-count` | The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24. | 3 |
+| `vcpu-count` | The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3. Otherwise, must equal half of or exactly the number of CPUs specified. | 3 |
+| `vnc-console` | Enables or disables VNC for the VM. | false |
+
+### Configuring secrets and config maps
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `orka-creds-secret` | The name of the secret holding your Orka credentials. | orka-creds |
+| `orka-creds-email-key` | The name of the key in the Orka user credentials secret for the email address associated with the Orka user. | email |
+| `orka-creds-password-key` | The name of the key in the Orka credentials secret for the password associated with the Orka user. | password |
+| `orka-token-secret` | The name of the secret holding the authentication token used to access the Orka API. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-token |
+| `orka-token-secret-key` | The name of the key in the Orka token secret, which holds the authentication token. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | token |
+| `orka-vm-name-config` | The name of the config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-vm-name |
+| `orka-vm-name-config-key` | The name of the key in the VM name config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | vm-name |

--- a/task/orka-init/0.1/orka-init.yaml
+++ b/task/orka-init/0.1/orka-init.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-init
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/tags: "orka, macstadium, init, setup"
+    tekton.dev/displayName: "MacStadium Orka Init"
+spec:
+  description: >-
+    With this set of Tasks, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task creates a VM template with the specified configuration.
+    All operations in this Task are performed against an Orka environment.
+  params:
+    - name: base-image
+      type: string
+      description: The Orka base image to use for the VM config.
+    - name: cpu-count
+      type: string
+      description: |
+        The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24.
+      default: "3"
+    - name: vcpu-count
+      type: string
+      description: |
+        The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3.
+        Otherwise, must equal half of or exactly the number of CPUs specified.
+      default: "3"
+    - name: vnc-console
+      type: string
+      description: Enables or disables VNC for the VM.
+      default: "true"
+    - name: orka-creds-secret
+      type: string
+      description: The name of the secret holding your Orka credentials.
+      default: orka-creds
+    - name: orka-creds-email-key
+      type: string
+      description: |
+        The name of the key in the Orka user credentials secret for the email address associated with the Orka user.
+      default: email
+    - name: orka-creds-password-key
+      type: string
+      description: |
+        The name of the key in the Orka credentials secret for the password associated with the Orka user.
+      default: password
+    - name: orka-token-secret
+      type: string
+      description: |
+        The name of the secret holding the authentication token used to access the Orka API.
+      default: orka-token
+    - name: orka-token-secret-key
+      type: string
+      description: |
+        The name of the key in the Orka token secret, which holds the authentication token.
+      default: token
+    - name: orka-vm-name-config
+      type: string
+      description: |
+        The name of the config map, which stores the name of the generated VM configuration.
+      default: orka-vm-name
+    - name: orka-vm-name-config-key
+      type: string
+      description: |
+        The name of the key in the VM name config map, which stores the name of the generated VM configuration.
+      default: vm-name
+  steps:
+    - name: init
+      image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: BASE_IMAGE
+          value: $(params.base-image)
+        - name: CPU_COUNT
+          value: $(params.cpu-count)
+        - name: VCPU_COUNT
+          value: $(params.vcpu-count)
+        - name: VNC_CONSOLE
+          value: $(params.vnc-console)
+        - name: SVC_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-email-key)
+        - name: SVC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-password-key)
+      script: |
+        #!/bin/sh
+        set -x
+        orka-init
+        if [ $? -ne 0 ]; then
+          orka-cleanup
+          exit 1
+        fi
+        TOKEN=/etc/orka-token
+        VM_NAME=/etc/orka-vm-name
+        if [ -f "$TOKEN" ] && [ -f "$VM_NAME" ]; then
+          kubectl delete secret $(params.orka-token-secret) --ignore-not-found
+          kubectl create secret generic $(params.orka-token-secret) \
+            --from-file=$(params.orka-token-secret-key)=$TOKEN
+          kubectl delete configmap $(params.orka-vm-name-config) --ignore-not-found
+          kubectl create configmap $(params.orka-vm-name-config) \
+            --from-file=$(params.orka-vm-name-config-key)=$VM_NAME
+        else
+          echo "fatal: could not create resources!"
+          orka-cleanup
+          exit 1
+        fi

--- a/task/orka-init/0.1/tests/fixtures/orka.yaml
+++ b/task/orka-init/0.1/tests/fixtures/orka.yaml
@@ -1,0 +1,16 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json

--- a/task/orka-init/0.1/tests/resources.yaml
+++ b/task/orka-init/0.1/tests/resources.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: orka-init-0-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner-init
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner-init
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: orka-init-0-1
+roleRef:
+  kind: ClusterRole
+  name: orka-runner-init
+  apiGroup: rbac.authorization.k8s.io

--- a/task/orka-init/0.1/tests/run.yaml
+++ b/task/orka-init/0.1/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: orka-init-test-run
+spec:
+  serviceAccountName: orka-svc
+  taskRef:
+    name: orka-init
+  params:
+    - name: base-image
+      value: base-image.img

--- a/task/orka-init/OWNERS
+++ b/task/orka-init/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- spikeburton
+- Tmoss11
+- ispasov
+reviewers:
+- spikeburton
+- Tmoss11
+- ispasov

--- a/task/orka-teardown/0.1/README.md
+++ b/task/orka-teardown/0.1/README.md
@@ -1,0 +1,49 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task`, along with `orka-init` and `orka-deploy`, allows you to utilize multiple macOS build agents in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-teardown`
+
+A `Task` that cleans up the Orka environment after your workload completes. This `Task` deletes the VM instances deployed with `orka-deploy` and their related template.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+* For the `orka-init` and `orka-teardown` tasks, you need a Kubernetes service account, a cluster role, and a cluster role binding. See [Kubernetes service account setup](#kubernetes-service-account-setup).
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/master/task/orka-init/0.1/README.md#installation) for more information on setting up the Orka API configuration.
+
+```sh
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-teardown/0.1/orka-teardown.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+## Kubernetes service account setup
+
+To use the `orka-init` and `orka-teardown` tasks, you need to configure a Kubernetes service account, a cluster role, and a cluster role binding.
+
+See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/master/task/orka-init/0.1/README.md#kubernetes-service-account-setup) for more information on setting up a service account.
+
+## Parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `orka-token-secret` | The name of the secret holding the authentication token used to access the Orka API. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-token |
+| `orka-token-secret-key` | The name of the key in the Orka token secret, which holds the authentication token. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | token |
+| `orka-vm-name-config` | The name of the config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-vm-name |
+| `orka-vm-name-config-key` | The name of the key in the VM name config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | vm-name |

--- a/task/orka-teardown/0.1/orka-teardown.yaml
+++ b/task/orka-teardown/0.1/orka-teardown.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-teardown
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/tags: "orka, macstadium, teardown, cleanup"
+    tekton.dev/displayName: "MacStadium Orka Teardown"
+spec:
+  description: >-
+    With this set of Tasks, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task cleans up the Orka environment after your workload completes.
+    This Task deletes the VM instances deployed with `orka-deploy` and their related templates.
+  params:
+    - name: orka-token-secret
+      type: string
+      description: |
+        The name of the secret holding the authentication token used to access the Orka API.
+      default: orka-token
+    - name: orka-token-secret-key
+      type: string
+      description: |
+        The name of the key in the Orka token secret, which holds the authentication token.
+      default: token
+    - name: orka-vm-name-config
+      type: string
+      description: |
+        The name of the config map, which stores the name of the generated VM configuration.
+      default: orka-vm-name
+    - name: orka-vm-name-config-key
+      type: string
+      description: |
+        The name of the key in the VM name config map, which stores the name of the generated VM configuration.
+      default: vm-name
+  steps:
+    - name: teardown
+      image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-token-secret)
+              key: $(params.orka-token-secret-key)
+        - name: VM_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: $(params.orka-vm-name-config)
+              key: $(params.orka-vm-name-config-key)
+      script: |
+        #!/bin/sh
+        set -x
+        orka-cleanup
+        kubectl delete secret $(params.orka-token-secret) --ignore-not-found
+        kubectl delete configmap $(params.orka-vm-name-config) --ignore-not-found

--- a/task/orka-teardown/0.1/tests/mocks/orka.yaml
+++ b/task/orka-teardown/0.1/tests/mocks/orka.yaml
@@ -1,0 +1,40 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/delete
+response:
+  status: 200
+  output: '{"message": "Successfully deleted VM"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/purge
+response:
+  status: 200
+  output: '{"message": "Successfully purged VM"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /token
+response:
+  status: 200
+  output: '{"tokensRevoked": 1}'
+  content-type: text/json

--- a/task/orka-teardown/0.1/tests/mods/mod_task.py
+++ b/task/orka-teardown/0.1/tests/mods/mod_task.py
@@ -1,0 +1,34 @@
+import os, sys, yaml
+
+def str_presenter(dumper, data):
+  scalar_style = "|" if len(data.splitlines()) > 1 else None
+  return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=scalar_style)
+
+yaml.add_representer(str, str_presenter)
+
+if __name__ == "__main__":
+    # Load YAML files
+    with open(os.path.join(sys.path[0], "..", "mocks", "orka.yaml"), "r", encoding="utf-8") as f:
+        mocks = f.read()
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    go_rest_api = [
+        {
+            "name": "go-rest-api",
+            "image": "quay.io/chmouel/go-rest-api-test",
+            "env": [
+                {
+                    "name": "CONFIG",
+                    "value": mocks
+                }
+            ]
+        }
+    ]
+
+    # Modify Task YAML
+    data["spec"]["sidecars"] = go_rest_api
+
+    # Dump YAML
+    print(yaml.dump(data, default_flow_style=False))

--- a/task/orka-teardown/0.1/tests/pre-apply-task-hook.sh
+++ b/task/orka-teardown/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Modify orka-init
+ORKA_INIT=$(mktemp /tmp/.mm.XXXXXX)
+MOD_SCRIPT=${taskdir}/tests/mods/mod_task.py
+cp task/orka-init/0.1/orka-init.yaml ${ORKA_INIT}
+python3 ${MOD_SCRIPT} ${ORKA_INIT} > ${ORKA_INIT}.mod
+
+# Add orka-init
+${KUBECTL_CMD} -n "${tns}" apply -f ${ORKA_INIT}.mod
+rm -f ${ORKA_INIT} ${ORKA_INIT}.mod
+
+# Modify task
+cp ${TMPF} ${TMPF}.read
+python3 ${MOD_SCRIPT} ${TMPF}.read > ${TMPF}
+rm -f ${TMPF}.read

--- a/task/orka-teardown/0.1/tests/resources.yaml
+++ b/task/orka-teardown/0.1/tests/resources.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: orka-teardown-0-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner-teardown
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner-teardown
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: orka-teardown-0-1
+roleRef:
+  kind: ClusterRole
+  name: orka-runner-teardown
+  apiGroup: rbac.authorization.k8s.io

--- a/task/orka-teardown/0.1/tests/run.yaml
+++ b/task/orka-teardown/0.1/tests/run.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: orka-teardown-test
+spec:
+  tasks:
+    - name: init
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: base-image.img
+    - name: teardown
+      taskRef:
+        name: orka-teardown
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: orka-teardown-test-run
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: orka-teardown-test

--- a/task/orka-teardown/OWNERS
+++ b/task/orka-teardown/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- spikeburton
+- Tmoss11
+- ispasov
+reviewers:
+- spikeburton
+- Tmoss11
+- ispasov


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change adds a set of modular Tasks to integrate Tekton with Orka
by MacStadium. Orka allows users to run macOS builds and workloads on
real Apple hardware. An Orka / Tekton integration will allow the
utilization of macOS build agents for CI jobs that run on Tekton
pipelines.

The tasks orka-init, orka-deploy and orka-teardown are designed to work
together in order to allow the utilization of multiple macOS
build agents in a CI/CD pipeline. The orka-deploy Task allows the user
to provide a build script as a parameter, and will allow the user to
store build artifacts in a Tekton workspace. The orka-init and
orka-teardown tasks create and delete virtual machine configurations.
This is accomplished by making calls to the Orka API running in a
separate Kubernetes cluster over a VPN connection.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
