### PR TITLE
Fix getting comment with multi Lines

### DIFF
--- a/task/github-add-comment/0.4/github-add-comment.yaml
+++ b/task/github-add-comment/0.4/github-add-comment.yaml
@@ -106,7 +106,7 @@ spec:
         api_url = "{base}/repos/{package}/issues/{id}".format(
           base="", package="/".join(split_url[1:3]), id=split_url[-1])
 
-        commentParamValue = "$(params.COMMENT_OR_FILE)"
+        commentParamValue = """$(params.COMMENT_OR_FILE)"""
 
         # check if workspace is bound and parameter passed is a filename or not
         if "$(workspaces.comment-file.bound)" == "true" and os.path.exists(commentParamValue):


### PR DESCRIPTION
# Changes

This use python multi string when getting the comment params so we don't bug out on multi lines comments.

Fixes issue #731 

/cc @afrittoli @vinamra28 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
