### PR TITLE
Update plumbing dep to pin gke version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/tektoncd/catalog
 
 go 1.13
 
-require github.com/tektoncd/plumbing v0.0.0-20210305071546-f1f0e093f988
+require github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/tektoncd/plumbing v0.0.0-20191114095731-51c53a31e779 h1:sSxeUSt6SAL0c
 github.com/tektoncd/plumbing v0.0.0-20191114095731-51c53a31e779/go.mod h1:dvZoTaPGpr3ZDqOUR1sc8VOhh/7OzYncVnbQETJTqvQ=
 github.com/tektoncd/plumbing v0.0.0-20210305071546-f1f0e093f988 h1:gH8pWcqdo2xQvVAEWOeta+sEf4gUY1seGU48TwTIBk0=
 github.com/tektoncd/plumbing v0.0.0-20210305071546-f1f0e093f988/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
+github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9 h1:ZLPo8/vilaxvpdvvdd9ZgIhhQJPkHyS5GeKK8UH4/Yo=
+github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/vendor/github.com/tektoncd/plumbing/scripts/README.md
+++ b/vendor/github.com/tektoncd/plumbing/scripts/README.md
@@ -235,7 +235,7 @@ Prerequisites:
 
 Usage:
 
-`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file]`
+`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file] [-g post-file]`
 
 Where:
 
@@ -248,5 +248,7 @@ Where:
 - `extra-path` is the root path within the bucket where release are stored, empty by default
 
 - `file` is the name of the release file, `release.yaml` by default
+
+- `post-file` is the name of the 2nd release file, none by default, `interceptors.yaml` by default for triggers
 
 To summarize, the deployment job will look for the release file into `<bucket>/<extra-path>/<project>/previous/<version>/<file>`

--- a/vendor/github.com/tektoncd/plumbing/scripts/deploy-release.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/deploy-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELEASE_FILE
+declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELEASE_FILE POST_RELEASE_FILE
 
 # This script allows to deploy a Tekton release to the dogfooding cluster
 # by creating a job in the robocat cluster. The complete flow is:
@@ -13,7 +13,7 @@ declare TEKTON_PROJECT TEKTON_VERSION RELEASE_BUCKET_OPT RELEASE_EXTRA_PATH RELE
 # - cluster gke_tekton-nightly_europe-north1-a_robocat defined in the local kubeconfig
 
 # Read command line options
-while getopts ":p:v:b:e:f:" opt; do
+while getopts ":p:v:b:e:f:g:c:r:" opt; do
   case ${opt} in
     p )
       TEKTON_PROJECT=$OPTARG
@@ -30,10 +30,19 @@ while getopts ":p:v:b:e:f:" opt; do
     f )
       RELEASE_FILE=$OPTARG
       ;;
+    g )
+      POST_RELEASE_FILE=$OPTARG
+      ;;
+    c )
+      CONTEXT=$OPTARG
+      ;;
+    r )
+      CLUSTER_RESOURCE=$OPTARG
+      ;;
     \? )
       echo "Invalid option: $OPTARG" 1>&2
       echo 1>&2
-      echo "Usage:  deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file]" 1>&2
+      echo "Usage:  deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file] [-g file] [-c context] [-r cluster-resource]" 1>&2
       ;;
     : )
       echo "Invalid option: $OPTARG requires an argument" 1>&2
@@ -59,13 +68,21 @@ if [ -z "$RELEASE_FILE" ]; then
         RELEASE_FILE="release.yaml"
     fi
 fi
+if [ -z "$POST_RELEASE_FILE" ]; then
+    if [ "$TEKTON_PROJECT" == "triggers" ]; then
+        POST_RELEASE_FILE="interceptors.yaml"
+    fi
+fi
+CONTEXT=${CONTEXT:-gke_tekton-nightly_europe-north1-a_robocat}
+CLUSTER_RESOURCE=${CLUSTER_RESOURCE:-dogfooding-tekton-deployer}
 
 # Deploy the release
-cat <<EOF | kubectl create --cluster gke_tekton-nightly_europe-north1-a_robocat -f-
+# cat <<EOF | tee
+cat <<EOF | kubectl create --cluster ${CONTEXT} -f-
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: tekton-deploy-${TEKTON_PROJECT}-${TEKTON_VERSION}-to-dogfooding-
+  generateName: tekton-deploy-${TEKTON_PROJECT}-${TEKTON_VERSION}-${CLUSTER_RESOURCE%%-*}-
   namespace: default
 spec:
   template:
@@ -88,7 +105,7 @@ spec:
             "params": {
               "target": {
                 "namespace": "tekton-pipelines",
-                "cluster-resource": "dogfooding-tekton-deployer"
+                "cluster-resource": "$CLUSTER_RESOURCE"
               },
               "tekton": {
                 "project": "$TEKTON_PROJECT",
@@ -96,6 +113,7 @@ spec:
                 "environment": "dogfooding",
                 "bucket": "$RELEASE_BUCKET",
                 "file": "$RELEASE_FILE",
+                "post-file": "$POST_RELEASE_FILE",
                 "extra-path": "$RELEASE_EXTRA_PATH"
               },
               "plumbing": {

--- a/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/library.sh
@@ -19,7 +19,7 @@
 # called from command line.
 
 # Default GKE version to be used with Tekton Serving
-readonly SERVING_GKE_VERSION=gke-latest
+readonly SERVING_GKE_VERSION=gke-channel-regular
 readonly SERVING_GKE_IMAGE=cos
 
 # Conveniently set GOPATH if unset

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,2 +1,2 @@
-# github.com/tektoncd/plumbing v0.0.0-20210305071546-f1f0e093f988
+# github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9
 github.com/tektoncd/plumbing/scripts


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit pins catalog to gke 1.18 for the next six months
while plumbing works on removing basic auth.

Major hat-tip to @jmcshane for doing the work to resolve this
problem!



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

/kind misc