### PR TITLE
Adds context param in golangci-lint

### DIFF
--- a/task/golangci-lint/0.1/README.md
+++ b/task/golangci-lint/0.1/README.md
@@ -12,6 +12,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 ### Parameters
 
 * **package**: base package under validation
+* **context**: path to the directory to use as context (default: .)
 * **flags**: flags to use for `golangci-lint` command (_default:_--verbose)
 * **version**: golangci-lint version to use (_default:_ v1.16)
 * **GOOS**: operating system target (_default:_ linux)

--- a/task/golangci-lint/0.1/golangci-lint.yaml
+++ b/task/golangci-lint/0.1/golangci-lint.yaml
@@ -15,6 +15,9 @@ spec:
   params:
   - name: package
     description: base package (and its children) under validation
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
   - name: flags
     description: flags to use for the test command
     default: --verbose
@@ -36,7 +39,7 @@ spec:
   steps:
   - name: lint
     image: docker.io/golangci/golangci-lint:$(params.version)
-    workingDir: $(workspaces.source.path)
+    workingDir: $(workspaces.source.path)/$(params.context)
     script: |
       golangci-lint run $(params.flags)
     env:


### PR DESCRIPTION
This adds context param to provide path to the directory to use
as context.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
