### PR TITLE
Add Task to post a file on Gist Github

### DIFF
--- a/task/github-add-gist/0.1/README.md
+++ b/task/github-add-gist/0.1/README.md
@@ -1,0 +1,70 @@
+# GitHub Add Gist
+
+The following task lets you upload a file to `gist` GitHub
+and outputs the raw url as the result.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/github-add-gist/0.1/github-add-gist.yaml
+```
+
+## Secrets
+
+This Task requires access to a GitHub token set via a Kubernetes Secret. By default, the name of this Secret should be `github` and the secret key should be `token`, but you can configure this via the `GITHUB_TOKEN_SECRET_NAME` and `GITHUB_TOKEN_SECRET_KEY` [parameters](#parameters) described below.
+
+To create such a Secret via `kubectl`:
+
+```
+kubectl create secret generic github --from-literal token="MY_TOKEN"
+```
+
+Check [this](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to get personal access token for `Github`.
+
+See GitHub's documentation on [Understanding scopes for OAuth Apps](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) to figure out what scopes you need to give to this token to add comment to an issue or a pull request.
+
+> Note: Make sure you have added `gist` scope while creating a personal access token.
+
+## Parameters
+
+- **GITHUB_HOST_URL:**: The GitHub host domain (_default:_ `api.github.com`)
+- **API_PATH_PREFIX:**: The GitHub Enterprise has a prefix for the API path. _e.g:_ `/api/v3`
+- **FILE_NAME:**: Name of the file to be uploaded to gist. _e.g:_ `catlin.txt`.
+- **GITHUB_TOKEN_SECRET_NAME**: The name of the Kubernetes Secret that
+  contains the GitHub token. (_default:_ `github`).
+- **GITHUB_TOKEN_SECRET_KEY**: The key within the Kubernetes Secret that contains the GitHub token. (_default:_ `token`).
+
+
+## Workspaces
+
+- **input**: The input workspace which contains the file to be uploaded to gist.
+
+## Usage
+
+The following example will take a file from ConfigMap and
+upload to gist.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: comment-cm
+data:
+  test.txt: |
+    This is the sample input comment via file.
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: github-add-gist-
+spec:
+  taskRef:
+    name: github-add-gist
+  workspace:
+    - name: input
+      configMap:
+        name: comment-cm
+  params:
+    - name: FILE_NAME
+      value: "test.txt"
+```

--- a/task/github-add-gist/0.1/github-add-gist.yaml
+++ b/task/github-add-gist/0.1/github-add-gist.yaml
@@ -1,0 +1,108 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-add-gist
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: github
+    tekton.dev/displayName: "upload to gist"
+spec:
+  description: |
+    This task will uploaded the provided file
+    to the GitHub gist.
+  workspaces:
+    - name: input
+      description: |
+        The input workspace which contains the file to be uploaded to gist.
+  params:
+    - name: GITHUB_HOST_URL
+      description: |
+        The GitHub host, adjust this if you run a GitHub enteprise.
+      default: "api.github.com"
+      type: string
+    - name: API_PATH_PREFIX
+      description: |
+        The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+      default: ""
+      type: string
+    - name: GITHUB_TOKEN_SECRET_NAME
+      description: |
+        The name of the Kubernetes Secret that contains the GitHub token.
+      type: string
+      default: github
+    - name: GITHUB_TOKEN_SECRET_KEY
+      description: |
+        The key within the Kubernetes Secret that contains the GitHub token.
+      type: string
+      default: token
+    - name: FILE_NAME
+      type: string
+      description: |
+        Name of the file to be uploaded to gist.
+  results:
+    - name: gist_url
+      description: The raw URL of the uploaded gist
+  steps:
+    - name: create-gist
+      workingDir: $(workspaces.input.path)
+      env:
+        - name: GITHUBTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.GITHUB_TOKEN_SECRET_NAME)
+              key: $(params.GITHUB_TOKEN_SECRET_KEY)
+
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      script: |
+        #!/usr/libexec/platform-python
+        import json
+        import os
+        import http.client
+        import urllib.parse
+
+        filename = "$(params.FILE_NAME)"
+        if not os.path.exists(filename):
+          print("File doesn't exists with file name "+filename)
+          os._exit(1)
+
+        contents = open(filename, "r")
+        comment = contents.read()
+
+        data = {
+          "public": "true",
+          "files": {
+            filename: {
+              "content": comment,
+            },
+          },
+        }
+
+        print("Creating a gist with filename: "+filename)
+
+        # This is for our fake github server
+        if "$(params.GITHUB_HOST_URL)".startswith("http://"):
+          conn = http.client.HTTPConnection("$(params.GITHUB_HOST_URL)".replace("http://", ""))
+        else:
+          conn = http.client.HTTPSConnection("$(params.GITHUB_HOST_URL)")
+
+        r = conn.request(
+            "POST",
+            "$(params.API_PATH_PREFIX)" + "/gists",
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
+            })
+        resp = conn.getresponse()
+        if not str(resp.status).startswith("2"):
+            print("Error: %d" % (resp.status))
+            print(resp.read())
+        else:
+          response = resp.read().decode('utf-8')
+          jsonObj = json.loads(response)
+          rawUrl = jsonObj['files'][filename]['raw_url']
+          resultFile = open("$(results.gist_url.path)", "w")
+          resultFile.write(rawUrl)
+          resultFile.close()

