### PR TITLE
Append volume in sidecar instead of podTemplate for fixture sidecar and Run CI on whole catalog if e2e test modified

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -224,6 +224,10 @@ function test_task_creation() {
             # available to the sidecar.
             ${KUBECTL_CMD} -n ${tns} create configmap fixtures --from-file=${taskdir}/tests/fixtures
             cat <<EOF>>${TMPF}
+  volumes:
+  - name: fixtures
+    configMap:
+      name: fixtures
   sidecars:
   - image: quay.io/chmouel/go-rest-api-test
     name: go-rest-api
@@ -248,19 +252,6 @@ EOF
             cp ${yaml} ${TMPF}
             [[ -f ${taskdir}/tests/pre-apply-taskrun-hook.sh ]] && source ${taskdir}/tests/pre-apply-taskrun-hook.sh
             function_exists pre-apply-taskrun-hook && pre-apply-taskrun-hook
-
-            # If we have fixtures, add a volume to the taskrun to mount
-            # the fixtures configmap. This only works as long as the original
-            # TaskRun does not use podTemplate
-            [[ -d ${taskdir}/tests/fixtures ]] && {
-            cat <<EOF>>${TMPF}
-  podTemplate:
-    volumes:
-      - name: fixtures
-        configMap:
-          name: fixtures
-EOF
-            }
 
             # Make sure we have deleted the content, this is in case of rerun
             # and namespace hasn't been cleaned up or there is some Cluster*

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -59,6 +59,13 @@ set -o pipefail
 
 all_tests=$(echo task/*/*/tests)
 
+function detect_changed_e2e_test() {
+    # detect for changes in e2e tests dir
+    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep "test/[^/]*"
+}
+
+[[ ! -z $(detect_changed_e2e_test) ]] && TEST_RUN_ALL_TESTS=1
+
 function detect_new_changed_tasks() {
     # detect for changes in tests dir of the task
     git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep 'task/[^\/]*/[^\/]*/tests/[^/]*'|xargs -I {} dirname {}|sed 's/\(tests\).*/\1/g'


### PR DESCRIPTION
# Changes

In e2e tests script podTemplate was getting added even if the yaml
manifest contains only ConfigMap which was failing the CI.
    
Add a envFrom to mount fixtures ConfigMap instead of using podTemplate
as appending the podTemplate was conditional and there can be scenarios
where podTemplate might get appended at wrong location.
    
Also removing `ask/github-add-comment/0.4/tests/fixtures/list-comment-response.json`
and moving this to fixtures file.

*Run CI on whole catalog if e2e test modified*
    
As of now if there is some modification in any e2e test then CI doesn't
run on whole catalog and this might result in failure of some task which
we get to know next day whene nightly periodic job runs.
    
This change detects the changes in the tests dir and if there is any
change then run the CI on whole catalog.

Closes #682 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413

/hold