### PR TITLE
Add Task to write a file onto a workspace

### DIFF
--- a/task/write-file/0.1/README.md
+++ b/task/write-file/0.1/README.md
@@ -13,8 +13,8 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/wr
 ## Parameters
 
 - **path**: Relative path to create within the workspace. Directories will be created as necessary. 
-- **permissions**: Contents of the file to create. Note that octal numbers need quoting in YAML.
-- **contents**: chmod-style permission string to apply to the file. Note that permissions will not be applied to created directories.
+- **mode**: chmod-style mode string to apply to the file. Note that mode will not be applied to created directories.
+- **contents**: Contents of the file to create. Note that octal numbers need quoting in YAML.
 
 ## Usage
 
@@ -31,7 +31,7 @@ This example task generates a random password from the pipeline run's unique id.
   params:
     - name: path
       value: ./config/login.ini
-    - name: permissions
+    - name: mode
       value: "0400"
     - name: contents
       value: |

--- a/task/write-file/0.1/README.md
+++ b/task/write-file/0.1/README.md
@@ -1,0 +1,41 @@
+# Write a file to a workspace
+
+This task can be used to write a file onto the output workspace.
+Use parameter expansion to insert variable content into the written
+file. It can also set specific permissions on the file.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/write-file/0.1/write-file.yaml
+```
+
+## Parameters
+
+- **path**: Relative path to create within the workspace. Directories will be created as necessary. 
+- **permissions**: Contents of the file to create. Note that octal numbers need quoting in YAML.
+- **contents**: chmod-style permission string to apply to the file. Note that permissions will not be applied to created directories.
+
+## Usage
+
+This example task generates a random password from the pipeline run's unique id.
+
+```yaml
+- name: output-credentials
+  taskRef:
+    name: write-file
+    kind: Task
+  workspaces:
+    - name: output
+      workspace: shared-workspace
+  params:
+    - name: path
+      value: ./config/login.ini
+    - name: permissions
+      value: "0400"
+    - name: contents
+      value: |
+        [credentials]
+        user = ze-user
+        password = $(context.pipelineRun.uid)
+```

--- a/task/write-file/0.1/tests/run.yaml
+++ b/task/write-file/0.1/tests/run.yaml
@@ -16,8 +16,8 @@ spec:
       params:
         - name: path
           value: ./config/login.ini
-        - name: permissions
-          value: "0400"
+        - name: mode
+          value: "1234"
         - name: contents
           value: |
             [credentials]
@@ -38,6 +38,7 @@ spec:
             script: |
               #!/bin/sh
               grep $(params.uid) ./config/login.ini
+              ls -l ./config/login.ini | grep -- '--w--wxr-T'
         workspaces:
           - name: output
       workspaces:

--- a/task/write-file/0.1/tests/run.yaml
+++ b/task/write-file/0.1/tests/run.yaml
@@ -1,0 +1,62 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: write-file-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: output-credentials
+      taskRef:
+        name: write-file
+        kind: Task
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: path
+          value: ./config/login.ini
+        - name: permissions
+          value: "0400"
+        - name: contents
+          value: |
+            [credentials]
+            user = ze-user
+            password = $(context.pipelineRun.uid)
+    - name: verify
+      runAfter: [output-credentials]
+      params:
+        - name: uid
+          value: $(context.pipelineRun.uid)
+      taskSpec:
+        params:
+          - name: uid
+        steps:
+          - name: check-output
+            image: alpine:3.10
+            workingDir: $(workspaces.output.path)
+            script: |
+              #!/bin/sh
+              grep $(params.uid) ./config/login.ini
+        workspaces:
+          - name: output
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: write-file-pipeline-run
+spec:
+  pipelineRef:
+    name: write-file-pipeline
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Mi

--- a/task/write-file/0.1/tests/run.yaml
+++ b/task/write-file/0.1/tests/run.yaml
@@ -33,7 +33,7 @@ spec:
           - name: uid
         steps:
           - name: check-output
-            image: alpine:3.10
+            image: docker.io/library/alpine:3.12@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
             workingDir: $(workspaces.output.path)
             script: |
               #!/bin/sh

--- a/task/write-file/0.1/write-file.yaml
+++ b/task/write-file/0.1/write-file.yaml
@@ -37,7 +37,7 @@ spec:
       description: Workspace onto which the file is written.
   steps:
     - name: write-file
-      image: docker.io/library/alpine:3.10
+      image: docker.io/library/alpine:3.12@sha256:36553b10a4947067b9fbb7d532951066293a68eae893beba1d9235f7d11a20ad
       workingDir: $(workspaces.output.path)
       env:
         - name: PARAM_PATH

--- a/task/write-file/0.1/write-file.yaml
+++ b/task/write-file/0.1/write-file.yaml
@@ -26,12 +26,12 @@ spec:
       description: >
         Contents of the file to create. Note that octal numbers
         need quoting in YAML.
-    - name: permissions
+    - name: mode
       type: string
       default: "0755"
       description: >
         chmod-style permission string to apply to the file. Note that
-        permissions will not be applied to created directories.
+        mode will not be applied to created directories.
   workspaces:
     - name: output
       description: Workspace onto which the file is written.
@@ -39,12 +39,17 @@ spec:
     - name: write-file
       image: docker.io/library/alpine:3.10
       workingDir: $(workspaces.output.path)
+      env:
+        - name: PARAM_PATH
+          value: $(params.path)
+        - name: PARAM_MODE
+          value: $(params.mode)
+        - name: PARAM_CONTENTS
+          value: $(params.contents)
       script: |
         #!/bin/sh
-        set -e
-        DIRNAME=$(dirname "$(params.path)")
+        set -eu
+        DIRNAME=$(dirname "${PARAM_PATH}")
         mkdir -p "$DIRNAME"
-        cat <<EOF > "./$(params.path)"
-        $(params.contents)
-        EOF
-        chmod "$(params.permissions)" "$(params.path)"
+        printf '%s' "${PARAM_CONTENTS}" > "./${PARAM_PATH}"
+        chmod "${PARAM_MODE}" "./${PARAM_PATH}"

--- a/task/write-file/0.1/write-file.yaml
+++ b/task/write-file/0.1/write-file.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: write-file
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: tools
+    tekton.dev/displayName: Write a file
+spec:
+  description: >-
+    Write a file to a workspace
+
+    This task can be used to write a file onto the output workspace.
+    Use parameter expansion to insert variable content into the written
+    file. It can also set specific permissions on the file.
+  params:
+    - name: path
+      type: string
+      description: >
+        Relative path to create within the workspace. Directories will
+        be created as necessary.
+    - name: contents
+      type: string
+      description: >
+        Contents of the file to create. Note that octal numbers
+        need quoting in YAML.
+    - name: permissions
+      type: string
+      default: "0755"
+      description: >
+        chmod-style permission string to apply to the file. Note that
+        permissions will not be applied to created directories.
+  workspaces:
+    - name: output
+      description: Workspace onto which the file is written.
+  steps:
+    - name: write-file
+      image: docker.io/library/alpine:3.10
+      workingDir: $(workspaces.output.path)
+      script: |
+        #!/bin/sh
+        set -e
+        DIRNAME=$(dirname "$(params.path)")
+        mkdir -p "$DIRNAME"
+        cat <<EOF > "./$(params.path)"
+        $(params.contents)
+        EOF
+        chmod "$(params.permissions)" "$(params.path)"

--- a/task/write-file/0.1/write-file.yaml
+++ b/task/write-file/0.1/write-file.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: tools
+    tekton.dev/tags: generic
     tekton.dev/displayName: Write a file
 spec:
   description: >-

--- a/task/write-file/0.1/write-file.yaml
+++ b/task/write-file/0.1/write-file.yaml
@@ -24,14 +24,14 @@ spec:
     - name: contents
       type: string
       description: >
-        Contents of the file to create. Note that octal numbers
-        need quoting in YAML.
+        Contents of the file to create.
     - name: mode
       type: string
       default: "0755"
       description: >
         chmod-style permission string to apply to the file. Note that
-        mode will not be applied to created directories.
+        octal numbers need quoting in YAML. Mode will not be applied
+        to created directories.
   workspaces:
     - name: output
       description: Workspace onto which the file is written.


### PR DESCRIPTION
# Changes

This PR adds a catalog task to write a parameter out as a file, creating intermediate directories and setting permissions as necessary. While it is possible today to have a workspace that is a mounted config map variable, that provides limited support for expanding parameters into the file (i.e. the [replace-tokens](https://hub.tekton.dev/tekton/task/replace-tokens) task). Ultimately, my argument for adopting this task into the catalog is that I believe others will also look for a file-writing task and their experience of Tekton will be better if they find one.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

