### PR TITLE
Remove permission check in write-file task

### DIFF
--- a/task/write-file/0.1/tests/run.yaml
+++ b/task/write-file/0.1/tests/run.yaml
@@ -38,7 +38,7 @@ spec:
             script: |
               #!/bin/sh
               grep $(params.uid) ./config/login.ini
-              ls -l ./config/login.ini | grep -- '--w--wxr-T'
+              ls -l ./config/login.ini
         workspaces:
           - name: output
       workspaces:


### PR DESCRIPTION
# Changes

In write-file task's tests we are checking whether file permission is
equal to `--w--wxr-T`. These permissions may vary depending on rbac
enforced cluster. Example on some cluster we can get the value as
`-rw-rwxr-T` thus failing the test.

In this commit I am removing the `grep -- '--w--wxr-T'` so that the
tests doesn't fail on other clusters.

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
