### PR TITLE
fix argocd sync and wait task

### DIFF
--- a/task/argocd-task-sync-and-wait/0.1/argocd-task-sync-and-wait.yaml
+++ b/task/argocd-task-sync-and-wait/0.1/argocd-task-sync-and-wait.yaml
@@ -35,14 +35,8 @@ spec:
     - name: login
       image: docker.io/argoproj/argocd:$(params.argocd-version)
       script: |
-        if [ -z $ARGOCD_AUTH_TOKEN ]; then
-          yes | argocd login $ARGOCD_SERVER --username=$ARGOCD_USERNAME --password=$ARGOCD_PASSWORD;
+        if [ -z "$ARGOCD_AUTH_TOKEN" ]; then
+          yes | argocd login "$ARGOCD_SERVER" --username="$ARGOCD_USERNAME" --password="$ARGOCD_PASSWORD";
         fi
-    - name: sync
-      image: docker.io/argoproj/argocd:$(params.argocd-version)
-      script: |
-        argocd app sync $(params.application-name) --revision $(params.revision) $(params.flags)
-    - name: wait
-      image: docker.io/argoproj/argocd:$(params.argocd-version)
-      script: |
-        argocd app wait $(params.application-name) --health $(params.flags)
+        argocd app sync "$(params.application-name)" --revision "$(params.revision)" "$(params.flags)"
+        argocd app wait "$(params.application-name)" --health "$(params.flags)"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Logging in from one container and having sync and wait run in the separate containers does not work. Authenticate once and reuse the connection across the containers in a pod is not supported. Sync and wait fails with the authentication error. Either we login at each step or collapse sync and wait along with the login step. Or we could authenticate once and
find a way to how to reuse the same connection across the containers.

For now, combining everything into a single step.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
