### PR TITLE
Openshift client task fix README of 0.1 and add 0.2

### DIFF
--- a/task/openshift-client/0.1/README.md
+++ b/task/openshift-client/0.1/README.md
@@ -22,7 +22,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/op
 
 ### Inputs
 
-* **cluster**: a `cluster`-type `PipelineResource` specifying the target OpenShift cluster to execute the commands against it
+* **source**: a `git`-type `PipelineResource` which holds the files that needs to be applied on the cluster. (_Optional_)
 
 ## ServiceAccount
 

--- a/task/openshift-client/0.2/README.md
+++ b/task/openshift-client/0.2/README.md
@@ -1,0 +1,46 @@
+## OpenShift Client Task
+
+[OpenShift](http://www.openshift.com) is a Kubernetes distribution from Red Hat which provides `oc`, the [OpenShift CLI](https://docs.openshift.com/container-platform/4.1/cli_reference/getting-started-cli.html) that complements `kubectl` for simplifying deployment and configuration applications on OpenShift.
+
+Openshift-client runs commands against the cluster provided by the user via optional workspace and if not provided then it will take the cluster on which the `Task` is running.
+
+## Changelog
+
+- Use `workspaces` instead of `PipelineResources`.
+- Add support for kubeconfig which can be provided via `workspaces`.
+- Added samples and improved the README.
+- Removed `ARGS` params.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/openshift-client/0.2/openshift-client.yaml
+```
+
+## Parameters
+
+- **SCRIPT:** script of oc commands to execute e.g. `oc get pod $1 -0 yaml` This will take the first value of ARGS as pod name (_default_: `oc help`)
+
+- **VERSION:** The OpenShift version to use (_default_: `4.7`)
+
+## Workspaces
+
+The `Task` uses 2 optional workspaces:
+
+- **manifest-dir**: The workspace which contains kubernetes manifests which we want to apply on the cluster.
+
+- **kubeconfig-dir**: The workspace which contains the `kubeconfig` file if in case we want to run the `oc` command on another cluster.
+
+## ServiceAccount
+
+If you don't specify a service account to be used for running the `TaskRun` or `PipelineRun`, the `default` [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server). OpenShift by default does not allow the default service account to modify objects in the namespace. Therefore you should either explicitly grant permission to the default service account (by creating rolebindings) or [create a new service account with sufficient privileges](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#service-account-permissions) and specify it on the [`TaskRun`](https://github.com/tektoncd/pipeline/blob/main/docs/taskruns.md#service-account) or [`PipelineRun`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelineruns.md#service-account).
+
+You can do the former via `oc` and running the following command, replacing `<namespace>` with your target namespace:
+
+```
+oc policy add-role-to-user edit -z default -n <namespace>
+```
+
+## Usage
+
+We can refer to the following [sample](./samples/run-with-workspace.yaml) of how to use this task.

--- a/task/openshift-client/0.2/openshift-client.yaml
+++ b/task/openshift-client/0.2/openshift-client.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: openshift-client
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: cli
+    tekton.dev/displayName: "openshift client"
+spec:
+  workspaces:
+    - name: manifest-dir
+      optional: true
+      description: >-
+        The workspace which contains kubernetes manifests which we want to apply on the cluster.
+    - name: kubeconfig-dir
+      optional: true
+      description: >-
+        The workspace which contains the the kubeconfig file if in case we want to run the oc command on another cluster.
+  description: >-
+    This task runs commands against the cluster provided by user
+    and if not provided then where the Task is being executed.
+
+    OpenShift is a Kubernetes distribution from Red Hat which provides oc,
+    the OpenShift CLI that complements kubectl for simplifying deployment
+    and configuration applications on OpenShift.
+
+  params:
+    - name: SCRIPT
+      description: The OpenShift CLI arguments to run
+      type: string
+      default: "oc help"
+    - name: VERSION
+      description: The OpenShift Version to use
+      type: string
+      default: "4.7"
+  steps:
+    - name: oc
+      image: quay.io/openshift/origin-cli:$(params.VERSION)
+      script: |
+        #!/usr/bin/env bash
+
+        [[ "$(workspaces.manifest-dir.bound)" == "true" ]] && \
+        cd $(workspaces.manifest-dir.path)
+
+        [[ "$(workspaces.kubeconfig-dir.bound)" == "true" ]] && \
+        [[ -f $(workspaces.kubeconfig-dir.path)/kubeconfig ]] && \
+        export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
+
+        $(params.SCRIPT)

--- a/task/openshift-client/0.2/samples/run-with-workspace.yaml
+++ b/task/openshift-client/0.2/samples/run-with-workspace.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-client-sa
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-client-role
+rules:
+  # Core API
+  - apiGroups: [""]
+    resources: ["services", "pods", "deployments", "configmaps", "secrets"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Apps API
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "jobs"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Tekton API
+  - apiGroups: ["tekton.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-client-binding
+subjects:
+  - kind: ServiceAccount
+    name: openshift-client-sa
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: openshift-client-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: openshift-client-run-ws
+spec:
+  serviceAccountName: openshift-client-sa
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+    tasks:
+      - name: fetch-repo
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/openshift/pipelines-vote-api
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: oc-deploy
+        runAfter:
+          - "fetch-repo"
+        taskRef:
+          name: openshift-client
+        workspaces:
+          - name: manifest-dir
+            workspace: shared-workspace
+        params:
+          - name: SCRIPT
+            value: |
+              oc apply --filename k8s/
+              oc wait --for=condition=available --timeout=600s deployment/pipelines-vote-api
+              echo "-----------Displaying all the pods-----------"
+              oc get pods

--- a/task/openshift-client/0.2/tests/run.yaml
+++ b/task/openshift-client/0.2/tests/run.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: openshift-client-test-run
+spec:
+  pipelineSpec:
+    tasks:
+      - name: oc-version
+        taskRef:
+          name: openshift-client
+        params:
+          - name: SCRIPT
+            value: oc version


### PR DESCRIPTION
# Changes
For Task version 0.1
- The README was showing that the task uses the input resource of
    cluster-type but the resource being used was of git-type so fixing that.

For Task version 0.2
- The task requires min pipelines version 0.17.0 as it uses two optional
    workspaces. First workspace is for passing the manifests which we want
    to apply on the cluster and second workspace can be used to mount the
    kubeconfig file if in case we want to run the oc command on another
    cluster.
    
Signed-off-by: vinamra28 <vinjain@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
