### PR TITLE
Bump github-create-deployment version to 0.2

### DIFF
--- a/task/github-create-deployment/0.2/README.md
+++ b/task/github-create-deployment/0.2/README.md
@@ -1,0 +1,73 @@
+## GitHub Create Deployment
+
+The `github-create-deployment` Task lets you create a GitHub deployment.
+
+See GitHub's deployment API on [Create a deployment](https://docs.github.com/rest/reference/repos#create-a-deployment) for more information.
+
+### Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-create-deployment/0.2/github-create-deployment.yaml
+```
+
+### Secrets
+
+This Task requires access to a GitHub token set via a Kubernetes Secret. By default, the name of this Secret should be `github` and the secret key should be `token`, but you can configure this via the `GITHUB_TOKEN_SECRET_NAME` and `GITHUB_TOKEN_SECRET_KEY` [parameters](#parameters) described below.
+
+To create such a Secret via `kubectl`:
+
+```
+kubectl create secret generic github --from-literal token="MY_TOKEN"
+```
+
+Token must have `repo_deployment` scope to create deployments. See GitHub's documentation on [Scopes for OAuth Apps](https://docs.github.com/developers/apps/scopes-for-oauth-apps) for details.
+
+### Parameters
+
+- **GITHUB_HOST_URL**: The GitHub host domain. (_default:_ `api.github.com`)
+- **API_PATH_PREFIX**: The GitHub Enterprise has a prefix for the API path. (_e.g.:_ `/api/v3`)
+- **REPO_FULL_NAME**: The GitHub repository full name. (_e.g.:_ `tektoncd/catalog`)
+- **REF**: The ref to deploy. This can be a branch, tag, or SHA. (_e.g.:_ `main`)
+- **TASK**: Specifies a task to execute. (_default:_ `deploy`)
+- **AUTO_MERGE**: Attempts to automatically merge the default branch into the
+  requested ref, if it's behind the default branch. (_default:_ `true`)
+- **REQUIRED_CONTEXTS**: The status contexts to verify against commit status checks. To
+  verify all unique contexts before creating a deployment, pass
+  in `*`. To bypass checking entirely, pass an empty string. (_default:_ `*`)
+- **PAYLOAD**: JSON payload with extra information about the deployment. (_default:_ `""`)
+- **ENVIRONMENT**: Name for the target deployment environment (_e.g.:_ `production`).
+- **DESCRIPTION**: Short description of the deployment. (_default:_ `""`).
+- **GITHUB_TOKEN_SECRET_NAME**: The name of the Kubernetes Secret that
+  contains the GitHub token. (_default:_ `github`).
+- **GITHUB_TOKEN_SECRET_KEY**: The key within the Kubernetes Secret that contains the GitHub token. (_default:_ `token`).
+
+### Results
+
+- **ID**: ID of the created deployment.
+- **URL**: URL of the created deployment.
+- **STATUSES_URL**: URL of the created deployment status.
+
+## Usage
+
+This TaskRun creates a GitHub deployment for the given repository.
+
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: github-create-deployment
+  name: github-create-tektoncd-catalog-deployment
+spec:
+  taskRef:
+    kind: Task
+    name: github-create-deployment
+  params:
+    - name: REPO_FULL_NAME
+      value: tektoncd/catalog
+    - name: REF
+      value: main
+    - name: ENVIRONMENT
+      value: staging
+```

