### PR TITLE
Choose dind image via params

### DIFF
--- a/task/docker-build/0.1/README.md
+++ b/task/docker-build/0.1/README.md
@@ -13,8 +13,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 ### Parameters
 
 * **image**: The name (reference) of the image to build.
-* **builder_image:**: The name of the image containing the Docker tool. See
-  note below.  (_default:_ docker.io/docker:latest)
+* **builder_image**: The name of the image containing the Docker tool. See
+  note below.  (_default:_ `docker.io/docker:latest`)
+* **dind_image**: The name of the image used by `docker-in-docker` sidecar container (_default:_ `docker:dind`). 
 * **dockerfile**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 * **context**: Path to the directory to use as context (_default:_

--- a/task/docker-build/0.1/docker-build.yaml
+++ b/task/docker-build/0.1/docker-build.yaml
@@ -20,6 +20,9 @@ spec:
   - name: builder_image
     description: The location of the docker builder image.
     default: docker.io/library/docker:stable@sha256:18ff92d3d31725b53fa6633d60bed323effb6d5d4588be7b547078d384e0d4bf #tag: stable
+  - name: dind_image
+    description: The location of the docker-in-docker image.
+    default: docker:dind
   - name: dockerfile
     description: Path to the Dockerfile to build.
     default: ./Dockerfile
@@ -81,7 +84,7 @@ spec:
       - mountPath: /certs/client
         name: dind-certs
   sidecars:
-  - image: docker:dind
+  - image: $(params.dind_image)
     name: server
     args:
       - --storage-driver=vfs


### PR DESCRIPTION
At the time of writing, the stable `docker:dind` is broken, the solution is to roll back to the previous version (https://github.com/containerd/containerd/issues/4837).
In other words, `docker:dind` should be temporarily replaced with `docker:19-dind`.
I think allowing users to specify the docker-in-docker image via params is the best way to get around this issue.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add param that determines the image used for docker-in-docker.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
