### PR TITLE
Avoid the usage of PipelineResources from s2i

### DIFF
--- a/task/s2i/0.2/Dockerfile
+++ b/task/s2i/0.2/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+# Install security updates
+RUN yum -y update && yum clean all &&  rm -rf /var/cache/yum && \
+    yum install python3 -y
+
+# Get latest S2I release  from github with some curl+rest+python magic (which is provided by default
+# in the image so wedon't have to install extra packages)
+RUN mkdir -p /usr/local/bin && \
+    curl -L $(curl -L -s "https://api.github.com/repos/openshift/source-to-image/releases/latest"| python3 -c "import sys, json;x=json.load(sys.stdin);print([ r['browser_download_url'] for r in x['assets'] if 'linux-amd64' in r['name']][0])") -o /tmp/s2i.tgz && \
+    tar xz -f/tmp/s2i.tgz -C /usr/local/bin/ && \
+    chmod -R 0755 /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/s2i"]

--- a/task/s2i/0.2/README.md
+++ b/task/s2i/0.2/README.md
@@ -1,0 +1,146 @@
+# Source-to-Image
+
+[Source-to-Image (S2I)](https://github.com/openshift/source-to-image)
+is a toolkit and workflow for building reproducible container images
+from source code. S2I produces images by injecting source code into a
+base S2I container image and letting the container prepare that source
+code for execution. The base S2I container images contains the
+language runtime and build tools needed for building and running the
+source code.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/s2i/0.2/s2i.yaml
+```
+
+## Parameters
+
+- **IMAGE_NAME**: Reference of the image S2I will produce.
+- **BUILDER_IMAGE**: The location of the s2i builder image.
+- **PATH_CONTEXT**: Source path from where s2i command need to be run
+  (_default: ._).
+- **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+
+## Workspaces
+
+- **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing the source to build.
+- **sslcertdir**: An [_optional_ Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry. Buildah will look for files ending with \*.crt, \*.cert, \*.key into this workspace. See [this sample](./samples/openshift-internal-registry.yaml) for a complete example on how to use it with OpenShift internal registry.
+
+## Results
+
+- **IMAGE_DIGEST**: Digest of the image just built.
+
+## ServiceAccount
+
+S2I builds an image and pushes it to the destination registry which is
+defined as a parameter. In order to properly authenticate to the
+remote container registry, it needs to have the proper
+credentials. The credentials can be provided through a service
+account. See
+[Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
+for further details.
+
+If you are running on OpenShift, you also need to allow the service
+account to run privileged containers because OpenShift does not allow
+containers run as privileged containers by default unless explicitly
+configured, due to security considerations.
+
+Run the following in order to create a service account named
+`pipeline` on OpenShift and allow it to run privileged containers:
+
+```bash
+oc create serviceaccount pipeline
+oc adm policy add-scc-to-user privileged -z pipeline
+oc adm policy add-role-to-user edit -z pipeline
+```
+
+## Usage
+
+This PipelineRun runs the Task to fetch a Git repo, and build and push a
+container image using s2i and a nodejs builder image.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: s2i-test-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+      - name: sslcertdir
+        optional: true
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/sclorg/nodejs-ex
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: s2i
+        taskRef:
+          name: s2i
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: shared-workspace
+        params:
+          - name: BUILDER_IMAGE
+            value: quay.io/centos7/nodejs-12-centos7
+          - name: TLSVERIFY
+            value: "false"
+          - name: LOGLEVEL
+            value: "10"
+          - name: IMAGE_NAME
+            value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(context.pipelineRun.name)
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Mi
+```
+
+Here is a non-exhaustive list of well maintained s2i builder image
+(from [`sclorg`](https://github.com/sclorg/)):
+
+- [go](https://github.com/sclorg/golang-container)
+  - [`centos/go-toolset-7-centos7`](https://github.com/sclorg/golang-container)
+- [nodejs](https://github.com/sclorg/s2i-nodejs-container)
+  - [`centos/nodejs-6-centos7`](https://hub.docker.com/r/centos/nodejs-6-centos7)
+  - [`centos/nodejs-8-centos7`](https://hub.docker.com/r/centos/nodejs-8-centos7)
+  - [`centos/nodejs-10-centos7`](https://hub.docker.com/r/centos/nodejs-10-centos7)
+- [perl](https://github.com/sclorg/s2i-perl-container)
+  - [`centos/perl-524-centos7`](https://hub.docker.com/r/centos/perl-524-centos7)
+  - [`centos/perl-526-centos7`](https://hub.docker.com/r/centos/perl-526-centos7)
+- [php](https://github.com/sclorg/s2i-php-container)
+  - [`centos/php-70-centos7`](https://hub.docker.com/r/centos/php-70-centos7)
+  - [`centos/php-71-centos7`](https://hub.docker.com/r/centos/php-71-centos7)
+  - [`centos/php-72-centos7`](https://hub.docker.com/r/centos/php-72-centos7)
+- [python](https://github.com/sclorg/s2i-python-container)
+  - [`centos/python-27-centos7`](https://hub.docker.com/r/centos/python-27-centos7)
+  - [`centos/python-35-centos7`](https://hub.docker.com/r/centos/python-35-centos7)
+  - [`centos/python-36-centos7`](https://hub.docker.com/r/centos/python-36-centos7)
+  - [`centos/python-38-centos7`](https://hub.docker.com/r/centos/python-38-centos7)
+- [ruby](https://github.com/sclorg/s2i-ruby-container)
+  - [`centos/ruby-23-centos7`](https://hub.docker.com/r/centos/ruby-23-centos7)
+  - [`centos/ruby-24-centos7`](https://hub.docker.com/r/centos/ruby-24-centos7)
+  - [`centos/ruby-25-centos7`](https://hub.docker.com/r/centos/ruby-25-centos7)
+
+#### Note: 
+- All those images above are also available with RHEL as base
+instead, just replace `centos7` by `rhel7` or `rhel8` when using from DockerHub
+- The following images are also available at quay.io/centos7

--- a/task/s2i/0.2/s2i.yaml
+++ b/task/s2i/0.2/s2i.yaml
@@ -1,0 +1,88 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: s2i
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+spec:
+  description: >-
+    Source-to-Image (S2I) is a toolkit and workflow for building reproducible
+    container images from source code
+
+    S2I produces images by injecting source code into a base S2I container image
+    and letting the container prepare that source code for execution. The base
+    S2I container images contains the language runtime and build tools needed for
+    building and running the source code.
+
+  params:
+    - name: BUILDER_IMAGE
+      description: The location of the s2i builder image.
+    - name: IMAGE_NAME
+      description: Reference of the image S2I will produce.
+    - name: PATH_CONTEXT
+      description: The location of the path to run s2i from.
+      default: .
+    - name: TLSVERIFY
+      description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+      default: "true"
+    - name: LOGLEVEL
+      description: Log level when running the S2I binary
+      default: "0"
+  workspaces:
+    - name: source
+    - name: sslcertdir
+      optional: true
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built.
+  steps:
+    - name: generate
+      image: quay.io/openshift-pipeline/s2i:nightly
+      workingDir: $(workspaces.source.path)
+      command:
+        - /usr/local/bin/s2i
+        - --loglevel=$(params.LOGLEVEL)
+        - build
+        - $(params.PATH_CONTEXT)
+        - $(params.BUILDER_IMAGE)
+        - --as-dockerfile
+        - /gen-source/Dockerfile.gen
+      volumeMounts:
+        - mountPath: /gen-source
+          name: gen-source
+    - name: build
+      image: quay.io/buildah/stable:v1.15.1
+      workingDir: /gen-source
+      script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+        buildah ${CERT_DIR_FLAG} bud --tls-verify=$(params.TLSVERIFY) --layers \
+        -f /gen-source/Dockerfile.gen -t $(params.IMAGE_NAME) .
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+        - mountPath: /gen-source
+          name: gen-source
+    - name: push
+      image: quay.io/buildah/stable:v1.15.1
+      script: |
+        [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+        buildah ${CERT_DIR_FLAG} push --tls-verify=$(params.TLSVERIFY) --digestfile $(workspaces.source.path)/image-digest \
+        $(params.IMAGE_NAME) docker://$(params.IMAGE_NAME)
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+    - name: digest-to-results
+      image: $(params.BUILDER_IMAGE)
+      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+  volumes:
+    - emptyDir: {}
+      name: varlibcontainers
+    - emptyDir: {}
+      name: gen-source

--- a/task/s2i/0.2/samples/openshift-internal-registry.yaml
+++ b/task/s2i/0.2/samples/openshift-internal-registry.yaml
@@ -1,0 +1,95 @@
+# Your custom CA, on OpenShift to be able to get the internal registry custom
+# certificates you can just import it to your namespace with :
+# oc get configmaps \
+#   -n openshift-controller-manager openshift-service-ca -o yaml | \
+#   sed '/namespace/d'|kubectl apply -f-
+---
+kind: ConfigMap
+metadata:
+  name: openshift-service-ca
+apiVersion: v1
+data:
+  service-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDUTCCAjmgAwIBAgIIUaNbmFRnX2gwDQYJKoZIhvcNAQELBQAwNjE0MDIGA1UE
+    Awwrb3BlbnNoaWZ0LXNlcnZpY2Utc2VydmluZy1zaWduZXJAMTYwMzczMDU0MTAe
+    Fw0yMDEwMjYxNjQyMjFaFw0yMjEyMjUxNjQyMjJaMDYxNDAyBgNVBAMMK29wZW5z
+    aGlmdC1zZXJ2aWNlLXNlcnZpbmctc2lnbmVyQDE2MDM3MzA1NDEwggEiMA0GCSqG
+    SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHNbOTMqKCISgRiq2LW2SPFBUcg9etDLqP
+    A9fwOVJPxRW5FpyRS9k9g28WpCi7jjf/Um5sid+AO4QkZ2bnHcGAtSq75bIHkYsh
+    sNVlfeQlJ1pcxAyxspUr/SFyQ63HmVcH/Xw9MRASE3TmPp/KYRNMT3Yz+sZOzhiz
+    mczxvzpxF26Vz/YzlSfzDDe6B8lT8Dv+s/Hnx/cBKFw53Q0U5VbBpbCuGLMG9VoQ
+    kog79skdY9aNF83wNH9V2DMb9Yzqf3IFFgfBlQQbqc6C2AutWDLzzyHWXs+Oa4E3
+    /ovdskwGP9/TKgF7zgbqAZLKhtch24m/SVY7cuJpzKRJ4gQ7ff21AgMBAAGjYzBh
+    MA4GA1UdDwEB/wQEAwICpDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBT1jpOw
+    4Tz/bifAgNYCP6JH3J3tyjAfBgNVHSMEGDAWgBT1jpOw4Tz/bifAgNYCP6JH3J3t
+    yjANBgkqhkiG9w0BAQsFAAOCAQEAqYZqX/qMXxOUuiBcd+LawuL8eCYyvcbV6jWW
+    /j3Evko1WznrXyHnTeDLsOUt4gS9VeftqzIBFdWMJ58pmX68/dZxuZJNZq+GOMQn
+    Pxjz7s+xoHPqE6YH+YPMLJfCbHzuqfKH872jN+dilxR4gUCSrCFQMOdkAz5cy5JX
+    Ktor0wWhOTJuioC2RfOuh1PG+7jOTUf/6H5fnxzRN7aAyAd0sA4n3r2jN7ypfRKg
+    jOBL06I4xPicJJAH/K2Uq03Y8dT7xVJY2WAKg/+K4uxRgQlbCKT9oj7An4zyheMP
+    0MFG1w4cfO/2p/IVZMG7QZyIfCywuhFH9L3x9q1C5qrw0RGSsw==
+    -----END CERTIFICATE-----
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: buildah-custom-ca-
+spec:
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    # Make sure the path ends up as ca.crt or buildah would not be able to find
+    # it.
+    - name: sslcertdir
+      configMap:
+        name: openshift-service-ca
+        defaultMode: 420
+        items:
+          - key: service-ca.crt
+            path: ca.crt
+        namespace: openshift-controller-manager
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+      - name: sslcertdir
+        optional: true
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/sclorg/django-ex
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: s2i
+        taskRef:
+          name: s2i
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: shared-workspace
+          - name: sslcertdir
+            workspace: sslcertdir
+        params:
+          - name: BUILDER_IMAGE
+            value: centos/python-36-centos7
+          - name: TLSVERIFY
+            value: "false"
+          - name: LOGLEVEL
+            value: "10"
+          - name: IMAGE_NAME
+            value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(context.pipelineRun.name)

--- a/task/s2i/0.2/tests/internal-registry/internal-registry.yaml
+++ b/task/s2i/0.2/tests/internal-registry/internal-registry.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+spec:
+  selector:
+    matchLabels:
+      run: registry
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: registry
+    spec:
+      containers:
+        - name: registry
+          image: docker.io/registry:2
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - name: sslcert
+              mountPath: /certs
+          env:
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: "/certs/ca.crt"
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: "/certs/ca.key"
+            - name: REGISTRY_HTTP_SECRET
+              value: "tekton"
+      volumes:
+        - name: sslcert
+          configMap:
+            defaultMode: 420
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: ca.key
+                path: ca.key
+            name: sslcert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+spec:
+  ports:
+    - port: 5000
+  selector:
+    run: registry

--- a/task/s2i/0.2/tests/pre-apply-task-hook.sh
+++ b/task/s2i/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+TMD=$(mktemp -d)
+
+# Generate SSL Certificate
+openssl req -newkey rsa:4096 -nodes -sha256 -keyout "${TMD}"/ca.key -x509 -days 365 \
+    -out "${TMD}"/ca.crt -subj "/C=FR/ST=IDF/L=Paris/O=Tekton/OU=Catalog/CN=registry"
+
+# Create a configmap from these certs
+kubectl create -n "${tns}" configmap sslcert \
+    --from-file=ca.crt="${TMD}"/ca.crt --from-file=ca.key="${TMD}"/ca.key
+
+# Add a secure internal registry as sidecar
+kubectl create -n "${tns}" -f task/buildah/0.2/tests/internal-registry/internal-registry.yaml
+
+# Add git-clone
+add_task git-clone latest

--- a/task/s2i/0.2/tests/run.yaml
+++ b/task/s2i/0.2/tests/run.yaml
@@ -1,0 +1,59 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: s2i-test-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+      - name: sslcertdir
+        optional: true
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/sclorg/django-ex
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: s2i
+        taskRef:
+          name: s2i
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: shared-workspace
+          - name: sslcertdir
+            workspace: sslcertdir
+        params:
+          - name: BUILDER_IMAGE
+            value: centos/python-36-centos7
+          - name: TLSVERIFY
+            value: "false"
+          - name: LOGLEVEL
+            value: "10"
+          - name: IMAGE_NAME
+            value: registry:5000/python-example-tekton
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Mi
+    - name: sslcertdir
+      configMap:
+        name: sslcert
+        defaultMode: 420
+        items:
+          - key: ca.crt
+            path: ca.crt


### PR DESCRIPTION
# Changes

Earlier version of s2i uses PipelineResources which are now deprecated.
Also the s2i task is missing the digest in results.

With this PR:-
- Removing the usage of PipelineResources and using equivalent task from
  catalog in the tests.
- Storing the digest in results so that it can be used later on by
  another task.
- Adds optional workspace for the cert dir to pass to buildah --cert-dir flag.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
