### PR TITLE
Task to request reviewers on a GitHub PR

### DIFF
--- a/task/github-request-reviewers/0.1/README.md
+++ b/task/github-request-reviewers/0.1/README.md
@@ -1,0 +1,72 @@
+# Request reviewers on a pull request
+
+The `github-request-reviewers` task lets one request reviewers on a pull request. It implements the corresponding [GitHub API](https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request) to request reviewers.
+
+## Changelog
+
+- v0.1: Initial version.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-request-reviewers/0.1/github-request-reviewers.yaml
+```
+
+## Secrets
+
+This Task requires access to a GitHub token. The token is expected to be in a workspace, which will typically be bound to Kubernetes Secret at run time. The name of the file in the workspace is `token` by default, but it can be configured via the `github-token-key` parameter from the [parameters](#parameters) described below.
+
+To create such a Secret via `kubectl`:
+
+```
+kubectl create secret generic github --from-literal token="MY_TOKEN"
+```
+
+Check [this](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to get personal access token for `Github`.
+
+Requesting reviewers only requires the `public_repo` scope for the token. See GitHub's documentation on
+[Understanding scopes for OAuth Apps](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/)
+for more details.
+
+## Parameters
+
+- **GITHUB_HOST_URL:**: The GitHub host domain (_default:_ `api.github.com`)
+- **API_PATH_PREFIX:**: The GitHub Enterprise has a prefix for the API path. _e.g:_ `/api/v3` (_default:_ "").
+- **PACKAGE:**: The GitHub {org}/{repo}, _e.g:_ `tektoncd/catalog`
+- **PULL_REQUEST_NUMBER:**: The GitHub pull request or issue url, _e.g:_ `1234`
+- **REVIEWERS:**: Comma separated list of github user slugs _e.g:_ `user1,user2` (_default:_ "").
+- **TEAM_REVIEWERS**: Comma separated list of github user slugs (_default:_ "").
+- **GITHUB_TOKEN_FILE**: The name of the file in the workspace that contains the github token. (_default:_ `token`).
+
+## Workspaces
+
+- **github**: The workspace that contains the github token
+
+## Usage
+
+This TaskRun requests both users and teams as reviewers:
+
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: github-request-reviewers-
+spec:
+  taskRef:
+    kind: Task
+    name: github-request-reviewers
+  workspace:
+    - name: github
+      secret:
+        secretName: "bot-token-github"
+  params:
+    - name: PACKAGE
+      value: tektoncd/catalog
+    - name: PULL_REQUEST_NUMBER
+      value: "1234"
+    - name: REVIEWERS
+      value: "user1,user2"
+    - name: TEAM_REVIEWERS
+      value: "team1,team2"
+```

