### PR TITLE
Use multi-arch alpine/git image for git-cli and git-rebase

### DIFF
--- a/task/git-cli/0.1/git-cli.yaml
+++ b/task/git-cli/0.1/git-cli.yaml
@@ -27,7 +27,7 @@ spec:
       description: |
         The base image for the task.
       type: string
-      default: docker.io/alpine/git:v2.26.2@sha256:8715680f27333935bb384a678256faf8e8832a5f2a0d4a00c9d481111c5a29c0 #tag: v2.26.2
+      default: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f #tag: v2.26.2
 
     - name: GIT_USER_NAME
       type: string

--- a/task/git-rebase/0.1/git-rebase.yaml
+++ b/task/git-rebase/0.1/git-rebase.yaml
@@ -80,7 +80,7 @@ spec:
   steps:
     - name: rebase
       workingDir: $(workspaces.source.path)
-      image: docker.io/alpine/git:v2.26.2@sha256:8715680f27333935bb384a678256faf8e8832a5f2a0d4a00c9d481111c5a29c0 #tag: v2.26.2
+      image: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f #tag: v2.26.2
       script: |
 
         # Setting up the config for the git.


### PR DESCRIPTION
# Changes

Image sha specified in git-cli and git-rebase tasks is for `amd64` version of `alpine/git:v2.26.2` image. The image is actually multi-arch one.
Replacement of image sha to point to multi-arch version will allow to use the same catalog task for many hardware acrhitectures.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
