### PR TITLE
Add github-create-deployment-status task

### DIFF
--- a/task/github-create-deployment-status/0.1/README.md
+++ b/task/github-create-deployment-status/0.1/README.md
@@ -1,0 +1,67 @@
+## GitHub Create Deployment Status
+
+The `github-create-deployment-status` Task lets you create a status for GitHub deployment.
+
+See GitHub's deployment API on [Create a deployment status](https://docs.github.com/rest/reference/repos#create-a-deployment-status) for more information.
+
+### Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-create-deployment-status/0.1/github-create-deployment-status.yaml
+```
+
+### Secrets
+
+This Task requires access to a GitHub token set via a Kubernetes Secret. By default, the name of this Secret should be `github` and the secret key should be `token`, but you can configure this via the `GITHUB_TOKEN_SECRET_NAME` and `GITHUB_TOKEN_SECRET_KEY` [parameters](#parameters) described below.
+
+To create such a Secret via `kubectl`:
+
+```
+kubectl create secret generic github --from-literal token="MY_TOKEN"
+```
+
+Token must have `repo_deployment` scope to create deployment status. See GitHub's documentation on [Scopes for OAuth Apps](https://docs.github.com/developers/apps/scopes-for-oauth-apps) for details.
+
+### Parameters
+
+- **GITHUB_HOST_URL**: The GitHub host domain. (_default:_ `api.github.com`)
+- **API_PATH_PREFIX**: The GitHub Enterprise has a prefix for the API path. (_e.g.:_ `/api/v3`)
+- **REPO_FULL_NAME**: The GitHub repository full name. (_e.g.:_ `tektoncd/catalog`)
+- **DEPLOYMENT_ID**: The ID of deployment. (_e.g.:_ `"1"`)
+- **STATE**: The state of the status. This can be one of "error", "failure",
+  "inactive", "in_progress", "queued", "pending" or "success". (_e.g.:_ `in_progress`)
+- **LOG_URL**: The full URL of the deployment's output. (_default:_ `""`)
+- **DESCRIPTION**: Short description of the status. (_default:_ `""`)
+- **ENVIRONMENT**: Name for the target deployment environment. (_default:_ `""`)
+- **ENVIRONMENT_URL**: The URL for accessing environment. (_default:_ `""`)
+- **AUTO_INACTIVE**: Adds a new inactive status to all prior non-transient,
+  non-production environment deployments with the same repository and
+  environment name as the created status's deployment. (_default:_ `"true"`)
+- **GITHUB_TOKEN_SECRET_NAME**: The name of the Kubernetes Secret that
+  contains the GitHub token. (_default:_ `github`).
+- **GITHUB_TOKEN_SECRET_KEY**: The key within the Kubernetes Secret that contains the GitHub token. (_default:_ `token`).
+
+## Usage
+
+This TaskRun creates a status for the given GitHub deployment.
+
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: github-create-deployment-status
+  name: github-create-tektoncd-catalog-deployment-status
+spec:
+  taskRef:
+    kind: Task
+    name: github-create-deployment-status
+  params:
+    - name: REPO_FULL_NAME
+      value: tektoncd/catalog
+    - name: DEPLOYMENT_ID
+      value: "1"
+    - name: STATE
+      value: in_progress
+```

