### PR TITLE
Add extra possibility for username and emoij to make it more Tekton Like

### DIFF
--- a/task/send-to-webhook-slack/0.1/README.md
+++ b/task/send-to-webhook-slack/0.1/README.md
@@ -37,6 +37,10 @@ kubectl apply -f webhook-secret.yaml
 
 * **message**: Plain text message to be posted in the slack channel
 
+* **bot-name**: The name of the bot to use. Defaults to `Tekton Bot`.
+
+* **icon-emoji**: The emoji to use for the bot. For example you could import a tekton emoji and use `:tekton:` over here.
+
 ## Usage
 
 This TaskRun runs the Task to post a message to the channel that the webhook URL is associated with.

--- a/task/send-to-webhook-slack/0.1/send-to-webhook-slack.yaml
+++ b/task/send-to-webhook-slack/0.1/send-to-webhook-slack.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: messaging
+    tekton.dev/displayName: "Send message to Slack Channel"
 spec:
   description: >-
     These tasks post a simple message to a slack channel.
@@ -20,15 +21,32 @@ spec:
   - name: message
     type: string
     description: plain text message
+  - name: bot-name
+    type: string
+    description: plain text message
+    default: 'Tekton Bot'
+  - name: icon-emoji
+    type: string
+    description: plain text message
+    default: ':robot_face:'
   steps:
   - name: post
     image: docker.io/curlimages/curl:7.68.0@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151 #tag: 7.68.0
     script: |
-      #!/bin/sh
-      /usr/bin/curl -X POST -H 'Content-type: application/json' --data '{"text":"$(params.message)"}' $URL
+      #!/usr/bin/env sh
+      MESSAGE=$(echo "${MESSAGE}" | sed -e 's/\"/\\\\"/g')
+      BOTNAME=$(echo "${BOTNAME}" | sed -e 's/\"/\\\\"/g')
+      JSON="{\"text\": \"${MESSAGE}\", \"username\": \"${BOTNAME}\", \"icon_emoji\": \"${EMOJI}\"}"
+      curl -X POST -H 'Content-Type: application/json' --data "${JSON}" "${URL}"
     env:
     - name: URL
       valueFrom:
         secretKeyRef:
           name: $(params.webhook-secret)
           key: url
+    - name: MESSAGE
+      value: $(params.message)
+    - name: BOTNAME
+      value: $(params.bot-name)
+    - name: EMOJI
+      value: $(params.icon-emoji)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a few more parameters to Slack webhook to make it more Tekton like in a Slack channel.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
