### PR TITLE
Add golang-test 0.2

### DIFF
--- a/task/golang-test/0.2/README.md
+++ b/task/golang-test/0.2/README.md
@@ -1,0 +1,54 @@
+# Golang Test
+
+This task is a Golang task to test Go projects.
+
+## Install the task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-test/0.1/golang-test.yaml
+```
+
+### Parameters
+
+* **package**: base package to build in
+* **packages**: packages to test (_default:_ ./cmd/...)
+* **image**: image to use for the golang container image (_default:_ docker.io/library/golang)
+* **context**: path to the directory to use as context (default: .)
+* **version**: golang version to use for builds (_default:_ latest)
+* **flags**: flags to use for `go test` command (_default:_ -race -cover -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+
+### Workspaces
+
+* **source**: A
+  [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md)
+  containing the source to build.
+* **cache**: An optional Workspace for sharing the go modules download
+  cache. See [this sample](./samples/golang-test-optional-cache-workspace.yaml)
+  for a complete pipeline example with a cache for go modules.
+
+## Usage
+
+This TaskRun runs the Task to run unit-tests on
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: test-my-code
+spec:
+  taskRef:
+    name: golang-test
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+  - name: packages
+    value: ./pkg/...
+```

--- a/task/golang-test/0.2/golang-test.yaml
+++ b/task/golang-test/0.2/golang-test.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-test
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: test
+    tekton.dev/displayName: "golang test"
+spec:
+  description: >-
+    This Task is Golang task to test Go projects.
+
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: packages
+    description: "packages to test (default: ./...)"
+    default: "./..."
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
+  - name: image
+    description: golang container image
+    default: "mirror.gcr.io/library/golang"
+  - name: version
+    description: golang version to use for tests
+    default: "latest"
+  - name: flags
+    description: flags to use for the test command
+    default: -race -cover -v
+  - name: GOOS
+    description: "running program's operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running program's architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  workspaces:
+  - name: source
+  - name: cache
+    optional: true
+  steps:
+  - name: unit-test
+    workingDir: $(workspaces.source.path)
+    image: $(params.image):$(params.version)
+    script: |
+      set -ex
+      mkdir -p $HOME/.cache
+      [ "$(workspaces.cache.bound)" = "true" ] && ln -vs $(workspaces.cache.path) $HOME/.cache/go-build
+
+      if [ ! -e $(workspaces.source.path)/go.mod ];then
+        SRC_PATH="$GOPATH/src/$(params.package)/$(params.context)"
+        mkdir -p $SRC_PATH
+        cp -R "$(workspaces.source.path)"/"$(params.context)"/* $SRC_PATH
+        cd $SRC_PATH
+      fi
+      go test $(params.flags) $(params.packages)
+    env:
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"

--- a/task/golang-test/0.2/samples/golang-test-optional-cache-workspace.yaml
+++ b/task/golang-test/0.2/samples/golang-test-optional-cache-workspace.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: golang-cache
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: test-git-clone
+spec:
+  params:
+    - name: repo_url
+    - name: revision
+  workspaces:
+  - name: source
+  - name: cache
+  tasks:
+    - name: fetch
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.repo_url)
+        - name: revision
+          value: $(params.revision)
+      workspaces:
+      - name: output
+        workspace: source
+    - name: test
+      runAfter: [fetch]
+      taskRef:
+        name: golang-test
+      params:
+        - name: package
+          value: "."
+        - name: flags
+          value: "-race -cover -v"
+      workspaces:
+        - name: source
+          workspace: source
+        - name: cache
+          workspace: cache
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: test-git-clone-pr
+spec:
+  pipelineRef:
+    name: test-git-clone
+  params:
+    - name: repo_url
+      value: https://github.com/chmouel/go-simple-uploader
+    - name: revision
+      value: master
+  workspaces:
+  - name: source
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  - name: cache
+    persistentVolumeClaim:
+      claimName: golang-cache

--- a/task/golang-test/0.2/tests/pre-apply-task-hook.sh
+++ b/task/golang-test/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Add git-clone
+add_task git-clone latest

--- a/task/golang-test/0.2/tests/resources.yaml
+++ b/task/golang-test/0.2/tests/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: golang-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/golang-test/0.2/tests/run.yaml
+++ b/task/golang-test/0.2/tests/run.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: golang-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/tektoncd/cli
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-test
+      taskRef:
+        name: golang-test
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: github.com/tektoncd/cli
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-test-pipeline-run
+spec:
+  pipelineRef:
+    name: golang-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: golang-source-pvc


### PR DESCRIPTION
Add golang-test 0.2

* No need to cp -R to $GOPATH if we are running with GO111MODULE=on.
* Add a optional workspace for go mod download cache.
* Add a complete sample showing on how to use the optional workspace.
* Allow redefining the container image location.
* Set the docker image to the gcr mirror image instead of the one from
  docker.io which gets easily rate limited.
