### PR TITLE
Adds context param in golang-test task

### DIFF
--- a/task/golang-test/0.1/README.md
+++ b/task/golang-test/0.1/README.md
@@ -12,6 +12,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 
 * **package**: base package to build in
 * **packages**: packages to test (_default:_ ./cmd/...)
+* **context**: path to the directory to use as context (default: .)
 * **version**: golang version to use for builds (_default:_ latest)
 * **flags**: flags to use for `go test` command (_default:_ -race -cover -v)
 * **GOOS**: operating system target (_default:_ linux)

--- a/task/golang-test/0.1/golang-test.yaml
+++ b/task/golang-test/0.1/golang-test.yaml
@@ -18,6 +18,9 @@ spec:
   - name: packages
     description: "packages to test (default: ./...)"
     default: "./..."
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
   - name: version
     description: golang version to use for tests
     default: "latest"
@@ -39,9 +42,9 @@ spec:
   - name: unit-test
     image: docker.io/library/golang:$(params.version)
     script: |
-      SRC_PATH="$GOPATH/src/$(params.package)"
+      SRC_PATH="$GOPATH/src/$(params.package)/$(params.context)"
       mkdir -p $SRC_PATH
-      cp -R "$(workspaces.source.path)"/* $SRC_PATH
+      cp -R "$(workspaces.source.path)"/"$(params.context)"/* $SRC_PATH
       cd $SRC_PATH
       go test $(params.flags) $(params.packages)
     env:


### PR DESCRIPTION
This adds context param to provide path to the directory to use
as context.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
