### PR TITLE
Add jib-maven 0.3 with certficate support for registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,8 @@ some environment variables to it that would be applied :
 We have some helper functions you can use from your `hook` scripts :
 
 * **add_sidecar_registry**: This will add a registry as a sidecar to allow the builder tasks to upload image directly to this sidecar registry instead of having to rely on external registries.
+* **add_sidecar_secure_registry**: This will run a secure registry as a sidecar to allow the tasks to push to this registry using the certs. It will create
+  a configmap `sslcert` with certificate available at key `ca.crt`
 * **add_task**: Install a task into the testing namespace, the first argument is the name of the task, the second argument is the version of the task. If the version is equal to `latest` it will install the latest version of the task.
 
 What can you run from those scripts is whatever defined in the test-runner

--- a/task/buildah/0.2/tests/pre-apply-task-hook.sh
+++ b/task/buildah/0.2/tests/pre-apply-task-hook.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 
-TMD=$(mktemp -d)
-
-# Generate SSL Certificate
-openssl req -newkey rsa:4096 -nodes -sha256 -keyout "${TMD}"/ca.key -x509 -days 365 \
-        -addext "subjectAltName = DNS:registry" \
-        -out "${TMD}"/ca.crt -subj "/C=FR/ST=IDF/L=Paris/O=Tekton/OU=Catalog/CN=registry"
-
-# Create a configmap from these certs
-kubectl create -n "${tns}" configmap sslcert \
-        --from-file=ca.crt="${TMD}"/ca.crt --from-file=ca.key="${TMD}"/ca.key
-
-# Add a secure internal registry as sidecar
-kubectl create -n "${tns}" -f task/buildah/0.2/tests/internal-registry/internal-registry.yaml
+add_sidecar_secure_registry
 
 # Add git-clone
 add_task git-clone latest

