### PR TITLE
Bump skopeo image to v1.3.0 and buildah image to v1.18.0

### DIFF
--- a/task/buildah/0.2/README.md
+++ b/task/buildah/0.2/README.md
@@ -36,6 +36,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bu
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 * **sslcertdir**: An [*optional* Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry. Buildah will look for files ending with *.crt, *.cert, *.key into this workspace. See [this sample](./samples/openshift-internal-registry.yaml) for a complete example on how to use it with OpenShift internal registry.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 spec:
   description: >-
     Buildah task builds source into a container image and
@@ -25,7 +26,7 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: quay.io/buildah/stable:v1.17.0
+    default: quay.io/buildah/stable:v1.18.0
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
     default: overlay

--- a/task/skopeo-copy/0.1/README.md
+++ b/task/skopeo-copy/0.1/README.md
@@ -60,6 +60,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sk
 
   [This](../0.1/samples/quay-secret.yaml) example can help to use secrets for providing credentials of image registries.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This task will use the `Service Account` with access to the secrets containing source and destination image registry credentials, this will authorize it to the respective image registries. 

--- a/task/skopeo-copy/0.1/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.1/skopeo-copy.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: cli
     tekton.dev/displayName: "skopeo copy"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 spec:
   description: >-
     Skopeo is a command line tool for working with remote image registries.
@@ -40,7 +41,7 @@ spec:
       default: "true"
   steps:
     - name: skopeo-copy
-      image: quay.io/skopeo/stable:v1.1.1
+      image: quay.io/skopeo/stable:v1.3.0
       script: |
         # Function to copy multiple images.
         #


### PR DESCRIPTION
# Changes

`quay.io/buildah/stable:v1.18.0` and `quay.io/skopeo/stable:v1.3.0` are multi-arch images, bumping images to these versions for buildah and skopeo-copy will allow to run the tasks on different architectures.
The update is tested for `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms. Both image versions have also `linux/arm64` support, so this platform is also mentioned.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
