### PR TITLE
Add a task to publish a catalog as bundles

### DIFF
--- a/task/tekton-catalog-publish/0.1/README.md
+++ b/task/tekton-catalog-publish/0.1/README.md
@@ -1,0 +1,82 @@
+# Tekton Catalog Publish
+
+This task publishes each Task in a Tekton catalog as [Tekton Bundles](https://tekton.dev/docs/pipelines/pipelines/#tekton-bundles).
+The catalog must be structured as a [Tekton Catalog](https://github.com/tektoncd/catalog#catalog-structure).
+
+Bundles are published to `$REGISTRY/$PATH/<task-name>:<task-version>` and, when `TAG` is provided, to
+`$REGISTRY/$PATH/<task-name>:$TAG`. An example of extra tag could be the git sha of the catalog repo that
+is being published. The task uses the `tkn bundle` command to publish, which is available
+in `tkn` starting with version v0.18.0.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tekton-catalog-publish/0.1/tekton-catalog-publush.yaml
+```
+
+## Parameters
+
+| name      | description                                 | default                               |
+| --------- | ------------------------------------------- | ------------------------------------- |
+| TKN_IMAGE | `tkn` CLI container image to run this task. | gcr.io/tekton-releases/dogfooding/tkn |
+| REGISTRY  | The registry where bundles are published to |                                       |
+| PATH      | The path in the registry                    | tekton/catalog/tasks                  |
+| TAG       | An optional extra tag (optional)            | ""                                    |
+
+## Workspaces
+
+- **catalog**: A workspace with the catalog to be published.
+- **dockerconfig**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks)
+  that allows providing a `.docker/config.json` file for tkn to access the container registry. The file should be placed at
+  the root of the Workspace with name `config.json`.
+
+## Usage
+
+1. Passing `REGISTRY` and catalog workspace:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: tekton-catalog-publish-
+spec:
+  taskRef:
+    name: tekton-catalog-publish
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+     - name: REGISTRY
+       value: icr.io
+```
+
+2. Passing `REGISTRY`, `PATH`, `TAG` and both workspaces
+
+   1. Sample secret can be found [here](https://github.com/tektoncd/catalog/tree/main/task/tekton-catalog-publish/0.1/samples/secrets.yaml)
+
+   2. Create `TaskRun`
+
+ ```yaml
+ apiVersion: tekton.dev/v1beta1
+ kind: TaskRun
+ metadata:
+   generateName: tekton-catalog-publish-
+ spec:
+   taskRef:
+     name: tekton-catalog-publish
+   workspaces:
+     - name: source
+       persistentVolumeClaim:
+         claimName: my-source
+     - name: dockerconfig
+       secret:
+         secretName: regcred
+   params:
+     - name: REGISTRY
+       value: icr.io
+     - name: PATH
+       value: tekton/mycatalog/tasks
+     - name: TAG
+       value: 49456927aef7e81a48a972db2bfd6e19a64d9a77
+ ```

--- a/task/tekton-catalog-publish/0.1/samples/run-with-workspace-secret.yaml
+++ b/task/tekton-catalog-publish/0.1/samples/run-with-workspace-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: tekton-catalog-publish-
+spec:
+  taskRef:
+    name: tekton-catalog-publish
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+    - name: dockerconfig
+      secret:
+        secretName: regcred
+  params:
+    - name: REGISTRY
+      value: icr.io
+    - name: PATH
+      value: tekton/mycatalog/tasks
+    - name: TAG
+      value: 49456927aef7e81a48a972db2bfd6e19a64d9a77

--- a/task/tekton-catalog-publish/0.1/samples/run-without-workspace-secret.yaml
+++ b/task/tekton-catalog-publish/0.1/samples/run-without-workspace-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: tekton-catalog-publish-
+spec:
+  taskRef:
+    name: tekton-catalog-publish
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: REGISTRY
+      value: icr.io

--- a/task/tekton-catalog-publish/0.1/samples/secrets.yaml
+++ b/task/tekton-catalog-publish/0.1/samples/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+stringData:
+  config.json: |
+    {
+      "auths" : {
+        "icr.io" : {
+          "auth" : "iamapikey",
+          "identitytoken" : "test123test123"
+        },
+      }
+    }

--- a/task/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
+++ b/task/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: tekton-catalog-publish
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: catalog, bundles
+    tekton.dev/displayName: "Publish a Tekton Catalog"
+spec:
+  description: >-
+    This task publishes each Task in a Tekton catalog as a Tekton Bundle.
+    The catalog must be structured as a Tekton Catalog.
+    Bundles are published to $TARGET/<task-name>:<task-version> and, when
+    TAG is provided, to $TARGET/<task-name>:$TAG. A typical extra tag
+    would be the git sha of the catalog repo that is being published.
+    The task uses the "tkn bundle" command to publish, which is available
+    in tkn starting with version v0.18.0.
+
+  workspaces:
+    - name: catalog
+      description: >-
+        A workspace that holds the catalog to be published. The catalog must be stored
+        in the root of the workspace mount point, and is must follow the
+        [Tetkon Catalog](https://github.com/tektoncd/catalog#catalog-structure) structure.
+    - name: dockerconfig
+      description: >-
+        An optional workspace that allows providing a .docker/config.json
+        file for tkn to access the container registry. The file should be placed at
+        the root of the Workspace with name config.json.
+      optional: true
+
+  params:
+    - name: TKN_IMAGE
+      type: string
+      description: tkn CLI container image to run this task
+      default: gcr.io/tekton-releases/dogfooding/tkn@sha256:015bb6018d5eaf4523a775f4955c85f68077099753661941d06843d5a61a86df
+    - name: REGISTRY
+      type: string
+      description: The registry where bundles are published to
+    - name: PATH
+      type: string
+      description: The path in the registry
+      default: tekton/catalog/tasks
+    - name: TAG
+      type: string
+      description: An optional extra tag. If provided, tasks are tagged with it too.
+      default: ""
+
+  steps:
+    - name: publish
+      image: "$(params.TKN_IMAGE)"
+      workingDir: "$(workspaces.catalog.path)"
+      env:
+        - name: REGISTRY
+          value: $(params.REGISTRY)
+        - name: REGISTRY_PATH
+          value: $(params.PATH)
+        - name: TAG
+          value: $(params.TAG)
+      script: |
+        #!/usr/bin/env sh
+        set -e
+        TARGET="${REGISTRY}"
+        [ "${REGISTRY_PATH}" != "" ] && TARGET="${TARGET}/${REGISTRY_PATH}"
+        find task -type f -mindepth 3 -maxdepth 3 -name '*.yaml' -o '*.yml'| while read -r task_version_dir; do
+          FOLDER=$(dirname "$task_version_dir")
+          VERSION=$(basename "$FOLDER")
+          TASK=$(basename "$(dirname "$FOLDER")")
+          tkn bundle push "${TARGET}/${TASK}:${VERSION}" -f "$task_version_dir"
+          [ "${TAG}" != "" ] && \
+            tkn bundle push "${TARGET}/${TASK}:${TAG}" -f "$task_version_dir"
+          sleep 0.1
+        done

--- a/task/tekton-catalog-publish/0.1/tests/pre-apply-task-hook.sh
+++ b/task/tekton-catalog-publish/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests withouth having to go to an external registry.
+add_sidecar_registry ${TMPF}
+
+# Add git-clone
+add_task git-clone latest

--- a/task/tekton-catalog-publish/0.1/tests/resources.yaml
+++ b/task/tekton-catalog-publish/0.1/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: catalog-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/tekton-catalog-publish/0.1/tests/run.yaml
+++ b/task/tekton-catalog-publish/0.1/tests/run.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: catalog-publish-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: reduce
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: all-but-one
+            image: alpine
+            script: |
+              set -e
+              cd "$(workspaces.source.path)/task"
+              ls | grep -v 'git-clone' | xargs rm -rf
+    - name: publish
+      runAfter:
+        - reduce
+      workspaces:
+        - name: catalog
+          workspace: shared-workspace
+      params:
+        - name: REGISTRY
+          value: localhost:5000
+        - name: TAG
+          value: $(tasks.fetch-repository.results.commit)
+      taskRef:
+        name: tekton-catalog-publish
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: catalog-publish-test-pipeline-run
+spec:
+  pipelineRef:
+    name: catalog-publish-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: catalog-source-pvc


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a new task that uses tkn bundle to publish a Tekton catalog as
bundles to a container registry. Each task corresponds to a dedicated
bundle, which task versions available as tags.

Optionally, bundles are tagged with an extra tag provided as an input
parameter.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
