### PR TITLE
change config file url for gitleaks

### DIFF
--- a/task/gitleaks/0.1/README.md
+++ b/task/gitleaks/0.1/README.md
@@ -66,7 +66,7 @@ spec:
     - name: repo_path
       value: contest-arena
     - name: config_file_url
-      value: https://raw.githubusercontent.com/urvashigupta7/secret_detection/master/gitleaks.toml
+      value: https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitleaks/0.1/samples/gitleaks.toml
     - name: config_file_path
       value: gitleaks.toml
     - name: output_format

--- a/task/gitleaks/0.1/samples/run.yaml
+++ b/task/gitleaks/0.1/samples/run.yaml
@@ -32,7 +32,7 @@ spec:
     - name: repo_path
       value: contest-arena
     - name: config_file_url
-      value: https://raw.githubusercontent.com/urvashigupta7/secret_detection/master/gitleaks.toml
+      value: https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitleaks/0.1/samples/gitleaks.toml
     - name: config_file_path
       value: gitleaks.toml
     - name: output_format

--- a/task/gitleaks/0.1/tests/run.yaml
+++ b/task/gitleaks/0.1/tests/run.yaml
@@ -151,7 +151,7 @@ spec:
     - name: repo_path
       value: chatapp
     - name: config_file_url
-      value: https://raw.githubusercontent.com/urvashigupta7/secret_detection/master/gitleaks.toml
+      value: https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitleaks/0.1/samples/gitleaks.toml
     - name: config_file_path
       value: gitleaks.toml
     - name: output_format
@@ -216,7 +216,7 @@ spec:
     - name: repo_path
       value: chatapp
     - name: config_file_url
-      value: https://raw.githubusercontent.com/urvashigupta7/secret_detection/master/gitleaks.toml
+      value: https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitleaks/0.1/samples/gitleaks.toml
     - name: config_file_path
       value: gitleaks.toml
     - name: output_format
@@ -279,7 +279,7 @@ spec:
     - name: repo_path
       value: chatapp
     - name: config_file_url
-      value: https://raw.githubusercontent.com/urvashigupta7/secret_detection/master/gitleaks.toml
+      value: https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitleaks/0.1/samples/gitleaks.toml
     - name: config_file_path
       value: gitleaks.toml
     - name: output_format


### PR DESCRIPTION


# Changes
Changed Config file url to the one present in [gitleaks/0.1/samples](https://github.com/tektoncd/catalog/tree/main/task/gitleaks/0.1/samples)
# Submitter Checklist


- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention