### PR TITLE
Add documentation about platform information for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,18 @@ _See [our project roadmap](roadmap.md)._
   ```yaml
 
    labels:
-      app.kubernetes.io/version: "0.1"            👈 Version of the resource
+      app.kubernetes.io/version: "0.1"                 👈 Version of the resource
 
     annotations:
-      tekton.dev/pipelines.minVersion: "0.12.1"   👈 Min Version of pipeline resource is compatible
-      tekton.dev/tags: "ansible, cli"             👈 Comma separated list of tags
-      tekton.dev/displayName: "Ansible Tower Cli" 👈 displayName can be optional
+      tekton.dev/pipelines.minVersion: "0.12.1"        👈 Min Version of pipeline resource is compatible
+      tekton.dev/tags: "ansible, cli"                  👈 Comma separated list of tags
+      tekton.dev/displayName: "Ansible Tower Cli"      👈 displayName can be optional
+      tekton.dev/platforms: "linux/amd64,linux/s390x"  👈 Comma separated list of platforms, can be optional
 
   spec:
     description: |-
       ansible-tower-cli task simplifies
-      workflow, jobs, manage users...             👈 Summary
+      workflow, jobs, manage users...                  👈 Summary
 
       Ansible Tower (formerly ‘AWX’) is a ...
 

--- a/recommendations.md
+++ b/recommendations.md
@@ -315,3 +315,20 @@ it already exists, nothing happens.
 
 This technique can be used to "short circuit" work when it is not
 necessary to _re-run_.
+
+## Provide "tekton.dev/platforms" annotation
+
+`tekton.dev/platforms` annotation indicates on which platforms (for
+instance, "linux/amd64,linux/arm64" or "windows/amd64") resource can
+be run.
+The most reliable option to verify the platform list is to run the
+e2e tests provided with the resource. Minimal requirement is to use
+the container image, which has support for corresponding platform.
+
+Add `Platforms` section into the README.md of the corresponding resource.
+If running of the resource on specific platform requires to use another
+image or do other customization, it should be also mentioned in the section.
+
+If you don't know, which platforms to specify, good start is to use
+"linux/amd64", as it is most popular platform and most likely the tests,
+you've done, were on top of it.


### PR DESCRIPTION

# Changes

Following TEP 70, `tekton.dev/platforms` annotation can be used to specify on which platforms the resource can be run.

- add best practices for platform information in the recommendations.md
- add example of usage for tekton.dev/platforms annotation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
