### PR TITLE
Use bash instead on sh in jib-maven

### DIFF
--- a/task/jib-maven/0.3/jib-maven.yaml
+++ b/task/jib-maven/0.3/jib-maven.yaml
@@ -48,7 +48,7 @@ spec:
     image: $(params.MAVEN_IMAGE)
     # Make sh evaluate $HOME.
     script: |
-      #!/bin/sh
+      #!/bin/bash
 
       [[ -f  /etc/ssl/certs/$(params.CACERTFILE) ]] && \
       keytool -import -keystore $JAVA_HOME/lib/security/cacerts -storepass "changeit" -file /etc/ssl/certs/$(params.CACERTFILE) -noprompt


### PR DESCRIPTION
This will fix the issue of task failing with some MAVEN_IMAGE
like 3.6.3-adoptopenjdk-11 etc because of [[ not found

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
