### PR TITLE
jenkins: Add set +x to test script.

### DIFF
--- a/task/jenkins/0.1/tests/pre-apply-task-hook.sh
+++ b/task/jenkins/0.1/tests/pre-apply-task-hook.sh
@@ -34,7 +34,7 @@ EOF
 kubectl -n "${tns}" wait --for=condition=available --timeout=600s deployment/jenkins
 kubectl -n "${tns}" expose deployment jenkins --target-port=8080
 
-set +e
+set +ex
 lock=0
 while true;do
     apitoken="$(kubectl -n "${tns}" exec deployment/jenkins -- cat /var/jenkins_home/secrets/initialAdminPassword 2>/dev/null)"
@@ -52,6 +52,7 @@ set -e
 # We need to execute the script on the pods, since it's too painful with direct exec the commands
 cat <<EOF>/tmp/script.sh
 #!/bin/bash
+set +x
 cookiejar=\$(mktemp)
 apitoken=\$(cat /var/jenkins_home/secrets/initialAdminPassword)
 while [[ -z "\${crumb}" ]];do


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is a follow up to https://github.com/tektoncd/catalog/pull/696.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [n/a] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [n/a] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [n/a] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [n/a] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [n/a] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [n/a] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._
