### PR TITLE
Go back to appending sidecars with python

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -42,21 +42,51 @@ function require_command() {
     fi
 }
 
-require_command ${KUBECTL_CMD}
+require_command ${KUBECTL_CMD} python3
+
+## Python Modules
+
+function require_python_module() {
+    for arg in "$@"; do
+        if ! python3 -c "import ${arg}" &> /dev/null;then
+            echo "required 'python3' module '${arg}' not be found"
+            echo "NOTE: the library name may be different but you you can try installing it via 'python3 -m pip install ${arg}'"
+            exit 1
+        fi
+    done
+}
+
+require_python_module yaml
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
+
+# Add sidecar resources, first argument is the file
+# following arguments are string formed json/yaml processed by yaml.safe_load
+# e.g. '{"image": "registry", "name": "registry"}'
+function add_sidecars() {
+    cp ${1} ${TMPF}.read
+    SCRIPT='
+import sys, yaml
+
+f=open(0, encoding="utf-8")
+data=yaml.load(f.read(), Loader=yaml.FullLoader)
+
+sidecars = map(lambda v: yaml.safe_load(v), sys.argv[1:]) # after -c
+for sidecar in sidecars:
+  if "sidecars" in data["spec"]:
+    data["spec"]["sidecars"].append(sidecar)
+  else:
+    data["spec"]["sidecars"] = [sidecar]
+print(yaml.dump(data, default_flow_style=False))
+'
+    cat ${TMPF}.read | python3 -c "$SCRIPT" "${@:2}" > ${TMPF}
+    rm -f ${TMPF}.read
+}
 
 # Add an internal registry as sidecar to a task so we can upload it directly
 # from our tests withouth having to go to an external registry.
 function add_sidecar_registry() {
-    cp ${1} ${TMPF}.read
-
-    cat ${TMPF}.read | sed -E 's/spec:/spec:\
-  sidecars:\
-  - image: registry\
-    name: registry/' > ${TMPF}
-
-    rm -f ${TMPF}.read
+    add_sidecars ${1} '{"image":"registry", "name": "registry"}'
 }
 
 function add_task() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Resolves #678

- Go back to using python to append yaml
  - I dislike python but after discussion in #678 it's clear the sensible choice is to go back to using it
- Check for libraries in a pip agnostic way
  - I install my python dependencies through [nix](https://search.nixos.org/packages?channel=unstable&show=python39Packages.pyyaml&from=0&size=50&sort=relevance&query=pyyaml) when I have to so the pip method doesn't work. This is likely the same if pyyaml is installed through apt/yum/etc
- allow for adding multiple sidecars with a reusable `add_sidecars` function
- fix overwriting sidecars issue for previous python
  - the previous python implementation would replace sidecars resulting in a _similar_ issue to the bash solution if `add_sidecar_registry` wasnt ran first
- make it more readable
  - There isn't really a cost to having the python multi-line & it's much more readable/maintainable

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
