### PR TITLE
Add image and requirements_file params to black task

### DIFF
--- a/task/black/0.2/README.md
+++ b/task/black/0.2/README.md
@@ -1,0 +1,82 @@
+# Black (Python Code Prettier)
+
+This task can be used to format the python source code using [Black](https://github.com/psf/black) which is an Opinionate Code Formatter.
+
+## Installing the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/black/0.2/black.yaml
+```
+
+## Parameters
+
+- **image**: The container image to use. (_Default_: `docker.io/cytopia/black:latest-0.2@sha256:2ec766f1c7e42e6b59c0873ce066fa0a2aa2bf8a80dbc1c40f1566bb539303e0`)
+- **requirements_file**: The name of the requirements file inside the workspace that will be used by pip to install black.
+      If this file does not exist the task will not fail, but pip will not install anything. (_Default_: `requirements.txt`)
+- **args**: The extra params along with the file path needs to be provided as the part of `args`. (_Default_: `["--help"]`)
+
+## Workspaces
+
+- **shared-workspace**: The workspace containing python source code which we want to format. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
+
+## Usage
+
+1. Create the `git-clone` task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
+```
+
+2. Create the PVC
+3. Apply the required tasks
+
+4. Create the Pipeline and PipelineRun for `Black`(Python Code Formatter)
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: python-formatter-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/wumaxd/pylint-pytest-example
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: python-black-run #python code prettier
+      taskRef:
+        name: black
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+      params:
+        - name: args
+          value: [".", "--check", "--diff"]
+        - name: image
+          value: python:3.8-slim
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: python-formatter-pipeline-run
+spec:
+  pipelineRef:
+    name: python-formatter-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: black-python-pvc
+```

--- a/task/black/0.2/black.yaml
+++ b/task/black/0.2/black.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: black
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Code Quality
+    tekton.dev/tags: formatter, python, black
+    tekton.dev/displayName: "Python Black"
+spec:
+  description: >-
+    This task can be used to format Python code
+  workspaces:
+    - name: shared-workspace
+      description: >-
+        The workspace containing python source code which we want to format.
+  params:
+    - name: image
+      description: The container image to use black in
+      default: docker.io/cytopia/black:latest-0.2@sha256:2ec766f1c7e42e6b59c0873ce066fa0a2aa2bf8a80dbc1c40f1566bb539303e0
+    - name: requirements_file
+      description: The name of the requirements file inside the source location
+      default: requirements.txt
+    - name: args
+      type: array
+      description: extra args that needs to be appended
+      default: ["--help"]
+  steps:
+    - name: format-python-code
+      image: $(params.image)
+      workingDir: $(workspaces.shared-workspace.path)
+      script: |
+        export HOME=/tmp/python
+        export PATH=$PATH:/tmp/python/.local/bin
+        if [ -n "$(params.requirements_file)" ] && [ -e "$(params.requirements_file)" ];then
+            python -mpip install --user -r $(params.requirements_file)
+        fi
+        black $@
+      args:
+        - $(params.args)

--- a/task/black/0.2/tests/resources.yaml
+++ b/task/black/0.2/tests/resources.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: black-python-configmap
+data:
+  requirements.txt: |
+    black==21.6b0

--- a/task/black/0.2/tests/run.yaml
+++ b/task/black/0.2/tests/run.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: python-formatter-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: python-black-run
+      taskRef:
+        name: black
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+      params:
+        - name: args
+          value: ["."]
+        - name: image
+          value: python:3.8-slim
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: python-formatter-pipeline-run
+spec:
+  pipelineRef:
+    name: python-formatter-pipeline
+  workspaces:
+    - name: shared-workspace
+      configmap:
+        name: black-python-configmap


### PR DESCRIPTION
This provides more flexibility to the user for which exact version of
black should be used. 


# Changes
You can now specify which image to use, and which requirement_file to use. Aside from allowing you to specify the black version, this will also allow you to more closely mimic your eventual production environment.
See also #792 for a similar PR. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
