### PR TITLE
Extend catalog test script to run tests for different platforms

### DIFF
--- a/test/linux-s390x.sh
+++ b/test/linux-s390x.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# s390x specific registry
+export REGISTRY_IMAGE=ibmcom/registry:2.6.2.5
+# Maven image to use for s390x maven tasks
+export MAVEN_IMAGE=maven:3.6.3-adoptopenjdk-11
+# Architecture to use for golang tasks
+export GOARCH=s390x
+# Gradle image to use for s390x gradle tasks
+export BUILDER_IMAGE=gradle:5.6.2-jdk11
+# Tasks to skip so far for s390x
+export TEST_TASKRUN_IGNORES="helm-upgrade-from-repo helm-upgrade-from-source golang-test kaniko"
+
+echo "Add extra MAVEN_IMAGE parameter"
+find task/*maven*/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|select(.metadata.name?=="jib-maven-test-pipeline"|"maven-test-pipeline")|.spec.tasks[1].params) |= . +{"name": "MAVEN_IMAGE","value": env(MAVEN_IMAGE)}' -i {}
+
+echo "Change registry image value"
+find task -name *registry*.yaml | xargs -I{} yq eval '(..|select(.kind?=="Deployment")|select(.metadata.name?=="registry")|.spec.template.spec.containers[0].image)|= env(REGISTRY_IMAGE)' -i {}
+
+echo "Change GOARCH parameter value"
+find task/golang*/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "GOARCH","value": env(GOARCH)}' -i {}
+
+echo "Add extra BUILDER_IMAGE parameter"
+find task/jib-gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "BUILDER_IMAGE","value": env(BUILDER_IMAGE)}' -i {}


### PR DESCRIPTION
# Changes

PLATFORM env variable is introduced. This variable allows to run tests for specific platform (for instance, "linux/s390x" or "linux/ppc64le").
If the environment variable is specified:
- some tests are updated with different image values, required for specific platform.
Image names should be specified in script file, separate for each platform. In the current code script file for linux/s390x is proposed.
- only tasks, which have mention about corresponding platform support in the annotation, will be tested.
If PLATFORM env variable is not specified, the behaviour of test scripts will be similar to the one before the PR.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
