### PR TITLE
Better issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,16 +1,36 @@
----
-name: Issue Template
-about: Template for both bug reports and feature requests
----
-
-# Expected Behavior
-
-# Actual Behavior
-
-# Steps to Reproduce the Problem
-
-1.
-2.
-3.
-
-# Additional Info
+name: Bug Report
+description: File a bug report
+labels: "bug"
+body:
+- type: markdown
+  attributes:
+    value: Before raising an issue, please search for existing issues to avoid creating duplicates. For questions and support please use the [community forum](https://github.com/tektoncd/catalog/discussions).
+- type: textarea
+  id: bug-description
+  attributes:
+    label: Bug description
+    description: Summarize the bug encountered concisely
+  validations:
+    required: true
+- type: textarea
+  id: steps-to-reproduce
+  attributes:
+    label: Steps to reproduce
+    description: Describe the steps to reproduce the issue
+  validations:
+    required: true
+- type: textarea
+  id: expected-behavior
+  attributes:
+    label: Expected behavior
+    description: Describe what you should see instead
+- type: textarea
+  id: example-repository
+  attributes:
+    label: Example repository
+    description: If possible, please create an [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) of the bug and link it here in the bug report
+- type: textarea
+  id: anything-else
+  attributes:
+    label: Anything else?
+    description: Let us know if you have any additional feedback!


### PR DESCRIPTION
# Changes

Trying a better github issue template which is something I saw in gitpod-io issue [template](https://raw.githubusercontent.com/gitpod-io/gitpod/main/.github/ISSUE_TEMPLATE/bug_report.yml)

The UI looks like this : 

<img width="1302" alt="image" src="https://user-images.githubusercontent.com/98980/119612574-59be8b00-bdfc-11eb-96e0-79f3f830a0e5.png">

The good part is that some section can be set as "required"

maybe something we can have for other projects and for pull request too?

/cc @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