--- a/task/github-add-gist/0.1/samples/pipeline.yaml
+++ b/task/github-add-gist/0.1/samples/pipeline.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: catlin-linter
+spec:
+  workspaces:
+    - name: store-changed-files
+  resources:
+    - name: source
+      type: git
+  params:
+    - name: gitCloneDepth
+    - name: gitHubCommand
+    - name: checkName
+    - name: pullRequestUrl
+  tasks:
+    - name: catalog-lint
+      taskRef:
+        name: catlin
+      workspaces:
+        - name: store-changed-files
+          workspace: store-changed-files
+      resources:
+        inputs:
+          - name: source
+            resource: source
+      params:
+        - name: gitCloneDepth
+          value: $(params.gitCloneDepth)
+    - name: post-gist
+      taskRef:
+        name: github-add-gist
+      params:
+        - name: FILE_NAME
+          value: "catlin.txt"
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: bot-token-github
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: bot-token
+      workspaces:
+        - name: input
+          workspace: store-changed-files
+      runAfter:
+        - catalog-lint
+    - name: post-comment
+      taskRef:
+        name: github-add-comment
+      params:
+        - name: COMMENT_OR_FILE
+          value: "$(tasks.post-gist.results.gist_url)"
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: bot-token-github
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: bot-token
+        - name: REQUEST_URL
+          value: $(params.pullRequestUrl)
+      workspaces:
+        - name: comment-file
+          workspace: store-changed-files
+      runAfter:
+        - post-gist

--- a/task/github-add-gist/0.1/tests/fixtures/github-post-gist.yaml
+++ b/task/github-add-gist/0.1/tests/fixtures/github-post-gist.yaml
@@ -1,0 +1,8 @@
+---
+headers:
+  method: POST
+  path: /gists
+response:
+  status: 200
+  output: '{"status": 200, "files": {"input.txt": {"raw_url": "http://127.0.0.1:8080"}}}'
+  content-type: text/json

--- a/task/github-add-gist/0.1/tests/pre-apply-task-hook.sh
+++ b/task/github-add-gist/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+kubectl -n ${tns} create secret generic github --from-literal token="secret"

--- a/task/github-add-gist/0.1/tests/resources.yaml
+++ b/task/github-add-gist/0.1/tests/resources.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sample-input
+data:
+  input.txt: |
+    Hello from TektonCD test

--- a/task/github-add-gist/0.1/tests/run.yaml
+++ b/task/github-add-gist/0.1/tests/run.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: github-add-gist-test
+spec:
+  workspaces:
+    - name: input
+  tasks:
+    - name: upload-gist
+      taskRef:
+        name: github-add-gist
+      params:
+        - name: GITHUB_HOST_URL
+          value: http://127.0.0.1:8080
+        - name: FILE_NAME
+          value: "input.txt"
+      workspaces:
+        - name: input
+          workspace: input
+    - name: echo-result
+      params:
+        - name: raw-url
+          value: $(tasks.upload-gist.results.gist_url)
+      taskSpec:
+        params:
+          - name: raw-url
+        steps:
+          - name: test-url
+            image: ubuntu
+            script: |
+              #!/usr/bin/env bash
+              [[ "$(params.raw-url)" == "http://127.0.0.1:8080" ]] && exit 0 || exit 1
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: github-add-gist-test-run
+spec:
+  pipelineRef:
+    name: github-add-gist-test
+  workspaces:
+    - name: input
+      configMap:
+        name: sample-input


### PR DESCRIPTION
# Changes

This adds a task to upload a file on gist github.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