--- a/task/github-request-reviewers/0.1/github-request-reviewers.yaml
+++ b/task/github-request-reviewers/0.1/github-request-reviewers.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-request-reviewers
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: github
+    tekton.dev/displayName: "request github reviewers"
+spec:
+  description: >-
+    This Task will request reviewers for a GitHub PR
+
+    It can take either a list of users or teams or both.
+    Note that, when teams are used, GitHub does not verify
+    if the team (or any of its members) are collaborators on
+    the repo, so a 201 reply may still result in no reviewer
+    added to the PR.
+  workspaces:
+    - name: github
+      description: The workspace that contains the GitHub secret
+  params:
+    - name: GITHUB_HOST_URL
+      description: |
+        The GitHub host, adjust this if you run a GitHub Enteprise.
+      default: "api.github.com"
+      type: string
+
+    - name: API_PATH_PREFIX
+      description: |
+        The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+      default: ""
+      type: string
+
+    - name: PACKAGE
+      description: "{owner}/{repo}"
+      type: string
+
+    - name: PULL_REQUEST_NUMBER
+      description: The pull request number
+      type: string
+
+    - name: REVIEWERS
+      description: |
+        Comma separated list of github user slugs.
+      type: string
+      default: ""
+
+    - name: TEAM_REVIEWERS
+      description: |
+        Comma separated list of github team slugs.
+      type: string
+      default: ""
+
+    - name: GITHUB_TOKEN_FILE
+      description: |
+        The file within workspace that contains the GitHub token.
+      type: string
+      default: token
+
+  steps:
+  - name: set-reviewers
+    image: docker.io/library/python:3.9-alpine3.13@sha256:437482dd314471f5f10967f7376489d9e7f67c111850c123cc725a1741b66aac
+    script: |
+      #!/usr/bin/env python
+      import json
+      import http.client
+
+      # Load the GitHub Token
+      github_token = ""
+      with open("$(workspaces.github.path)/$(params.GITHUB_TOKEN_FILE)", "r") as gh:
+        github_token = gh.read()
+
+      # Implement the request reviewers GitHub API
+      # https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request
+      reviewers_url = "{prefix}/repos/{package}/pulls/{pull_number}/requested_reviewers".format(
+        prefix="$(params.API_PATH_PREFIX)", package="$(params.PACKAGE)",
+        pull_number="$(params.PULL_REQUEST_NUMBER)")
+
+      reviewers = "$(params.REVIEWERS)".split(",")
+      team_reviewers = "$(params.TEAM_REVIEWERS)".split(",")
+
+      data = dict()
+      if reviewers:
+        data["reviewers"] = reviewers
+      if team_reviewers:
+        data["team_reviewers"] = team_reviewers
+
+      print("Sending this data to GitHub: ")
+      print(data)
+
+      if "$(params.GITHUB_HOST_URL)".startswith("http://"):
+        conn = http.client.HTTPConnection("$(params.GITHUB_HOST_URL)".replace("http://", ""))
+      else:
+        conn = http.client.HTTPSConnection("$(params.GITHUB_HOST_URL)")
+      r = conn.request(
+          "POST",
+          reviewers_url,
+          body=json.dumps(data),
+          headers={
+              "User-Agent": "TektonCD, the peaceful cat",
+              "Authorization": "Bearer " + github_token,
+              "Accept": "application/vnd.github.v3+json ",
+          })
+      resp = conn.getresponse()
+      if not str(resp.status).startswith("2"):
+          print("Error: %d" % (resp.status))
+          print(resp.read())
+      else:
+        print("Reviewers {}, {} have been requested for PR {} on {}".format(
+          reviewers, team_reviewers, $(params.PULL_REQUEST_NUMBER), "$(params.PACKAGE)"))

--- a/task/github-request-reviewers/0.1/tests/fixtures/github-post-comment.yaml
+++ b/task/github-request-reviewers/0.1/tests/fixtures/github-post-comment.yaml
@@ -1,0 +1,8 @@
+---
+headers:
+  method: POST
+  path: /repos/{repo:[^/]+/[^/]+}/pulls/{[0-9]+}/requested_reviewers
+response:
+  status: 201
+  output: '{"status": 201}'
+  content-type: text/json

--- a/task/github-request-reviewers/0.1/tests/pre-apply-task-hook.sh
+++ b/task/github-request-reviewers/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+kubectl -n ${tns} create secret generic github --from-literal token="secret"

--- a/task/github-request-reviewers/0.1/tests/run.yaml
+++ b/task/github-request-reviewers/0.1/tests/run.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: github-request-reviewers
+spec:
+  workspaces:
+    - name: github
+  tasks:
+    - name: github-request-reviewers
+      taskRef:
+        name: github-request-reviewers
+      workspaces:
+        - name: github
+          workspace: github
+      params:
+        - name: GITHUB_HOST_URL
+          value: http://127.0.0.1:8080
+        - name: PACKAGE
+          value: tektoncd/catalog
+        - name: PULL_REQUEST_NUMBER
+          value: "1234"
+        - name: REVIEWERS
+          value: "user1,user2"
+        - name: TEAM_REVIEWERS
+          value: "team1,team2"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: github-request-reviewers-test-run
+spec:
+  pipelineRef:
+    name: github-request-reviewers
+  workspaces:
+    - name: github
+      secret:
+        secretName: "github"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a new task that allows to request reviewers on a GitHub PR.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

```
spec:
  description: >-
    This Task will request reviewers for a GitHub PR

    It can take either a list of users or teams or both.
    Note that, when teams are used, GitHub does not verify
    if the team (or any of its members) are collaborators
    the repo, so a 201 reply may still result in no reviewer
    added to the PR.
```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