--- a/task/github-create-deployment/0.2/github-create-deployment.yaml
+++ b/task/github-create-deployment/0.2/github-create-deployment.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-create-deployment
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: github
+    tekton.dev/displayName: "create github deployment"
+spec:
+  description: >-
+    This Task will create a GitHub deployment for a repository.
+
+  params:
+    - name: GITHUB_HOST_URL
+      description: |
+        The GitHub host, adjust this if you run a GitHub enterprise.
+      default: "api.github.com"
+      type: string
+
+    - name: API_PATH_PREFIX
+      description: |
+        The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+      default: ""
+      type: string
+
+    - name: REPO_FULL_NAME
+      description: |
+        The GitHub repository full name, i.e: tektoncd/catalog.
+      type: string
+
+    - name: REF
+      description: |
+        The ref to deploy. This can be a branch, tag, or SHA.
+      type: string
+
+    - name: TASK
+      description: |
+        Specifies a task to execute (e.g., deploy or deploy:migrations).
+      default: "deploy"
+      type: string
+
+    - name: AUTO_MERGE
+      description: |
+        Attempts to automatically merge the default branch into the
+        requested ref, if it's behind the default branch.
+      default: "true"
+      type: string
+
+    - name: REQUIRED_CONTEXTS
+      description: |
+        The status contexts to verify against commit status checks. To
+        verify all unique contexts before creating a deployment, pass
+        in "*". To bypass checking entirely, pass an empty string.
+      default: "*"
+
+    - name: PAYLOAD
+      description: |
+        JSON payload with extra information about the deployment.
+      default: ""
+      type: string
+
+    - name: ENVIRONMENT
+      description: |
+        Name for the target deployment environment (e.g., production, staging).
+      type: string
+
+    - name: DESCRIPTION
+      description: |
+        Short description of the deployment.
+      default: ""
+      type: string
+
+    - name: GITHUB_TOKEN_SECRET_NAME
+      description: |
+        The name of the Kubernetes Secret that contains the GitHub token.
+      default: "github"
+      type: string
+
+    - name: GITHUB_TOKEN_SECRET_KEY
+      description: |
+        The key within the Kubernetes Secret that contains the GitHub token.
+      default: "token"
+      type: string
+
+  results:
+    - name: ID
+      description: ID of the created deployment.
+
+    - name: URL
+      description: URL of the created deployment.
+
+    - name: STATUSES_URL
+      description: URL of the created deployment status.
+
+  steps:
+    - name: create-deployment
+      env:
+        - name: GITHUBTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.GITHUB_TOKEN_SECRET_NAME)
+              key: $(params.GITHUB_TOKEN_SECRET_KEY)
+        - name: DEPLOYMENT_ID_PATH
+          value: $(results.ID.path)
+        - name: DEPLOYMENT_URL_PATH
+          value: $(results.URL.path)
+        - name: DEPLOYMENT_STATUSES_URL_PATH
+          value: $(results.STATUSES_URL.path)
+
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      script: |
+        #!/usr/libexec/platform-python
+        import http.client
+        import json
+        import os
+        import sys
+
+        deployment_url = "$(params.API_PATH_PREFIX)" + \
+            "/repos/$(params.REPO_FULL_NAME)/deployments"
+
+        if "$(params.REQUIRED_CONTEXTS)" == "*":
+            required_contexts = None
+        elif "$(params.REQUIRED_CONTEXTS)" == "":
+            required_contexts = []
+        else:
+            required_contexts = "$(params.REQUIRED_CONTEXTS)".split(",")
+
+        # payload should either be a JSON object or an empty string
+        if "$(params.PAYLOAD)":
+            payload = json.loads("$(params.PAYLOAD)")
+        else:
+            payload = ""
+
+        data = {
+            "ref": "$(params.REF)",
+            "task": "$(params.TASK)",
+            "auto_merge": json.loads("$(params.AUTO_MERGE)"),
+            "required_contexts": required_contexts,
+            "payload": payload,
+            "environment": "$(params.ENVIRONMENT)",
+            "description": "$(params.DESCRIPTION)",
+        }
+
+        print("Sending this data to GitHub: ")
+        print(data)
+
+        # This is for our fake github server
+        if "$(params.GITHUB_HOST_URL)".startswith("http://"):
+            conn = http.client.HTTPConnection("$(params.GITHUB_HOST_URL)"
+                                              .replace("http://", ""))
+        else:
+            conn = http.client.HTTPSConnection("$(params.GITHUB_HOST_URL)")
+
+        r = conn.request(
+            "POST",
+            deployment_url,
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
+            })
+        resp = conn.getresponse()
+
+        # only look for 201 statuses to signify a deployment was successfully
+        # created, as a merged branch response returns a 202 status but does not
+        # actually create the deployment.
+        # https://developer.github.com/v3/repos/deployments/#merged-branch-response
+        if resp.status != 201:
+            print(f'Error: {resp.status}')
+            print(resp.read())
+            sys.exit(1)
+        else:
+            body = json.loads(resp.read().decode())
+            open(os.environ.get('DEPLOYMENT_ID_PATH'), 'w').write(f'{body["id"]}')
+            open(os.environ.get('DEPLOYMENT_URL_PATH'), 'w').write(body["url"])
+            open(os.environ.get('DEPLOYMENT_STATUSES_URL_PATH'), 'w') \
+                .write(body["statuses_url"])
+            print("GitHub deployment created for $(params.REPO_FULL_NAME): "
+                  f'id={body["id"]} ref={body["ref"]} sha={body["sha"]} '
+                  f'environment={body["environment"]} url={body["url"]}')

