### PR TITLE
Add option to use Basic Auth

### DIFF
--- a/task/github-set-status/0.2/README.md
+++ b/task/github-set-status/0.2/README.md
@@ -44,12 +44,14 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gi
   from the status of other systems. _e.g:_ `continuous-integration/tekton`
 * **STATE**: The state of the status. Can be one of the following `error`,
   `failure`, `pending`, or `success`.
+* **AUTH_TYPE**: The type of authentication to use. You could use the less secure "Basic"
+      for example. See https://docs.github.com/en/rest/overview/other-authentication-methods for more information.
 * **GITHUB_TOKEN_SECRET_NAME** \[optional\]: The name of the kubernetes secret that
   contains the GitHub token. Default value: `github`
 * **GITHUB_TOKEN_SECRET_KEY** \[optional\]: The key within the kubernetes secret that
   contains the GitHub token. Default value: `token`
 
-## Usage
+## Usage for Bearer authentication
 
 This TaskRun sets a commit on GitHub to `pending` getting tested by the CI.
 
@@ -74,6 +76,50 @@ spec:
       value: "Build has started"
     - name: STATE
       value: pending
+    - name: TARGET_URL
+      value: https://tekton/dashboard/taskrun/log
+```
+
+
+## Usage for Basic authentication
+
+Make sure the token is fabricated by base64 encoding the username and password with a semicolon in between.
+Example shell script to use:
+
+```bash
+#!/bin/bash
+echo "${1}:${2}" | base64
+```
+
+Calling this script like this `./script.sh githubuser reallyinsecurepassword` would result in `Z2l0aHVidXNlcjpyZWFsbHlpbnNlY3VyZXBhc3N3b3JkCg==`.
+
+Place the result in a secret in the way as the token-based authenticaton.
+
+The following TaskRun shows the usage of Basic authentication. Adding the `AUTH_TYPE` parameter.
+
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: github-set-status
+  name: github-set-status-run-on-commit-bd93
+spec:
+  taskRef:
+    kind: Task
+    name: github-set-status-with-basic-auth
+  params:
+    - name: REPO_FULL_NAME
+      value: tektoncd/catalog
+    - name: SHA
+      value: bd93869b489258cef567ccf85e7ef6bc0d6949ea
+    - name: DESCRIPTION
+      value: "Build has started"
+    - name: STATE
+      value: pending
+    - name: AUTH_TYPE
+      value: Basic
     - name: TARGET_URL
       value: https://tekton/dashboard/taskrun/log
 ```

--- a/task/github-set-status/0.2/github-set-status.yaml
+++ b/task/github-set-status/0.2/github-set-status.yaml
@@ -80,6 +80,13 @@ spec:
       The state of the status. Can be one of the following `error`,
       `failure`, `pending`, or `success`.
     type: string
+
+  - name: AUTH_TYPE
+    description: |
+      The type of authentication to use. You could use the less secure "Basic" for example
+    type: string
+    default: Bearer
+
   steps:
     - name: set-status
       env:
@@ -92,6 +99,9 @@ spec:
       image: registry.access.redhat.com/ubi8/python-38:1-34.1599745032
       script: |
         #!/usr/libexec/platform-python
+
+        """This script will send the message towards Slack"""
+
         import json
         import os
         import http.client
@@ -108,14 +118,16 @@ spec:
         print("Sending this data to GitHub: ")
         print(data)
 
+        authHeader = "$(params.AUTH_TYPE) " + os.environ["GITHUBTOKEN"]
+
         conn = http.client.HTTPSConnection("$(params.GITHUB_HOST_URL)")
-        r = conn.request(
+        conn.request(
             "POST",
             status_url,
             body=json.dumps(data),
             headers={
                 "User-Agent": "TektonCD, the peaceful cat",
-                "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
+                "Authorization": authHeader,
                 "Accept": "application/vnd.github.v3+json ",
             })
         resp = conn.getresponse()
@@ -123,5 +135,5 @@ spec:
             print("Error: %d" % (resp.status))
             print(resp.read())
         else:
-          print("GitHub status '$(params.STATE)' has been set on "
+            print("GitHub status '$(params.STATE)' has been set on "
                 "$(params.REPO_FULL_NAME)#$(params.SHA) ")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add the option to influence the authorization type so a user could use Basic Auth with prefabricated b64 encoded token.
Not the most secure option, but it's another option for setting commit status.

# Submitter Checklist

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
- [X] File path follows  `<kind>/<name>/<version>/name.yaml`
- [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
- [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
- [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
- [X] mandatory `spec.description` follows the convention