--- a/task/github-create-deployment-status/0.1/github-create-deployment-status.yaml
+++ b/task/github-create-deployment-status/0.1/github-create-deployment-status.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-create-deployment-status
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: github
+    tekton.dev/displayName: "create github deployment status"
+spec:
+  description: >-
+    This Task will create a status for a GitHub deployment.
+
+  params:
+    - name: GITHUB_HOST_URL
+      description: |
+        The GitHub host, adjust this if you run a GitHub enteprise.
+      default: "api.github.com"
+      type: string
+
+    - name: API_PATH_PREFIX
+      description: |
+        The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+      default: ""
+      type: string
+
+    - name: REPO_FULL_NAME
+      description: |
+        The GitHub repository full name, i.e: tektoncd/catalog.
+      type: string
+
+    - name: DEPLOYMENT_ID
+      description: |
+        The ID of deployment
+      type: string
+
+    - name: STATE
+      description: |
+        The state of the status. This can be one of "error", "failure",
+        "inactive", "in_progress", "queued", "pending" or "success".
+      type: string
+
+    - name: LOG_URL
+      description: |
+        The full URL of the deployment's output.
+      default: ""
+      type: string
+
+    - name: DESCRIPTION
+      description: |
+        Short description of the status.
+      default: ""
+      type: string
+
+    - name: ENVIRONMENT
+      description: |
+        Name for the target deployment environment (e.g., production, staging).
+      default: ""
+      type: string
+
+    - name: ENVIRONMENT_URL
+      description: |
+        The URL for accessing environment.
+      default: ""
+      type: string
+
+    - name: AUTO_INACTIVE
+      description: |
+        Adds a new inactive status to all prior non-transient,
+        non-production environment deployments with the same repository and
+        environment name as the created status's deployment.
+      default: "true"
+      type: string
+
+    - name: GITHUB_TOKEN_SECRET_NAME
+      description: |
+        The name of the Kubernetes Secret that contains the GitHub token.
+      default: "github"
+      type: string
+
+    - name: GITHUB_TOKEN_SECRET_KEY
+      description: |
+        The key within the Kubernetes Secret that contains the GitHub token.
+      default: "token"
+      type: string
+
+  steps:
+    - name: create-deployment-status
+      env:
+        - name: GITHUBTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.GITHUB_TOKEN_SECRET_NAME)
+              key: $(params.GITHUB_TOKEN_SECRET_KEY)
+
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      script: |
+        #!/usr/libexec/platform-python
+        import http.client
+        import json
+        import os
+        import sys
+
+        deployment_status_url = \
+            "$(params.API_PATH_PREFIX)" + \
+            "/repos/$(params.REPO_FULL_NAME)/deployments" + \
+            "/$(params.DEPLOYMENT_ID)/statuses"
+
+        data = {
+            "state": "$(params.STATE)",
+            "log_url": "$(params.LOG_URL)",
+            "description": "$(params.DESCRIPTION)",
+            "environment_url": "$(params.ENVIRONMENT_URL)",
+            "auto_inactive": json.loads("$(params.AUTO_INACTIVE)"),
+        }
+
+        if "$(params.ENVIRONMENT)" != "":
+            data["environment"] = "$(params.ENVIRONMENT)"
+
+        print("Sending this data to GitHub: ")
+        print(data)
+
+        # This is for our fake github server
+        if "$(params.GITHUB_HOST_URL)".startswith("http://"):
+            conn = http.client.HTTPConnection("$(params.GITHUB_HOST_URL)"
+                                              .replace("http://", ""))
+        else:
+            conn = http.client.HTTPSConnection("$(params.GITHUB_HOST_URL)")
+
+        r = conn.request(
+            "POST",
+            deployment_status_url,
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
+                "Accept": "application/vnd.github.ant-man-preview+json, " +
+                          "application/vnd.github.flash-preview+json"
+            })
+        resp = conn.getresponse()
+
+        if resp.status != 201:
+            print(f'Error: {resp.status}')
+            print(resp.read())
+            sys.exit(1)
+        else:
+            body = json.loads(resp.read().decode())
+            print("GitHub deployment status created for "
+                  "$(params.REPO_FULL_NAME)/$(params.DEPLOYMENT_ID): "
+                  f'id={body["id"]} environment={body["environment"]} '
+                  f'state={body["state"]}')

--- a/task/github-create-deployment-status/0.1/samples/run.yaml
+++ b/task/github-create-deployment-status/0.1/samples/run.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: github-create-deployment-status-run
+spec:
+  taskRef:
+    name: github-create-deployment-status
+  params:
+    - name: REPO_FULL_NAME
+      value: tektoncd/catalog
+    - name: DEPLOYMENT_ID
+      value: "1"
+    - name: STATE
+      value: in_progress

--- a/task/github-create-deployment-status/0.1/samples/secret.yaml
+++ b/task/github-create-deployment-status/0.1/samples/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github
+type: Opaque
+stringData:
+  token: $(personal_github_token)

--- a/task/github-create-deployment-status/0.1/tests/fixtures/github-create-deployment-status.yaml
+++ b/task/github-create-deployment-status/0.1/tests/fixtures/github-create-deployment-status.yaml
@@ -1,0 +1,26 @@
+---
+headers:
+  method: POST
+  path: /repos/{repo:[^/]+/[^/]+}/deployments/{deployment:[0-9]+}/statuses
+response:
+  status: 201
+  output: |
+    {
+      "id": 2,
+      "environment": "staging",
+      "state": "in_progress"
+    }
+  content-type: application/json
+---
+headers:
+  method: POST
+  path: /api/v3/repos/{repo:[^/]+/[^/]+}/deployments/{deployment:[0-9]+}/statuses
+response:
+  status: 201
+  output: |
+    {
+      "id": 2,
+      "environment": "staging",
+      "state": "in_progress"
+    }
+  content-type: application/json

--- a/task/github-create-deployment-status/0.1/tests/pre-apply-task-hook.sh
+++ b/task/github-create-deployment-status/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+kubectl -n ${tns} create secret generic github --from-literal token="secret"

--- a/task/github-create-deployment-status/0.1/tests/run.yaml
+++ b/task/github-create-deployment-status/0.1/tests/run.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: github-create-deployment-status-test-run
+spec:
+  pipelineSpec:
+    tasks:
+      - name: github
+        taskRef:
+          name: github-create-deployment-status
+        params:
+          - name: GITHUB_HOST_URL
+            value: http://127.0.0.1:8080
+          - name: REPO_FULL_NAME
+            value: tektoncd/catalog
+          - name: DEPLOYMENT_ID
+            value: "1"
+          - name: STATE
+            value: in_progress
+      - name: github-enterprise
+        taskRef:
+          name: github-create-deployment-status
+        params:
+          - name: GITHUB_HOST_URL
+            value: http://127.0.0.1:8080
+          - name: API_PATH_PREFIX
+            value: /api/v3
+          - name: REPO_FULL_NAME
+            value: tektoncd/catalog
+          - name: DEPLOYMENT_ID
+            value: "1"
+          - name: STATE
+            value: in_progress


### PR DESCRIPTION
# Changes

This task allows to update a status of GitHub deployment from a Tekton pipeline. This task can be used while deploying or
after deployed (with `finally`) to show status at GitHub deployment status tab.

Signed-off-by: Sunghoon Kang <hoon@linecorp.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```