--- a/task/jib-maven/0.3/README.md
+++ b/task/jib-maven/0.3/README.md
@@ -1,0 +1,57 @@
+# Jib Maven
+
+This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google's [Jib](https://github.com/GoogleContainerTools/jib) tool.
+
+Jib works with [Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin) and [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin) projects, and this template is for Maven projects.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-maven/0.3/jib-maven.yaml
+```
+
+## Parameters
+
+- **IMAGE**: The name of the image to build
+- **MAVEN_IMAGE**: The base image for maven (_default_: `gcr.io/cloud-builders/mvn`)
+- **DIRECTORY**: The directory in the source repository where source should be found. (*default: .*)
+- **CACHE**: The name of the volume for caching Maven artifacts and
+  base image layers (*default: empty-dir-volume*)
+- **INSECUREREGISTRY**: Whether to allow insecure registry (_default:_ `false`)
+- **CACERTFILE**: CA cert file name containing the certs for TLS verify (_default:_ `service-ca.crt`)
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+* **sslcertdir**: An [*optional* Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry.
+
+## Results
+
+- **IMAGE_DIGEST**: Digest of the image just built.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Jib (Maven)
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-jib-maven
+spec:
+  taskRef:
+    name: jib-maven
+  params:
+  - name: IMAGE
+    value: gcr.io/my-repo/my-image
+  - name: DIRECTORY
+    value: ./examples/helloworld
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+If you would like to customize the container, configure the `jib-maven-plugin` in your `pom.xml`.
+See [setup instructions for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#setup) for more information.

--- a/task/jib-maven/0.3/jib-maven.yaml
+++ b/task/jib-maven/0.3/jib-maven.yaml
@@ -1,0 +1,82 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: jib-maven
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "jib maven"
+spec:
+  description: >-
+    This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google's Jib tool.
+
+    Jib works with Maven and Gradle projects, and this template is for Maven projects.
+
+  params:
+  - name: IMAGE
+    description: Name of the image to build
+  - name: MAVEN_IMAGE
+    type: string
+    description: Maven base image
+    default: gcr.io/cloud-builders/mvn@sha256:57523fc43394d6d9d2414ee8d1c85ed7a13460cbb268c3cd16d28cfb3859e641 #tag: latest
+  - name: DIRECTORY
+    description: The directory containing the app, relative to the source repository root
+    default: .
+  - name: CACHE
+    description: The name of the volume for caching Maven artifacts and base image layers
+    default: empty-dir-volume
+  - name: INSECUREREGISTRY
+    description: Whether to allow insecure registry
+    default: "false"
+  - name: CACERTFILE
+    description: CA cert file name for insecure registry service
+    default: "service-ca.crt"
+  workspaces:
+  - name: source
+  - name: sslcertdir
+    optional: true
+    mountPath: /etc/ssl/certs
+
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+
+  steps:
+  - name: build-and-push
+    image: $(params.MAVEN_IMAGE)
+    # Make sh evaluate $HOME.
+    script: |
+      #!/bin/sh
+
+      [[ -f  /etc/ssl/certs/$(params.CACERTFILE) ]] && \
+      keytool -import -keystore $JAVA_HOME/lib/security/cacerts -storepass "changeit" -file /etc/ssl/certs/$(params.CACERTFILE) -noprompt
+
+      mvn -B \
+        -Duser.home=$HOME \
+        -Djib.allowInsecureRegistries=$(params.INSECUREREGISTRY) \
+        -Djib.to.image=$(params.IMAGE) \
+        compile \
+        com.google.cloud.tools:jib-maven-plugin:build
+    workingDir: $(workspaces.source.path)/$(params.DIRECTORY)
+    env:
+    - name: HOME
+      value: /workspace
+    - name: "DOCKER_CONFIG"
+      value: $(credentials.path)/.docker/
+    volumeMounts:
+    - name: $(params.CACHE)
+      mountPath: /workspace/.m2
+      subPath: m2-cache
+    - name: $(params.CACHE)
+      mountPath: /workspace/.cache
+      subPath: jib-cache
+
+  - name: digest-to-results
+    image: $(params.MAVEN_IMAGE)
+    script: cat $(workspaces.source.path)/target/jib-image.digest | tee /tekton/results/IMAGE_DIGEST
+
+  volumes:
+  - name: empty-dir-volume
+    emptyDir: {}

--- a/task/jib-maven/0.3/tests/internal-registry/internal-registry.yaml
+++ b/task/jib-maven/0.3/tests/internal-registry/internal-registry.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+spec:
+  selector:
+    matchLabels:
+      run: registry
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: registry
+    spec:
+      containers:
+      - name: registry
+        image: docker.io/registry:2
+        ports:
+        - containerPort: 5000
+        volumeMounts:
+          - name: sslcert
+            mountPath: /certs
+        env:
+          - name: REGISTRY_HTTP_TLS_CERTIFICATE
+            value: "/certs/ca.crt"
+          - name: REGISTRY_HTTP_TLS_KEY
+            value: "/certs/ca.key"
+          - name: REGISTRY_HTTP_SECRET
+            value: "tekton"
+      volumes:
+        - name: sslcert
+          configMap:
+            defaultMode: 420
+            items:
+            - key: ca.crt
+              path: ca.crt
+            - key: ca.key
+              path: ca.key
+            name: sslcert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+spec:
+  ports:
+  - port: 5000
+  selector:
+    run: registry

--- a/task/jib-maven/0.3/tests/pre-apply-task-hook.sh
+++ b/task/jib-maven/0.3/tests/pre-apply-task-hook.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 
-TMD=$(mktemp -d)
-
-# Generate SSL Certificate
-openssl req -newkey rsa:4096 -nodes -sha256 -keyout "${TMD}"/ca.key -x509 -days 365 \
-        -addext "subjectAltName = DNS:registry" \
-        -out "${TMD}"/ca.crt -subj "/C=FR/ST=IDF/L=Paris/O=Tekton/OU=Catalog/CN=registry"
-
-# Create a configmap from these certs
-kubectl create -n "${tns}" configmap sslcert \
-        --from-file=ca.crt="${TMD}"/ca.crt --from-file=ca.key="${TMD}"/ca.key
-
-# Add a secure internal registry as sidecar
-kubectl create -n "${tns}" -f task/jib-maven/0.3/tests/internal-registry/internal-registry.yaml
+add_sidecar_secure_registry
 
 # Add git-clone
 add_task git-clone latest

--- a/task/jib-maven/0.3/tests/pre-apply-task-hook.sh
+++ b/task/jib-maven/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+TMD=$(mktemp -d)
+
+# Generate SSL Certificate
+openssl req -newkey rsa:4096 -nodes -sha256 -keyout "${TMD}"/ca.key -x509 -days 365 \
+        -addext "subjectAltName = DNS:registry" \
+        -out "${TMD}"/ca.crt -subj "/C=FR/ST=IDF/L=Paris/O=Tekton/OU=Catalog/CN=registry"
+
+# Create a configmap from these certs
+kubectl create -n "${tns}" configmap sslcert \
+        --from-file=ca.crt="${TMD}"/ca.crt --from-file=ca.key="${TMD}"/ca.key
+
+# Add a secure internal registry as sidecar
+kubectl create -n "${tns}" -f task/jib-maven/0.3/tests/internal-registry/internal-registry.yaml
+
+# Add git-clone
+add_task git-clone latest

--- a/task/jib-maven/0.3/tests/resources.yaml
+++ b/task/jib-maven/0.3/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jib-maven-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/jib-maven/0.3/tests/run.yaml
+++ b/task/jib-maven/0.3/tests/run.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: jib-maven-test-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  - name: ssl-certs
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/che-samples/console-java-simple
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: jib-maven
+    taskRef:
+      name: jib-maven
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    - name: sslcertdir
+      workspace: ssl-certs
+    params:
+    - name: IMAGE
+      value: registry:5000/console-java-simple
+    - name: CACERTFILE
+      value: "ca.crt"
+  - name: verify-digest
+    runAfter:
+    - jib-maven
+    params:
+    - name: digest
+      value: $(tasks.jib-maven.results.IMAGE_DIGEST)
+    taskSpec:
+      params:
+      - name: digest
+      steps:
+      - name: bash
+        image: ubuntu
+        script: |
+          echo $(params.digest)
+          case .$(params.digest) in
+            ".sha"*) exit 0 ;;
+            *)       echo "Digest value is not correct" && exit 1 ;;
+          esac
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: jib-maven-test-pipeline-run
+spec:
+  pipelineRef:
+    name: jib-maven-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: jib-maven-source-pvc
+  - name: ssl-certs
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+        - key: ca.crt
+          path: ca.crt

--- a/task/s2i/0.2/tests/pre-apply-task-hook.sh
+++ b/task/s2i/0.2/tests/pre-apply-task-hook.sh
@@ -1,17 +1,6 @@
 #!/usr/bin/env bash
 
-TMD=$(mktemp -d)
-
-# Generate SSL Certificate
-openssl req -newkey rsa:4096 -nodes -sha256 -keyout "${TMD}"/ca.key -x509 -days 365 \
-    -out "${TMD}"/ca.crt -subj "/C=FR/ST=IDF/L=Paris/O=Tekton/OU=Catalog/CN=registry"
-
-# Create a configmap from these certs
-kubectl create -n "${tns}" configmap sslcert \
-    --from-file=ca.crt="${TMD}"/ca.crt --from-file=ca.key="${TMD}"/ca.key
-
-# Add a secure internal registry as sidecar
-kubectl create -n "${tns}" -f task/buildah/0.2/tests/internal-registry/internal-registry.yaml
+add_sidecar_secure_registry
 
 # Add git-clone
 add_task git-clone latest


### PR DESCRIPTION
This will add jib-maven 0.3 version with support for providing cert file
to talk to insecure registry

Fix #686

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
