### PR TITLE
Pass git-clone Params as EnvVars Instead

### DIFF
--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -74,8 +74,33 @@ spec:
   steps:
     - name: clone
       image: $(params.gitInitImage)
+      env:
+      - name: PARAM_URL
+        value: $(params.url)
+      - name: PARAM_REVISION
+        value: $(params.revision)
+      - name: PARAM_REFSPEC
+        value: $(params.refspec)
+      - name: PARAM_SUBMODULES
+        value: $(params.submodules)
+      - name: PARAM_DEPTH
+        value: $(params.depth)
+      - name: PARAM_SSL_VERIFY
+        value: $(params.sslVerify)
+      - name: PARAM_SUBDIRECTORY
+        value: $(params.subdirectory)
+      - name: PARAM_DELETE_EXISTING
+        value: $(params.deleteExisting)
+      - name: PARAM_HTTP_PROXY
+        value: $(params.httpProxy)
+      - name: PARAM_HTTPS_PROXY
+        value: $(params.httpsProxy)
+      - name: PARAM_NO_PROXY
+        value: $(params.noProxy)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
       script: |
-        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
 
         cleandir() {
           # Delete any existing contents of the repo directory if it exists.
@@ -92,22 +117,22 @@ spec:
           fi
         }
 
-        if [[ "$(params.deleteExisting)" == "true" ]] ; then
+        if [[ "${PARAM_DELETE_EXISTING}" == "true" ]] ; then
           cleandir
         fi
 
-        test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
-        test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
-        test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
         /ko-app/git-init \
-          -url "$(params.url)" \
-          -revision "$(params.revision)" \
-          -refspec "$(params.refspec)" \
+          -url "${PARAM_URL}" \
+          -revision "${PARAM_REVISION}" \
+          -refspec "${PARAM_REFSPEC}" \
           -path "$CHECKOUT_DIR" \
-          -sslVerify="$(params.sslVerify)" \
-          -submodules="$(params.submodules)" \
-          -depth "$(params.depth)"
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth "${PARAM_DEPTH}"
         cd "$CHECKOUT_DIR"
         RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
         EXIT_CODE="$?"

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -80,15 +80,42 @@ spec:
   steps:
     - name: clone
       image: $(params.gitInitImage)
+      env:
+      - name: PARAM_URL
+        value: $(params.url)
+      - name: PARAM_REVISION
+        value: $(params.revision)
+      - name: PARAM_REFSPEC
+        value: $(params.refspec)
+      - name: PARAM_SUBMODULES
+        value: $(params.submodules)
+      - name: PARAM_DEPTH
+        value: $(params.depth)
+      - name: PARAM_SSL_VERIFY
+        value: $(params.sslVerify)
+      - name: PARAM_SUBDIRECTORY
+        value: $(params.subdirectory)
+      - name: PARAM_DELETE_EXISTING
+        value: $(params.deleteExisting)
+      - name: PARAM_HTTP_PROXY
+        value: $(params.httpProxy)
+      - name: PARAM_HTTPS_PROXY
+        value: $(params.httpsProxy)
+      - name: PARAM_NO_PROXY
+        value: $(params.noProxy)
+      - name: PARAM_VERBOSE
+        value: $(params.verbose)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
       script: |
         #!/bin/sh
         set -eu -o pipefail
 
-        if [[ "$(params.verbose)" == "true" ]] ; then
+        if [[ "${PARAM_VERBOSE}" == "true" ]] ; then
           set -x
         fi
 
-        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
 
         cleandir() {
           # Delete any existing contents of the repo directory if it exists.
@@ -105,22 +132,22 @@ spec:
           fi
         }
 
-        if [[ "$(params.deleteExisting)" == "true" ]] ; then
+        if [[ "${PARAM_DELETE_EXISTING}" == "true" ]] ; then
           cleandir
         fi
 
-        test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
-        test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
-        test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
         /ko-app/git-init \
-          -url "$(params.url)" \
-          -revision "$(params.revision)" \
-          -refspec "$(params.refspec)" \
+          -url "${PARAM_URL}" \
+          -revision "${PARAM_REVISION}" \
+          -refspec "${PARAM_REFSPEC}" \
           -path "$CHECKOUT_DIR" \
