### PR TITLE
Add a script to help managing embedded scripts externally

### DIFF
--- a/test/embed-script-externally/README.md
+++ b/test/embed-script-externally/README.md
@@ -1,0 +1,42 @@
+# Embed your script in external files
+
+This is a small script that helps you manage your embedded [scripts
+](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#running-scripts-within-steps)
+inside your Tekton tasks externally.
+
+## Install
+
+You need the [ruamel.yaml](https://yaml.readthedocs.io/en/latest/) library, it
+should be availabe in fedora/debian default repositories or you can simply use
+pip to install it :
+
+```shell
+pip3 install ruamel.yaml
+```
+
+## Usage
+
+If for example you have a task like this :
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  steps:
+    - name: step1
+      script: "#include script.sh"
+```
+
+The "embed_script" script will see it and includes the `script.sh` in place of
+your `"#include script.sh"`.
+
+At the end it will print every yaml documents even the ones who have not been
+substituted from includes. Each document will be separated with a `"---"`
+separator.
+
+## CAVEAT
+
+It doesn't support embedded `TaskSpec` or `PipelineSpec` yet but there is no
+reason this cannot be supported.

--- a/test/embed-script-externally/__init__.py
+++ b/test/embed-script-externally/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Author: Chmouel Boudjnah <chmouel@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/test/embed-script-externally/embed_script.py
+++ b/test/embed-script-externally/embed_script.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import io
+import os.path
+import re
+import sys
+import typing
+
+from ruamel.yaml import YAML
+
+REGEXP = r"^#include\s*([^$]*)"
+
+
+def replace(yamlBlob: str) -> typing.List:
+    yaml = YAML()
+    docs = yaml.load_all(yamlBlob)
+    rets = []
+    for doc in docs:
+        if "spec" not in doc and "tasks" not in doc["spec"]:
+            continue
+        for task in doc["spec"]["steps"]:
+            if "script" not in task:
+                continue
+            if not task["script"].startswith("#include "):
+                continue
+            match = re.match(REGEXP, task["script"])
+            if not match:
+                continue
+            filename = match[1].strip()
+            if not os.path.exists(filename):
+                sys.stderr.write(
+                    f"WARNING: we could not find a file called: {filename} in task: {doc['metadata']['name']} step: {task['name']}"
+                )
+                continue
+            fp = open(filename)
+            task["script"] = fp.read()
+            fp.close()
+        output = io.StringIO()
+        yaml.dump(doc, output)
+        rets.append(output.getvalue())
+    return rets
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Manage your embedded Tekton script task externally")
+    parser.add_argument("yaml_file", help="Yaml file to parse")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    replaced = replace(open(args.yaml_file))
+    for doc in replaced:
+        if not doc or not doc.strip():
+            continue
+        print("---")
+        print(doc)

--- a/test/embed-script-externally/test_embed_script.py
+++ b/test/embed-script-externally/test_embed_script.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os.path
+import tempfile
+import unittest
+
+import embed_script
+
+taskreplace = """
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  steps:
+    - name: step1
+      script: "#include %s"
+"""
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.test_file = tempfile.NamedTemporaryFile(delete=False).name
+
+    def tearDown(self):
+        os.remove(self.test_file)
+
+    def test_replace(self):
+        scriptstr = "Et ipsa scientia potestas est"
+        fp = open(self.test_file, 'w')
+        fp.write(scriptstr)
+        fp.close()
+
+        blob = taskreplace % (self.test_file)
+        ret = embed_script.replace(blob)
+        if not ret:
+            self.fail("we didn't get any task back")
+        if scriptstr not in ret[0]:
+            self.fail("we didn't get any replacement in task")
+
+    def test_skip(self):
+        strs = "nowheretobefile.bash"
+        blob = taskreplace % strs
+        ret = embed_script.replace(blob)
+        if not ret:
+            self.fail("we should still have task back")
+
+        # TODO: monkeypatch sys.write to caputre the warning, but that's another fight for another day
+        if "#include %s" % (strs) not in ret[0]:
+            self.fail("we should have kept the #include")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The idea of this script is if you have inside your script something like this :

It will replace this #include with the content of python/script.py

This make it easier to write your tasks and use linters/code checkers from your
editor on your included script.

This sparked from @afrittoli  discussion here https://github.com/tektoncd/catalog/discussions/715

Currently this is a helper so this would be up to the contributor to uses it before commit but i think we can maybe think on how to do this post merge so to be transparent.

