### PR TITLE
Add platforms annotation to github-* tasks

### DIFF
--- a/task/github-add-comment/0.4/README.md
+++ b/task/github-add-comment/0.4/README.md
@@ -54,6 +54,10 @@ See GitHub's documentation on [Understanding scopes for OAuth Apps](https://deve
 
 - **comment-file**: The optional workspace containing comment file to be posted.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun add a comment to an issue.

--- a/task/github-add-comment/0.4/github-add-comment.yaml
+++ b/task/github-add-comment/0.4/github-add-comment.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: github
     tekton.dev/displayName: "add github comment"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task will add a comment to a pull request or an issue.

--- a/task/github-add-gist/0.1/README.md
+++ b/task/github-add-gist/0.1/README.md
@@ -39,6 +39,10 @@ See GitHub's documentation on [Understanding scopes for OAuth Apps](https://deve
 
 - **input**: The input workspace which contains the file to be uploaded to gist.
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 The following example will take a file from ConfigMap and

--- a/task/github-add-gist/0.1/github-add-gist.yaml
+++ b/task/github-add-gist/0.1/github-add-gist.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: github
     tekton.dev/displayName: "upload to gist"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: |
     This task will uploaded the provided file

--- a/task/github-add-labels/0.1/README.md
+++ b/task/github-add-labels/0.1/README.md
@@ -25,6 +25,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gi
 
 Check [this](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to get personal access token for `Github`.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
 
 ## Usage
 

--- a/task/github-add-labels/0.1/github-add-labels.yaml
+++ b/task/github-add-labels/0.1/github-add-labels.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: github
     tekton.dev/displayName: "add github label"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task will add a label to an issue in Github.

--- a/task/github-close-issue/0.2/README.md
+++ b/task/github-close-issue/0.2/README.md
@@ -34,6 +34,9 @@ See GitHub's documentation on [Understanding scopes for OAuth Apps](https://deve
   contains the GitHub token. (_default:_ `github`).
 * **GITHUB_TOKEN_SECRET_KEY**: The key within the Kubernetes Secret that contains the GitHub token. (_default:_ `token`).
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
 
 ## Usage
 

--- a/task/github-close-issue/0.2/github-close-issue.yaml
+++ b/task/github-close-issue/0.2/github-close-issue.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "close github issue"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task will close a pull request or an issue.

--- a/task/github-create-deployment-status/0.1/README.md
+++ b/task/github-create-deployment-status/0.1/README.md
@@ -41,6 +41,10 @@ Token must have `repo_deployment` scope to create deployment status. See GitHub'
   contains the GitHub token. (_default:_ `github`).
 - **GITHUB_TOKEN_SECRET_KEY**: The key within the Kubernetes Secret that contains the GitHub token. (_default:_ `token`).
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun creates a status for the given GitHub deployment.

--- a/task/github-create-deployment-status/0.1/github-create-deployment-status.yaml
+++ b/task/github-create-deployment-status/0.1/github-create-deployment-status.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "create github deployment status"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task will create a status for a GitHub deployment.

--- a/task/github-create-deployment/0.2/README.md
+++ b/task/github-create-deployment/0.2/README.md
@@ -47,6 +47,10 @@ Token must have `repo_deployment` scope to create deployments. See GitHub's docu
 - **URL**: URL of the created deployment.
 - **STATUSES_URL**: URL of the created deployment status.
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun creates a GitHub deployment for the given repository.

--- a/task/github-create-deployment/0.2/github-create-deployment.yaml
+++ b/task/github-create-deployment/0.2/github-create-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "create github deployment"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task will create a GitHub deployment for a repository.

--- a/task/github-open-pr/0.1/README.md
+++ b/task/github-open-pr/0.1/README.md
@@ -46,6 +46,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gi
 - **NUMBER**: Number of the created pull request.
 - **URL**: URL of the created pull request.
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage for Bearer authentication
 
 This TaskRun opens a pull request on GitHub.

--- a/task/github-open-pr/0.1/github-open-pr.yaml
+++ b/task/github-open-pr/0.1/github-open-pr.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "open github pull request"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This task will open a PR on Github based on several parameters.

--- a/task/github-request-reviewers/0.1/README.md
+++ b/task/github-request-reviewers/0.1/README.md
@@ -42,6 +42,10 @@ for more details.
 
 - **github**: The workspace that contains the github token
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun requests both users and teams as reviewers:

--- a/task/github-request-reviewers/0.1/github-request-reviewers.yaml
+++ b/task/github-request-reviewers/0.1/github-request-reviewers.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: github
     tekton.dev/displayName: "request github reviewers"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task will request reviewers for a GitHub PR

--- a/task/github-set-status/0.2/README.md
+++ b/task/github-set-status/0.2/README.md
@@ -51,6 +51,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gi
 * **GITHUB_TOKEN_SECRET_KEY** \[optional\]: The key within the kubernetes secret that
   contains the GitHub token. Default value: `token`
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage for Bearer authentication
 
 This TaskRun sets a commit on GitHub to `pending` getting tested by the CI.

--- a/task/github-set-status/0.2/github-set-status.yaml
+++ b/task/github-set-status/0.2/github-set-status.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "set github status"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This task will set the status of the CI job to the specified value along


### PR DESCRIPTION
# Changes

Annotation about linux/amd64, linux/s390x and linux/ppc64le platforms was added to the latest versions of the github-* tasks.

The tasks were tested for linux/amd64, linux/s390x, and linux/ppc64le.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
