### PR TITLE
Use multi-arch tkn container image for tkn task

### DIFF
--- a/task/tkn/0.1/tkn.yaml
+++ b/task/tkn/0.1/tkn.yaml
@@ -15,7 +15,7 @@ spec:
   params:
   - name: tkn-image
     description: tkn CLI container image to run this task
-    default: gcr.io/tekton-releases/dogfooding/tkn@sha256:88c94cc875cae83a3c835e7c52c0a524e7422c5d759d170f2e460e5d91403669 #tag: latest
+    default: gcr.io/tekton-releases/dogfooding/tkn@sha256:f79c0a56d561b1ae98afca545d0feaf2759f5c486ef891a79f23dc2451167dad #tag: latest
   - name: ARGS
     type: array
     description: tkn CLI arguments to run

--- a/task/tkn/0.2/tkn.yaml
+++ b/task/tkn/0.2/tkn.yaml
@@ -23,7 +23,7 @@ spec:
   params:
     - name: TKN_IMAGE
       description: tkn CLI container image to run this task
-      default: gcr.io/tekton-releases/dogfooding/tkn@sha256:defb97935a4d4be26c760e43a397b649fb5591ac1aa6a736ada01e559c13767b
+      default: gcr.io/tekton-releases/dogfooding/tkn@sha256:f79c0a56d561b1ae98afca545d0feaf2759f5c486ef891a79f23dc2451167dad
     - name: SCRIPT
       description: tkn CLI script to execute
       type: string


### PR DESCRIPTION
# Changes

multi-arch tkn image allows to use the same catalog task in the setup
for many hardware acrhitectures (latest tkn image is available for
linux/amd64, linux/s390x and linux/ppc64le)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
