### PR TITLE
Add platforms annotation to kaniko task

### DIFF
--- a/task/kaniko/0.4/README.md
+++ b/task/kaniko/0.4/README.md
@@ -32,6 +32,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ka
 * **CONTEXT**: The build context used by Kaniko (_default:_ `./`)
 * **EXTRA_ARGS**: Additional args to pass to the Kaniko executor.
 * **BUILDER_IMAGE**: The Kaniko executor image to use (_default:_ `gcr.io/kaniko-project/executor:v1.5.1`)
+* **JQ_IMAGE**: The image to parse digest after the image build (_default:_ `docker.io/stedolan/jq:latest`)
 
 ## Workspaces
 
@@ -51,6 +52,15 @@ the docker `config.json`.
 
 When using a workspace, the workspace shall be bound to a secret that embeds the
 configuration file in a key called `config.json`.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+For `linux/s390x` platform specify `BUILDER_IMAGE` parameter with `gcr.io/kaniko-project/executor:s390x-9ed158c1f63a059cde4fd5f8b95af51d452d9aa7`
+value and `JQ_IMAGE` parameter with `ibmcom/jq-s390x:latest` value  in TaskRun or PipelineRun.
+
+For `linux/ppc64le` platform specify `JQ_IMAGE` parameter with `ibmcom/jq-ppc64le:latest` value  in TaskRun or PipelineRun.
 
 ## Usage
 

--- a/task/kaniko/0.4/kaniko.yaml
+++ b/task/kaniko/0.4/kaniko.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
     tekton.dev/displayName: "Build and upload container image using Kaniko"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task builds source into a container image using Google's kaniko tool.
@@ -33,6 +34,9 @@ spec:
   - name: BUILDER_IMAGE
     description: The image on which builds will run (default is v1.5.1)
     default: gcr.io/kaniko-project/executor:v1.5.1@sha256:c6166717f7fe0b7da44908c986137ecfeab21f31ec3992f6e128fff8a94be8a5
+  - name: JQ_IMAGE
+    description: The image to parse digest after the image build.
+    default: docker.io/stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09
   workspaces:
   - name: source
     description: Holds the context and docker file
@@ -61,7 +65,7 @@ spec:
       runAsUser: 0
   - name: write-digest
     workingDir: $(workspaces.source.path)
-    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.16.2
+    image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.18.0
     # output of imagedigestexport [{"key":"digest","value":"sha256:eed29..660","resourceRef":{"name":"myrepo/myimage"}}]
     command: ["/ko-app/imagedigestexporter"]
     args:
@@ -71,6 +75,6 @@ spec:
       runAsUser: 0
   - name: digest-to-results
     workingDir: $(workspaces.source.path)
-    image: docker.io/stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09
+    image: $(params.JQ_IMAGE)
     script: |
       cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE-DIGEST


### PR DESCRIPTION
# Changes

Annotation about `linux/amd64`,`linux/s390x`, and `linux/ppc64le` platforms was added to the latest versions of the kaniko task, as well as information which custom images to use for `linux/s390x` and `linux/ppc64le` platforms.
`JQ_IMAGE` parameter is introduced with default value from the existing task to be able to use custom image for non-Intel architecture.

The changes were tested for `linux/amd64`,`linux/s390x`, and `linux/ppc64le` platforms.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
