### PR TITLE
Add kind catalog task.

### DIFF
--- a/task/kind/0.1/README.md
+++ b/task/kind/0.1/README.md
@@ -1,0 +1,51 @@
+# kind
+
+This configures a kind (Kubernetes-in-Docker) environment to be ran in a Task.
+
+See https://kind.sigs.k8s.io for more details.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/kind/0.1/kind.yaml
+```
+
+## Workspaces
+
+- **source**: A workspace that contains the working directory to share among
+  Tasks.
+
+## Parameters
+
+| Name    | Description                                                                                                               |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| image   | kind runtime image to use. Users must override this for their particular runtime environment needed for their kind tests. |
+| command | command to run                                                                                                            |
+
+## Usage
+
+This task sets up settings needed to run `kind` in a Tekton Task using
+Docker-in-Docker. Because of the dependency on DinD, the Task runs in privileged
+mode. Within the task users can create and interact with the `kind` clusters
+like normal.
+
+```yaml
+name: kind
+taskRef:
+  name: kind
+params:
+  - name: command
+    value: [<your command here>]
+  - name: image
+    value: <your image here>
+workspaces:
+  - name: source
+    workspace: <workspace>
+```
+
+For a working example, see [tests/run.yaml](tests/run.yaml). This clones
+[a sample repo](https://github.com/wlynch/tekton-kind) which includes a simple
+script to create and interact with a kind cluster. `image` should point to an
+image containing all runtime dependencies needed to run your test, including
+kind. See https://github.com/wlynch/tekton-kind/blob/main/Dockerfile for a
+sample Dockerfile to get started.

--- a/task/kind/0.1/kind.yaml
+++ b/task/kind/0.1/kind.yaml
@@ -1,0 +1,74 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kind
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/displayName: "kind"
+    tekton.dev/tags: "kind"
+spec:
+  description: >-
+    Sets up and executes commands in KinD (Kubernetes in Docker) environment.
+
+    See https://kind.sigs.k8s.io for more details.
+  params:
+    - name: command
+      type: array
+      description: command to run inside kind environment.
+    - name: image
+      type: string
+      description: Task runtime image. Should typically contain the kind CLI (https://kind.sigs.k8s.io)
+  workspaces:
+    - name: source
+  steps:
+    - image: $(params.image)
+      workingDir: $(workspaces.source.path)
+      name: kind
+      volumeMounts:
+        - mountPath: /var/run/
+          name: dind-socket
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      command: ["$(params.command[*])"]
+  sidecars:
+    - image: docker:18.05-dind
+      name: dind
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - mountPath: /var/lib/docker
+          name: dind-storage
+        - mountPath: /var/run/
+          name: dind-socket
+  volumes:
+    - name: dind-storage
+      emptyDir: {}
+    - name: dind-socket
+      emptyDir: {}
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+    - name: cgroup
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory

--- a/task/kind/0.1/tests/pre-apply-task-hook.sh
+++ b/task/kind/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+add_task git-clone latest

--- a/task/kind/0.1/tests/run.yaml
+++ b/task/kind/0.1/tests/run.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: kind
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: workspace
+    tasks:
+      - name: git
+        taskRef:
+          name: git-clone
+        params:
+          - name: url
+            value: https://github.com/wlynch/tekton-kind.git
+        workspaces:
+          - name: output
+            workspace: workspace
+      - name: kind
+        taskRef:
+          name: kind
+        params:
+          - name: command
+            value: ["$(workspaces.source.path)/test.sh"]
+          - name: image
+            value: gcr.io/tekton-releases/dogfooding/kind-runner@sha256:bfe11e36d3d44ac89e5e9b39382c9b3638f5a3fedc3dc45b54ade8bb0248286d
+        workspaces:
+          - name: source
+            workspace: workspace
+        runAfter:
+          - git
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100M


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds support for running kind within Tekton. This includes 2
main components:

1. Catalog Task for configuring Docker-in-Docker environment.
2. Dockerfile Runner image as a base environment for common runtime tools.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
