### PR TITLE
Raise the visibility of authoring recommendations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ your descriptive commit message(s)! -->
 These are the criteria that every PR should meet, please check them off as you
 review them:
 
+- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
 - [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
 - [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
 - [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,17 +37,7 @@ the following guidelines:
 While this repository is meant to be educational, its primary goal is to serve
 as a place users can find, share and discover useful components.
 This is **not** a samples repo to showcase Tekton features, this is a collection
-* Submissions should follow established best practices.
-Tekton is still young so this is going to be a shifting goalpost, but here are
-some examples:
-    * `Task`s should expose parameters and declare input/output resources, and
-    document them.
-    * Submissions should be as *portable* as possible.
-    They should not be hardcoded to specific repositories, clusters,
-    environments etc.
-    * Images should either be pinned by digest or point to tags with
-    documented maintenance policies.
-    The goal here is to make it so that submissions keep working.
+* Submissions should follow established [authoring recommendations](recommendations.md)
 * Submissions should be well-documented.
 * *Coming Soon* Submissions should be testable, and come with the required
 tests.

--- a/recommendations.md
+++ b/recommendations.md
@@ -61,6 +61,13 @@ On the catalog, this means that you should, where possible:
         privileged: true
   ```
 
+## Be as portable and compatible as possible
+
+Make use of recent Kubernetes and Tekton features only when a user
+will expect it from the task's purpose. Your task may be of great use
+to users that have good reason not to upgrade right now. Your task
+should include the `tekton.dev/pipelines.minVersion`.
+
 ## Remember that there are other languages than sh and bash
 
 Yes, sh and bash are DSLs for running processes, but sometimes there


### PR DESCRIPTION
# Changes

Writing my first contribution to the catalog, I failed to find the authoring recommendations, resulting in unnecessary Slack noise. This adds references to parts of the documentation that I did read in the hope that others will see them in time.

I removed the recommendations list that was inlined in CONTRIBUTING.md as it is covered by the linked recommendations.md. The "portability" item was only partially covered by the recommendations, so I took the liberty of adding a section about backwards version compatibility, as that is the most important portability concern I can think of in this context.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)