### PR TITLE
Add optional workspaces in kubernetes-actions task

### DIFF
--- a/task/kubernetes-actions/0.2/README.md
+++ b/task/kubernetes-actions/0.2/README.md
@@ -1,0 +1,97 @@
+# kubernetes actions
+
+This is a generic task used to perform kubernetes actions such as `kubectl get deployment` or `kubectl create -f filename.yaml`. For more commands [see](https://kubernetes.io/docs/reference/kubectl/overview/).
+
+## Install the task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/kubernetes-actions/0.2/kubernetes-actions.yaml
+```
+
+## Inputs
+
+### Parameters
+
+- **script**: script of `kubectl` commands to execute e.g. `kubectl get pod $1 -0 yaml`. This will take the first value of ARGS as pod name (_default_: `kubectl $@`)
+- **args**: args to execute which are appended to `kubectl` e.g. `start-build myapp` (_default_: `help`)
+- **image**: Default image being `gcr.io/cloud-builders/kubectl`. If somebody wants to use their own image then they can provide it as a part of params. For example an image avilable is `lachlanevenson/k8s-kubectl`
+
+### Workspaces(Optional)
+
+- **kubeconfig-dir**: If you want to deploy you application to another cluster then you can mount your `kubeconfig` file via this `workspace`.
+- **manifest-dir**: Manifest files can be provided via the workspaces.
+
+## Results
+
+- **output-result**: If you want to emit some result which can be used in decision making. One such case is when using [whenExpressions](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md#guard-task-execution-using-whenexpressions).
+
+## Usage
+
+In case no manifests are mounted
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kubectl-run
+spec:
+  taskRef:
+    name: kubectl-actions
+  params:
+    - name: SCRIPT
+      value: |
+        kubectl get pods 
+        echo "-----------"
+        kubectl get deploy
+```
+
+In case manifest is present on `GitHub` :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kubectl-run
+spec:
+  taskRef:
+    name: kubectl-actions
+  params:
+    - name: script
+      value: |
+        kubectl apply -f https://raw.githubusercontent.com/vinamra28/social-client/master/k8s/deployment.yaml
+        ----------
+        kubectl get deployment
+```
+
+Running `kubectl` commands on other cluster
+
+1. Create a `ConfigMap` or `Secret` which contains `kubeconfig`
+
+   ```sh
+   kubectl create configmap kubeconfig --from-file="/path/to/kubeconfig"
+   ```
+
+2. Create the `TaskRun`
+   ```yaml
+   apiVersion: tekton.dev/v1beta1
+   kind: TaskRun
+   metadata:
+     name: kubectl-run
+   spec:
+     taskRef:
+       name: kubectl-actions
+     workspaces:
+       - name: kubeconfig-dir
+         configMap:
+           name: kubeconfig
+     params:
+       - name: script
+         value: |
+           kubectl apply -f https://raw.githubusercontent.com/vinamra28/social-client/master/k8s/deployment.yaml
+           ----------
+           kubectl get deployment
+   ```
+
+## Kubectl Patch Deployment Image Example
+
+If you have existing deployment and after period of time image of the application is being updated. So to update the container image in the deployment, this task can be used as this task will patch the image with the new image in the existing deployment. The TaskRun for this scenario can be found [here](./samples/update-deployment-image-taskrun.yaml)

--- a/task/kubernetes-actions/0.2/kubernetes-actions.yaml
+++ b/task/kubernetes-actions/0.2/kubernetes-actions.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kubernetes-actions
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: CLI, kubectl
+    tekton.dev/displayName: "kubernetes actions"
+spec:
+  description: >-
+    This task is the generic kubectl CLI task which can be used
+    to run all kinds of k8s commands
+  workspaces:
+    - name: manifest-dir
+      optional: true
+    - name: kubeconfig-dir
+      optional: true
+  results:
+    - name: output-result
+      description: some result can be emitted if someone wants to.
+  params:
+    - name: script
+      description: The Kubernetes CLI script to run
+      type: string
+      default: "kubectl $@"
+    - name: args
+      description: The Kubernetes CLI arguments to run
+      type: array
+      default:
+        - "help"
+    - name: image
+      default: gcr.io/cloud-builders/kubectl@sha256:8ab94be8b2b4f3d117f02d868b39540fddd225447abf4014f7ba4765cb39f753 #image is huge
+      description: Kubectl wrapper image
+  steps:
+    - name: kubectl
+      image: $(params.image)
+      script: |
+        #!/usr/bin/env bash
+
+        [[ "$(workspaces.manifest-dir.bound)" == "true" ]] && \
+        cd $(workspaces.manifest-dir.path)
+
+        [[ "$(workspaces.kubeconfig-dir.bound)" == "true" ]] && \
+        [[ -f $(workspaces.kubeconfig-dir.path)/kubeconfig ]] && \
+        export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
+
+        $(params.script)
+
+      args:
+        - "$(params.args)"

--- a/task/kubernetes-actions/0.2/samples/kubectl-actions-run.yaml
+++ b/task/kubernetes-actions/0.2/samples/kubectl-actions-run.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kubectl-run
+spec:
+  taskRef:
+    name: kubernetes-actions
+  params:
+    - name: script
+      value: |
+        kubectl get pods
+        echo "---------"
+        kubectl get deploy

--- a/task/kubernetes-actions/0.2/samples/update-deployment-image-taskrun.yaml
+++ b/task/kubernetes-actions/0.2/samples/update-deployment-image-taskrun.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: update-deployment-image-taskrun
+spec:
+  taskRef:
+    name: kubernetes-actions
+  params:
+    - name: script
+      value: |
+        kubectl patch deployment $1 --patch='{"spec":{"template":{"spec":{
+          "containers":[{
+            "name": $1,
+            "image":$2
+          }]
+        }}}}'
+    - name: args
+      value:
+        - my-client-v1
+        - quay.io/openshift/origin-cli

--- a/task/kubernetes-actions/0.2/tests/resources.yaml
+++ b/task/kubernetes-actions/0.2/tests/resources.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-actions-account
+  namespace: kubernetes-actions-0-2
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubernetes-actions-role
+rules:
+  # Core API
+  - apiGroups: [""]
+    resources: ["services", "pods", "deployments", "configmaps", "secrets"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Apps API
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "jobs"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Tekton API
+  - apiGroups: ["tekton.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-actions-binding
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-actions-account
+    namespace: kubernetes-actions-0-2
+roleRef:
+  kind: ClusterRole
+  name: kubernetes-actions-role
+  apiGroup: rbac.authorization.k8s.io

--- a/task/kubernetes-actions/0.2/tests/run.yaml
+++ b/task/kubernetes-actions/0.2/tests/run.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: kubernetes-actions-run
+spec:
+  serviceAccountName: kubernetes-actions-account
+  taskRef:
+    name: kubernetes-actions
+  params:
+    - name: script
+      value: |
+        kubectl get pods
+        echo "---------"
+        kubectl get deploy


### PR DESCRIPTION
# Changes

This PR adds optional workspaces support in kubernetes-actions
task and also adds tests for the task.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
