### PR TITLE
Minor fix to ansible-runner README

### DIFF
--- a/task/ansible-runner/0.1/README.md
+++ b/task/ansible-runner/0.1/README.md
@@ -71,7 +71,7 @@ List the pods of `kube-system` namespace:
  tkn task start ansible-runner \
    --serviceaccount ansible-deployer-account \
    --param=project-dir=kubernetes \
-   --param=args=-p, list-pods.yml \
+   --param=args=-p,list-pods.yml \
    --workspace=name=runner-dir,claimName=ansible-playbooks \
    --showlog
 ```
@@ -84,7 +84,7 @@ Create a deployment in  `funstuff` namespace:
  tkn task start ansible-runner \
    --serviceaccount ansible-deployer-account \
    --param=project-dir=kubernetes \
-   --param=args=-p, create-deployment.yml \
+   --param=args=-p,create-deployment.yml \
    --workspace=name=runner-dir,claimName=ansible-playbooks \
    --showlog
 ```
@@ -97,7 +97,7 @@ Create a service in `funstuff` namespace:
  tkn task start ansible-runner \
    --serviceaccount ansible-deployer-account \
    --param=project-dir=kubernetes \
-   --param=args=-p, create-service.yml \
+   --param=args=-p,create-service.yml \
    --workspace=name=runner-dir,claimName=ansible-playbooks \
    --showlog
 ```

--- a/task/ansible-runner/0.1/README.md
+++ b/task/ansible-runner/0.1/README.md
@@ -84,7 +84,7 @@ Create a deployment in  `funstuff` namespace:
  tkn task start ansible-runner \
    --serviceaccount ansible-deployer-account \
    --param=project-dir=kubernetes \
-   --param=args='-p create-deployment.yml' \
+   --param=args=-p, create-deployment.yml \
    --workspace=name=runner-dir,claimName=ansible-playbooks \
    --showlog
 ```
@@ -97,7 +97,7 @@ Create a service in `funstuff` namespace:
  tkn task start ansible-runner \
    --serviceaccount ansible-deployer-account \
    --param=project-dir=kubernetes \
-   --param=args='-p create-service.yml' \
+   --param=args=-p, create-service.yml \
    --workspace=name=runner-dir,claimName=ansible-playbooks \
    --showlog
 ```


### PR DESCRIPTION
Fixing second & third `tkn` examples to match the first.  Args are passed as a comma-separated array with no spaces.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Completing a fix to the README.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
