### PR TITLE
Add a VERSION params to openshift client task

### DIFF
--- a/task/openshift-client/0.1/README.md
+++ b/task/openshift-client/0.1/README.md
@@ -16,6 +16,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 
 * **SCRIPT:** script of oc commands to execute  e.g. `oc get pod $1 -0 yaml` This will take the first value of ARGS as pod name (_default_: `oc $@`)
 
+* **VERSION:** The OpenShift version to use (_default_: `4.6`)
 
 ## Resources
 

--- a/task/openshift-client/0.1/openshift-client.yaml
+++ b/task/openshift-client/0.1/openshift-client.yaml
@@ -28,6 +28,10 @@ spec:
     type: array
     default:
     - "help"
+  - name: VERSION
+    description: The OpenShift Version to use
+    type: string
+    default: "4.6"
   resources:
     inputs:
       - name: source
@@ -35,7 +39,7 @@ spec:
         optional: true
   steps:
     - name: oc
-      image: quay.io/openshift/origin-cli:4.6
+      image: quay.io/openshift/origin-cli:$(params.VERSION)
       script: "$(params.SCRIPT)"
       args:
         - "$(params.ARGS)"

--- a/task/openshift-client/0.1/tests/run.yaml
+++ b/task/openshift-client/0.1/tests/run.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: openshift-client-test-run
+spec:
+  pipelineSpec:
+    tasks:
+    - name: oc-version
+      taskRef:
+        name: openshift-client
+      params:
+      - name: ARGS
+        value: ["version"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a params to allow the user to specify an OpenShift Version for the
openshift-client task to use.

Add a test along the way.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413