### PR TITLE
Add upload-pypi 0.2 task

### DIFF
--- a/task/upload-pypi/0.2/README.md
+++ b/task/upload-pypi/0.2/README.md
@@ -1,0 +1,87 @@
+# Publish-Python-Package
+
+This Task publishes Python packages to PyPI index using [Twine](https://pypi.org/project/twine/) utility module. It provides build system independent uploads of source and binary distribution artifacts for both new and existing projects.
+
+## Changelog
+
+- Added optional parameters for secret name and keys
+- Added optional prebuild script parameter
+- Added builder image parameter and changed to python image instead of Twine
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/task/upload-pypi/0.2/upload-pypi.yaml
+```
+## Requirement
+
+A secret is needed with Twine credentials for python module publishing to PyPI index. The default name is `pypi-secret`, and default keys are:
+
+- **username**: The username to authenticate to the repository (package index).
+- **password**: The password to authenticate to the repository (package index).
+
+These values can be overwritten using the parameters.
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pypi-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: foo
+  password: bar
+```
+
+## Parameters
+
+* **TWINE_REPOSITORY_URL**: The repository (package index) to upload the package to.
+* **SECRET_NAME**: Name of the secret containing the username & password used to upload the package.
+* **SECRET_USERNAME_KEY**: Name of the secret key containing the username.
+* **SECRET_PASSWORD_KEY**: Name of the secret key containing the password.
+* **PREBUILD_SCRIPT**: Script to run prior to build. Useful for installing dependencies.
+* **BUILDER_IMAGE**: Image to use for building the package.
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and publishes a python module.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: publish-package
+spec:
+  taskRef:
+    name: upload-pypi
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+In this example, the Git repo being used is expected to have a `setup.py` file at the root of the repository. [setup.py](https://packaging.python.org/tutorials/packaging-projects/#creating-setup-py) is build script for [setuptools](https://pypi.org/project/setuptools/)
+
+This TaskRun outputs several `Results`:
+
+- A `sha256` hash for each uploaded file (the bdist and the sdist packages).
+- The name of the uploaded package
+- The version of the uploaded package
+
+This looks like:
+
+```
+  taskResults:
+  - name: bdist_sha
+    value: 97dd35b7097443b6896734d979a1a52c64023f17474e4027d69d2df0b9acb797  dist/foo.whl
+  - name: package_name
+    value: foo
+  - name: package_version
+    value: 2.24.4
+  - name: sdist_sha
+    value: 8fda69bc68ece690d135d0091ebdd10a8c15db477c2eafce0d0a65bc9712f5bf  dist/foo.tar.gz
+```

--- a/task/upload-pypi/0.2/samples/run.yaml
+++ b/task/upload-pypi/0.2/samples/run.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pypi-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: foo
+  password: bar
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-task-storage
+spec:
+  resources:
+    requests:
+      storage: 500Mi
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: publish-package-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/pypa/twine.git
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+
+  - name: upload-pypi-run
+    taskRef:
+      name: upload-pypi
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    runAfter:
+    - fetch-repository
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: publish-package-pipeline-run
+spec:
+  podTemplate:
+    securityContext:
+      runAsNonRoot: false
+      runAsUser: 0
+  pipelineRef:
+    name: publish-package-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentVolumeClaim:
+      claimName: shared-task-storage

--- a/task/upload-pypi/0.2/tests/pre-apply-task-hook.sh
+++ b/task/upload-pypi/0.2/tests/pre-apply-task-hook.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Add pypiserver sidecar
-add_sidecars ${TMPF} '{"image":"registry", "name": "registry", "args": ["-P .", "-a ."]}'
+add_sidecars ${TMPF} '{"image":"pypiserver/pypiserver:latest", "name": "pypiserver", "args": ["-P .", "-a ."]}'
 
 # Add git-clone
 add_task git-clone latest

--- a/task/upload-pypi/0.2/tests/pre-apply-task-hook.sh
+++ b/task/upload-pypi/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Add pypiserver sidecar
+add_sidecars ${TMPF} '{"image":"registry", "name": "registry", "args": ["-P .", "-a ."]}'
+
+# Add git-clone
+add_task git-clone latest

--- a/task/upload-pypi/0.2/tests/resources.yaml
+++ b/task/upload-pypi/0.2/tests/resources.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: upload-pypi-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pypi-secret
+type: kubernetes.io/basic-auth
+stringData:
+  username: foo
+  password: bar

--- a/task/upload-pypi/0.2/tests/run.yaml
+++ b/task/upload-pypi/0.2/tests/run.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: upload-pypi-test-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: 'https://github.com/pypa/sampleproject'
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: upload-pypi-run
+    params: 
+    - name: TWINE_REPOSITORY_URL
+      value: 'http://localhost:8080/'
+    taskRef:
+      name: upload-pypi
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    runAfter:
+    - fetch-repository
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: upload-pypi-test-pipeline-run
+spec:
+  pipelineRef:
+    name: upload-pypi-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: upload-pypi-source-pvc

--- a/task/upload-pypi/0.2/tests/run.yaml
+++ b/task/upload-pypi/0.2/tests/run.yaml
@@ -21,7 +21,7 @@ spec:
     - name: deleteExisting
       value: "true"
   - name: upload-pypi-run
-    params: 
+    params:
     - name: TWINE_REPOSITORY_URL
       value: 'http://localhost:8080/'
     taskRef:

--- a/task/upload-pypi/0.2/upload-pypi.yaml
+++ b/task/upload-pypi/0.2/upload-pypi.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: upload-pypi
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Publishing
+    tekton.dev/tags: build
+    tekton.dev/displayName: "upload pypi"
+spec:
+  description: >-
+    This Task publishes Python packages to PyPI index using Twine utility module.
+
+    It provides build system independent uploads of source and binary distribution
+    artifacts for both new and existing projects.
+
+  params:
+  - name: TWINE_REPOSITORY_URL
+    description: The repository (package index) to upload the package to.
+    default: "https://upload.pypi.org/legacy/"
+    type: string
+  - name: SECRET_NAME
+    description: Name of the secret containing the username & password used to upload the package.
+    default: "pypi-secret"
+    type: string
+  - name: SECRET_USERNAME_KEY
+    description: Name of the secret key containing the username.
+    default: "username"
+    type: string
+  - name: SECRET_PASSWORD_KEY
+    description: Name of the secret key containing the password.
+    default: "password"
+    type: string    
+  - name: PREBUILD_SCRIPT
+    description: Script to execute prior to running setup.py.
+    type: string
+    default: ''
+  - name: BUILDER_IMAGE
+    description: Image to use for building the package
+    type: string
+    default: 'python:3.9'
+
+  workspaces:
+  - name: source
+
+  steps:
+  - name: build-package
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)
+    script: |
+      $(params.PREBUILD_SCRIPT)
+
+      python setup.py sdist bdist_wheel
+  - name: upload-package
+    image: quay.io/thoth-station/twine@sha256:643ab12bb05c91db1cec6c042160466a3f258e030f5acff2a39d5b0a00442f4b #tag: latest
+    workingDir: $(workspaces.source.path)
+    env:
+    - name: TWINE_REPOSITORY_URL
+      value: $(params.TWINE_REPOSITORY_URL)
+    - name: TWINE_USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: $(params.SECRET_NAME)
+          key: $(params.SECRET_USERNAME_KEY)
+    - name: TWINE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: $(params.SECRET_NAME)
+          key: $(params.SECRET_PASSWORD_KEY)
+    script: |
+      twine upload --disable-progress-bar dist/*
+      # Now write out all our results, stripping newlines.
+      # sdist files are .tar.gz's
+      sha256sum dist/*.tar.gz | tr -d '\n' | tee $(results.sdist_sha.path)
+      # bdist files are .whls's
+      sha256sum dist/*.whl | tr -d '\n' | tee $(results.bdist_sha.path)
+      python setup.py --name | tr -d '\n' | tee $(results.package_name.path)
+      python setup.py --version | tr -d '\n' | tee $(results.package_version.path)
+  results:
+  - name: sdist_sha
+    description: sha256 (and filename) of the sdist package
+  - name: bdist_sha
+    description: sha256 (and filename) of the bdist package
+  - name: package_name
+    description: name of the uploaded package
+  - name: package_version
+    description: version of the uploaded package

--- a/task/upload-pypi/0.2/upload-pypi.yaml
+++ b/task/upload-pypi/0.2/upload-pypi.yaml
@@ -33,7 +33,7 @@ spec:
   - name: SECRET_PASSWORD_KEY
     description: Name of the secret key containing the password.
     default: "password"
-    type: string    
+    type: string
   - name: PREBUILD_SCRIPT
     description: Script to execute prior to running setup.py.
     type: string


### PR DESCRIPTION
# Changes

Added 0.2 version of the upload-pypi task with the following changes/improvements:

- Added optional parameters for secret name and keys
- Added optional prebuild script parameter
- Added builder image parameter and changed to python image instead of Twine

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
 - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
 - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
 - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
 - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
 - [x] mandatory `spec.description` follows the convention

