### PR TITLE
Allow overriding GO caching environment variable

### DIFF
--- a/task/golang-build/0.2/README.md
+++ b/task/golang-build/0.2/README.md
@@ -1,0 +1,51 @@
+# Golang Build
+
+This Task is Golang task to build Go projects.
+
+## Install the task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.2/golang-build.yaml
+
+```
+
+
+### Parameters
+
+* **package**: base package under test
+* **packages**: packages to test (_default:_ ./...)
+* **version**: golang version to use for tests (_default:_ latest)
+* **flags**: flags to use for `go build` command (_default:_ -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+* **GOCACHE**: value for go caching path (_default:_ "")
+* **GOMODCACHE**: value for go module caching path (_default:_ "")
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+
+## Usage
+
+This TaskRun runs the Task to compile commands from
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+`golangci-lint`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: build-my-code
+spec:
+  taskRef:
+    name: golang-build
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+```

--- a/task/golang-build/0.2/golang-build.yaml
+++ b/task/golang-build/0.2/golang-build.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-build
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: build-tool
+    tekton.dev/displayName: "golang build"
+spec:
+  description: >-
+    This Task is Golang task to build Go projects.
+
+  params:
+  - name: package
+    description: base package to build in
+  - name: packages
+    description: "packages to build (default: ./cmd/...)"
+    default: "./cmd/..."
+  - name: version
+    description: golang version to use for builds
+    default: "latest"
+  - name: flags
+    description: flags to use for the test command
+    default: -v
+  - name: GOOS
+    description: "running program's operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running program's architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  - name: GOCACHE
+    description: "Go caching directory path"
+    default: ""
+  - name: GOMODCACHE
+    description: "Go mod caching directory path"
+    default: ""
+  workspaces:
+  - name: source
+  steps:
+  - name: build
+    image: docker.io/library/golang:$(params.version)
+    workingDir: $(workspaces.source.path)
+    script: |
+      if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+         SRC_PATH="$GOPATH/src/$(params.package)"
+         mkdir -p $SRC_PATH
+         cp -R "$(workspaces.source.path)"/* $SRC_PATH
+         cd $SRC_PATH
+      fi
+      go build $(params.flags) $(params.packages)
+    env:
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"
+    - name: GOCACHE
+      value: "$(params.GOCACHE)"
+    - name: GOMODCACHE
+      value: "$(params.GOMODCACHE)"

--- a/task/golang-build/0.2/tests/pre-apply-task-hook.sh
+++ b/task/golang-build/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Add git-clone
+add_task git-clone latest

--- a/task/golang-build/0.2/tests/resources.yaml
+++ b/task/golang-build/0.2/tests/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: golang-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/golang-build/0.2/tests/run.yaml
+++ b/task/golang-build/0.2/tests/run.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: golang-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/chmouel/go-rest-api-test
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-build
+      taskRef:
+        name: golang-build
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: github.com/chmouel/go-rest-api-test
+        - name: packages
+          value: "./"
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-test-pipeline-run
+spec:
+  pipelineRef:
+    name: golang-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: golang-source-pvc

--- a/task/golang-test/0.2/README.md
+++ b/task/golang-test/0.2/README.md
@@ -1,0 +1,50 @@
+# Golang Test
+
+This task is a Golang task to test Go projects.
+
+## Install the task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-test/0.2/golang-test.yaml
+```
+
+### Parameters
+
+* **package**: base package to build in
+* **packages**: packages to test (_default:_ ./cmd/...)
+* **context**: path to the directory to use as context (default: .)
+* **version**: golang version to use for builds (_default:_ latest)
+* **flags**: flags to use for `go test` command (_default:_ -race -cover -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+* **GOCACHE**: value for go caching path (_default:_ "")
+* **GOMODCACHE**: value for go module caching path (_default:_ "")
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+## Usage
+
+This TaskRun runs the Task to run unit-tests on
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: test-my-code
+spec:
+  taskRef:
+    name: golang-test
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+  - name: packages
+    value: ./pkg/...
+```

--- a/task/golang-test/0.2/golang-test.yaml
+++ b/task/golang-test/0.2/golang-test.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-test
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: test
+    tekton.dev/displayName: "golang test"
+spec:
+  description: >-
+    This Task is Golang task to test Go projects.
+
+  params:
+  - name: package
+    description: package (and its children) under test
+  - name: packages
+    description: "packages to test (default: ./...)"
+    default: "./..."
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
+  - name: version
+    description: golang version to use for tests
+    default: "latest"
+  - name: flags
+    description: flags to use for the test command
+    default: -race -cover -v
+  - name: GOOS
+    description: "running program's operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running program's architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  - name: GOCACHE
+    description: "Go caching directory path"
+    default: ""
+  - name: GOMODCACHE
+    description: "Go mod caching directory path"
+    default: ""
+  workspaces:
+  - name: source
+  steps:
+  - name: unit-test
+    image: docker.io/library/golang:$(params.version)
+    workingDir: $(workspaces.source.path)
+    script: |
+      if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+         SRC_PATH="$GOPATH/src/$(params.package)"
+         mkdir -p $SRC_PATH
+         cp -R "$(workspaces.source.path)"/* $SRC_PATH
+         cd $SRC_PATH
+      fi
+      go test $(params.flags) $(params.packages)
+    env:
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"
+    - name: GOCACHE
+      value: "$(params.GOCACHE)"
+    - name: GOMODCACHE
+      value: "$(params.GOMODCACHE)"

--- a/task/golang-test/0.2/tests/pre-apply-task-hook.sh
+++ b/task/golang-test/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Add git-clone
+add_task git-clone latest

--- a/task/golang-test/0.2/tests/resources.yaml
+++ b/task/golang-test/0.2/tests/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: golang-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/golang-test/0.2/tests/run.yaml
+++ b/task/golang-test/0.2/tests/run.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: golang-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/chmouel/go-rest-api-test
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-test
+      taskRef:
+        name: golang-test
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: github.com/chmouel/go-rest-api-test
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-test-pipeline-run
+spec:
+  pipelineRef:
+    name: golang-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: golang-source-pvc

--- a/task/golangci-lint/0.2/README.md
+++ b/task/golangci-lint/0.2/README.md
@@ -1,0 +1,52 @@
+# Golangci Lint
+
+This Task is a Golang task to validate Go projects.
+
+## Install the task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golangci-lint/0.2/golangci-lint.yaml
+
+```
+
+### Parameters
+
+* **package**: base package under validation
+* **context**: path to the directory to use as context (default: .)
+* **flags**: flags to use for `golangci-lint` command (_default:_--verbose)
+* **version**: golangci-lint version to use (_default:_ v1.16)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+* **GOCACHE**: value for go caching path (_default:_ "")
+* **GOMODCACHE**: value for go module caching path (_default:_ "")
+* **GOLANGCI_LINT_CACHE**: value for golangci-lint caching path (_default:_ "")
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+## Usage
+
+This TaskRun runs the Task to validate
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline) `pkg` package with
+`golangci-lint`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: lint-my-code
+spec:
+  taskRef:
+    name: golangci-lint
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+  - name: flags
+    value: --verbose
+```

--- a/task/golangci-lint/0.2/golangci-lint.yaml
+++ b/task/golangci-lint/0.2/golangci-lint.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golangci-lint
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: lint
+    tekton.dev/displayName: "golangci lint"
+spec:
+  description: >-
+    This Task is Golang task to validate Go projects.
+
+  params:
+  - name: package
+    description: base package (and its children) under validation
+  - name: context
+    description: path to the directory to use as context.
+    default: "."
+  - name: flags
+    description: flags to use for the test command
+    default: --verbose
+  - name: version
+    description: golangci-lint version to use
+    default: "v1.39"
+  - name: GOOS
+    description: "running operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  - name: GOCACHE
+    description: "Go caching directory path"
+    default: ""
+  - name: GOMODCACHE
+    description: "Go mod caching directory path"
+    default: ""
+  - name: GOLANGCI_LINT_CACHE
+    description: "golangci-lint cache path"
+    default: ""
+  workspaces:
+  - name: source
+    mountPath: /workspace/src/$(params.package)
+  steps:
+  - name: lint
+    image: docker.io/golangci/golangci-lint:$(params.version)
+    workingDir: $(workspaces.source.path)/$(params.context)
+    script: |
+      golangci-lint run $(params.flags)
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"
+    - name: GOCACHE
+      value: "$(params.GOCACHE)"
+    - name: GOMODCACHE
+      value: "$(params.GOMODCACHE)"
+    - name: GOLANGCI_LINT_CACHE
+      value: "$(params.GOLANGCI_LINT_CACHE)"

--- a/task/golangci-lint/0.2/tests/pre-apply-task-hook.sh
+++ b/task/golangci-lint/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests without having to go to an external registry.
+add_sidecar_registry ${TMPF}
+
+# Add git-clone
+add_task git-clone latest

--- a/task/golangci-lint/0.2/tests/resources.yaml
+++ b/task/golangci-lint/0.2/tests/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: golang-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/golangci-lint/0.2/tests/run.yaml
+++ b/task/golangci-lint/0.2/tests/run.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: golang-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-lint
+      taskRef:
+        name: golangci-lint
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: github.com/tektoncd/catalog
+        - name: flags
+          value: --disable-all --enable=errcheck
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-test-pipeline-run
+spec:
+  pipelineRef:
+    name: golang-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: golang-source-pvc

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -59,7 +59,7 @@ all_tests=$(echo task/*/*/tests)
 
 function detect_changed_e2e_test() {
     # detect for changes in e2e tests dir
-    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep "test/[^/]*"
+    git --no-pager diff --name-only "${PULL_BASE_SHA}".."${PULL_PULL_SHA}"|grep "^test/[^/]*"
 }
 
 [[ -z ${TEST_RUN_ALL_TESTS} ]] && [[ ! -z $(detect_changed_e2e_test) ]] && TEST_RUN_ALL_TESTS=1


### PR DESCRIPTION
# Changes

Allow overriding the GO cache, GO mod caching and golangci-lint caching.

Optimize golang-build and golang-test to not do a fulll copy of the source
inside the GOPATH if we have a go.mod in source root directory.

Changed the test for smaller repo since the pipeline/cli one were really slow (~12mn per test)

Background: https://blog.chmouel.com/2021/05/25/speed-up-your-tekton-pipeline-caching-the-hacky-way/



# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413