### PR TITLE
Add parameters for pypi upload secret

### DIFF
--- a/task/upload-pypi/0.1/upload-pypi.yaml
+++ b/task/upload-pypi/0.1/upload-pypi.yaml
@@ -22,6 +22,18 @@ spec:
     description: The repository (package index) to upload the package to.
     default: "https://upload.pypi.org/legacy/"
     type: string
+  - name: SECRET_NAME
+    description: Name of the secret containing the username & password used to upload the package.
+    default: "pypi-secret"
+    type: string
+  - name: SECRET_USERNAME_KEY
+    description: Name of the secret key containing the username.
+    default: "username"
+    type: string
+  - name: SECRET_PASSWORD_KEY
+    description: Name of the secret key containing the password.
+    default: "password"
+    type: string    
 
   workspaces:
   - name: source
@@ -42,13 +54,13 @@ spec:
     - name: TWINE_USERNAME
       valueFrom:
         secretKeyRef:
-          name: pypi-secret
-          key: username
+          name: $(params.SECRET_NAME)
+          key: $(params.SECRET_USERNAME_KEY)
     - name: TWINE_PASSWORD
       valueFrom:
         secretKeyRef:
-          name: pypi-secret
-          key: password
+          name: $(params.SECRET_NAME)
+          key: $(params.SECRET_PASSWORD_KEY)
     script: |
       twine upload --disable-progress-bar dist/*
       # Now write out all our results, stripping newlines.


### PR DESCRIPTION
# Changes

Changed hardcoded values for the pypi-secret in `upload-pypi` to parameters.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

---

