### PR TITLE
Remove extra set -x commands in e2e tests.

### DIFF
--- a/task/jenkins/0.1/tests/pre-apply-task-hook.sh
+++ b/task/jenkins/0.1/tests/pre-apply-task-hook.sh
@@ -52,7 +52,6 @@ set -e
 # We need to execute the script on the pods, since it's too painful with direct exec the commands
 cat <<EOF>/tmp/script.sh
 #!/bin/bash
-set -x
 cookiejar=\$(mktemp)
 apitoken=\$(cat /var/jenkins_home/secrets/initialAdminPassword)
 while [[ -z "\${crumb}" ]];do

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
-
 # Configure the number of parallel tests running at the same time, start from 0
 MAX_NUMBERS_OF_PARALLEL_TASKS=4 # => 5
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Aims to make e2e tests consistent across projects.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [n/a] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [n/a] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [n/a] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [n/a] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [n/a] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [n/a] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---