### PR TITLE
Add flake8 task

### DIFF
--- a/task/flake8/0.1/README.md
+++ b/task/flake8/0.1/README.md
@@ -1,0 +1,49 @@
+# flake8
+
+The task provides linting based on [flake8](https://pypi.org/project/flake8/) for Python.
+
+## Install the Task
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) volume containing the python code.
+
+### Install the flake8 task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/flake8/0.1/flake8.yaml
+```
+
+## Parameters
+
+* **args**: The arguments to be passed to the flake8 CLI. (_Default_: `[""]`)
+* **path**: The path to the module which should be analysed by flake8. (_Default_: `"."`)
+* **requirements_file**: The path to the requirements file to pip install for your application to be checked. (_Default_: `"requirements.txt"`)
+
+## Usage
+
+This `TaskRun` runs `flake8` in a python module directory called `module/`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: lint
+spec:
+  taskRef:
+    name: flake8
+  workspaces:
+  - name: source
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi
+  params:
+  - name: args
+    value: ["--verbose"]
+  - name: path
+    value: "module/"
+```

--- a/task/flake8/0.1/flake8.yaml
+++ b/task/flake8/0.1/flake8.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: flake8
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Code Quality
+    tekton.dev/tags: python, flake8, linter
+    tekton.dev/displayName: flake8
+
+spec:
+  description: >-
+    This task will run flake8 on the provided input.
+
+  workspaces:
+    - name: source
+  params:
+    - name: image
+      description: The container image with flake8
+      default: docker.io/alpine/flake8@sha256:bb280bf2af4a434be912f25bbcb6c79ea4d735ed3c8e259f96c405998920871f
+    - name: path
+      description: The path to the module which should be analysed by flake8
+      default: "."
+      type: string
+    - name: requirements_file
+      description: The name of the requirements file inside the source location
+      default: "requirements.txt"
+    - name: args
+      description: The arguments to pass to the flake8 CLI.
+      type: array
+      default: []
+  steps:
+    - name: flake8
+      image: $(params.image)
+      workingDir: $(workspaces.source.path)
+      script: |
+        export HOME=/tmp/python
+        export PATH=$PATH:/tmp/python/.local/bin
+        if [ -n "$(params.requirements_file)" ] && [ -e "$(params.requirements_file)" ];then
+            python -mpip install --user -r $(params.requirements_file)
+        fi
+        flake8 $@ $(params.path)
+      args:
+        - $(params.args)

--- a/task/flake8/0.1/tests/run.yaml
+++ b/task/flake8/0.1/tests/run.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flake8-example-dir
+data:
+  requirements.txt: |
+    flake8==3.9.2
+  example.py: |
+    def test_add(a, b):
+        # unused_var = 12  # Uncomment this line to make it fail
+        return a + b
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: flake8-task-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+    tasks:
+      - name: flake8
+        taskRef:
+          name: flake8
+        params:
+          - name: path
+            value: example.py
+          - name: args
+            value: ["--verbose"]
+        workspaces:
+          - name: source
+            workspace: shared-workspace
+  workspaces:
+    - name: shared-workspace
+      configmap:
+        name: flake8-example-dir

--- a/task/flake8/OWNERS
+++ b/task/flake8/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- wumaxd
+- vinamra28
+- frerikandriessen
+
+reviewers:
+- wumaxd
+- vinamra28
+- frerikandriessen


### PR DESCRIPTION
It's a word-for-word copy of the pylint-0.2 task.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Flake8 is another very popular python linting tool. There was no task for it yet so I figured I'd add it, based on the already existing pylint task. I made the OWNERS of this task the same as the OWNERS of the pylint task. Of course, I don't know if they're actually available for that, let me know if I need to change it. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