-          -sslVerify="$(params.sslVerify)" \
-          -submodules="$(params.submodules)" \
-          -depth "$(params.depth)"
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth "${PARAM_DEPTH}"
         cd "$CHECKOUT_DIR"
         RESULT_SHA="$(git rev-parse HEAD)"
         EXIT_CODE="$?"
@@ -129,4 +156,4 @@ spec:
         fi
         # ensure we don't add a trailing newline to the result
         echo -n "$RESULT_SHA" > $(results.commit.path)
-        echo -n "$(params.url)" > $(results.url.path)
+        echo -n "${PARAM_URL}" > $(results.url.path)

--- a/task/git-clone/0.3/git-clone.yaml
+++ b/task/git-clone/0.3/git-clone.yaml
@@ -86,15 +86,44 @@ spec:
   steps:
     - name: clone
       image: $(params.gitInitImage)
+      env:
+      - name: PARAM_URL
+        value: $(params.url)
+      - name: PARAM_REVISION
+        value: $(params.revision)
+      - name: PARAM_REFSPEC
+        value: $(params.refspec)
+      - name: PARAM_SUBMODULES
+        value: $(params.submodules)
+      - name: PARAM_DEPTH
+        value: $(params.depth)
+      - name: PARAM_SSL_VERIFY
+        value: $(params.sslVerify)
+      - name: PARAM_SUBDIRECTORY
+        value: $(params.subdirectory)
+      - name: PARAM_DELETE_EXISTING
+        value: $(params.deleteExisting)
+      - name: PARAM_HTTP_PROXY
+        value: $(params.httpProxy)
+      - name: PARAM_HTTPS_PROXY
+        value: $(params.httpsProxy)
+      - name: PARAM_NO_PROXY
+        value: $(params.noProxy)
+      - name: PARAM_VERBOSE
+        value: $(params.verbose)
+      - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+        value: $(params.sparseCheckoutDirectories)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
       script: |
         #!/bin/sh
         set -eu -o pipefail
 
-        if [[ "$(params.verbose)" == "true" ]] ; then
+        if [[ "${PARAM_VERBOSE}" == "true" ]] ; then
           set -x
         fi
 
-        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
 
         cleandir() {
           # Delete any existing contents of the repo directory if it exists.
@@ -111,23 +140,23 @@ spec:
           fi
         }
 
-        if [[ "$(params.deleteExisting)" == "true" ]] ; then
+        if [[ "${PARAM_DELETE_EXISTING}" == "true" ]] ; then
           cleandir
         fi
 
-        test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
-        test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
-        test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
         /ko-app/git-init \
-          -url "$(params.url)" \
-          -revision "$(params.revision)" \
-          -refspec "$(params.refspec)" \
+          -url "${PARAM_URL}" \
+          -revision "${PARAM_REVISION}" \
+          -refspec "${PARAM_REFSPEC}" \
           -path "$CHECKOUT_DIR" \
-          -sslVerify="$(params.sslVerify)" \
-          -submodules="$(params.submodules)" \
-          -depth "$(params.depth)" \
-          -sparseCheckoutDirectories "$(params.sparseCheckoutDirectories)"
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth "${PARAM_DEPTH}" \
+          -sparseCheckoutDirectories "${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
         cd "$CHECKOUT_DIR"
         RESULT_SHA="$(git rev-parse HEAD)"
         EXIT_CODE="$?"
@@ -136,4 +165,4 @@ spec:
         fi
         # ensure we don't add a trailing newline to the result
         echo -n "$RESULT_SHA" > $(results.commit.path)
-        echo -n "$(params.url)" > $(results.url.path)
+        echo -n "${PARAM_URL}" > $(results.url.path)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Previously we passed params directly into the `script` block of
the clone step. Because Pipelines doesn't escape variable values
when interpolating them the behaviour of the task could be changed
by the contents of a param.

This commit changes the way params are provided to the script;
instead of being interpolated directly they are converted first
into environment variables and accessed through shell's `${}`
construct.


# Submitter Checklist

There are no behaviour changes to the git-clone tasks themselves.