### PR TITLE
Fix jenkins and trigger-jenkins-job task tests

### DIFF
--- a/task/jenkins/0.1/tests/pre-apply-task-hook.sh
+++ b/task/jenkins/0.1/tests/pre-apply-task-hook.sh
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: jenkins
-        image: jenkins/jenkins:lts
+        image: jenkins/jenkins:2.263.2-lts-centos7@sha256:666a183ad54ddd2ccd1f4bc84dadf0085254a528ab96b98a790569a6c8ca3799
         ports:
         - containerPort: 8080
         volumeMounts:

--- a/task/trigger-jenkins-job/0.1/tests/pre-apply-task-hook.sh
+++ b/task/trigger-jenkins-job/0.1/tests/pre-apply-task-hook.sh
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: jenkins
-        image: jenkins/jenkins:lts
+        image: jenkins/jenkins:2.263.2-lts-centos7@sha256:666a183ad54ddd2ccd1f4bc84dadf0085254a528ab96b98a790569a6c8ca3799
         ports:
         - containerPort: 8080
         volumeMounts:


### PR DESCRIPTION
# Changes

Currently in pre-apply-task-hook.sh we are using `jenkins:lts` image
which gets updated on a regular basis which might break the CI while
testing the following tasks:- jenkins, trigger-jenkins-job.

Adding a tag+digest to the image used in test so that the tests don't
break in future.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
