### PR TITLE
Fix typo in `generate-build-id` documentation

### DIFF
--- a/task/generate-build-id/0.1/README.md
+++ b/task/generate-build-id/0.1/README.md
@@ -74,7 +74,7 @@ spec:
           value: "$(tasks.get-build-id.results.build-id)"
 ```
 As can be seen from the example the first task generates the build id while the second task consumes the generated build id.
-In the task to generate the build id, we override the default value of `base-version` using the value of the `service-version` pipeline parameter that has currentluy been set to a default value of 3.1.1.
+In the task to generate the build id, we override the default value of `base-version` using the value of the `service-version` pipeline parameter that has currently been set to a default value of 3.1.1.
 In the task to build the service api, we then pass the generated build from the first task as its input param called `build-id`.
 For the sake of completeness, here is what the task to build the service api (`build-service-api.yaml`) looks like:
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes a simple typo in `generate-build-id` documentation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