--- a/task/github-create-deployment/0.2/tests/fixtures/github-create-deployment.yaml
+++ b/task/github-create-deployment/0.2/tests/fixtures/github-create-deployment.yaml
@@ -1,0 +1,32 @@
+---
+headers:
+  method: POST
+  path: /repos/{repo:[^/]+/[^/]+}/deployments
+response:
+  status: 201
+  output: |
+    {
+      "url": "http://localhost:8080/repos/tekton/catalog/deployments/1",
+      "id": 1,
+      "sha": "1a38009d97722101792f041edb96c2ea383ec078",
+      "ref": "main",
+      "environment": "staging",
+      "statuses_url": "http://localhost:8080/repos/tekton/catalog/deployments/1/statuses"
+    }
+  content-type: application/json
+---
+headers:
+  method: POST
+  path: /api/v3/repos/{repo:[^/]+/[^/]+}/deployments
+response:
+  status: 201
+  output: |
+    {
+      "url": "http://localhost:8080/api/v3/repos/tekton/catalog/deployments/1",
+      "id": 1,
+      "sha": "1a38009d97722101792f041edb96c2ea383ec078",
+      "ref": "main",
+      "environment": "staging",
+      "statuses_url": "http://localhost:8080/api/v3/repos/tekton/catalog/deployments/1/statuses"
+    }
+  content-type: application/json

--- a/task/github-create-deployment/0.2/tests/pre-apply-task-hook.sh
+++ b/task/github-create-deployment/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+kubectl -n ${tns} create secret generic github --from-literal token="secret"

--- a/task/github-create-deployment/0.2/tests/run.yaml
+++ b/task/github-create-deployment/0.2/tests/run.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: github-create-deployment-test-run
+spec:
+  pipelineSpec:
+    tasks:
+      - name: github
+        taskRef:
+          name: github-create-deployment
+        params:
+          - name: GITHUB_HOST_URL
+            value: http://127.0.0.1:8080
+          - name: REPO_FULL_NAME
+            value: tektoncd/catalog
+          - name: REF
+            value: main
+          - name: ENVIRONMENT
+            value: staging
+      - name: github-enterprise
+        taskRef:
+          name: github-create-deployment
+        params:
+          - name: GITHUB_HOST_URL
+            value: http://127.0.0.1:8080
+          - name: API_PATH_PREFIX
+            value: /api/v3
+          - name: REPO_FULL_NAME
+            value: tektoncd/catalog
+          - name: REF
+            value: main
+          - name: ENVIRONMENT
+            value: staging


### PR DESCRIPTION
# Changes

Bump github-create-deployment version to 0.2

- Add API_PATH_PREFIX to github-create-deployment task parameter

### Background

GitHub enterprise exposes API using path (e.g. `/api/v3`) instead of host.

Current github-create-deployment implementation will fail on this case, since `HTTPSConnection` does not allow path included host.

Signed-off-by: Sunghoon Kang <hoon@linecorp.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```