### PR TITLE
Add platforms annotation to send-to-* tasks

### DIFF
--- a/task/send-to-channel-slack/0.1/README.md
+++ b/task/send-to-channel-slack/0.1/README.md
@@ -43,6 +43,11 @@ kubectl apply -f token-secret.yaml
 
 * **message**: Plain text message to be posted in the slack channel
 
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun runs the Task to post a message to the channel.

--- a/task/send-to-channel-slack/0.1/send-to-channel-slack.yaml
+++ b/task/send-to-channel-slack/0.1/send-to-channel-slack.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Messaging
     tekton.dev/tags: messaging
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     These tasks post a simple message to a slack channel.
@@ -27,7 +28,7 @@ spec:
     description: plain text message
   steps:
   - name: post
-    image: docker.io/curlimages/curl:7.68.0@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151 #tag: 7.68.0
+    image: docker.io/curlimages/curl:7.70.0@sha256:031df77a11e5edded840bc761a845eab6e3c2edee22669fb8ad6d59484b6a1c4 #tag: 7.70.0
     script: |
       #!/bin/sh
       /usr/bin/curl -X POST -H 'Content-type: application/json' -H 'Authorization: Bearer '$TOKEN --data '{"channel":"$(params.channel)", "text":"$(params.message)"}' https://slack.com/api/chat.postMessage

--- a/task/send-to-microsoft-teams/0.1/README.md
+++ b/task/send-to-microsoft-teams/0.1/README.md
@@ -33,6 +33,10 @@ stringData:
 
 * **message**: Plain text message to be posted in the chat.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun runs the Task to post a message to the the teams channel.

--- a/task/send-to-microsoft-teams/0.1/send-to-microsoft-teams.yaml
+++ b/task/send-to-microsoft-teams/0.1/send-to-microsoft-teams.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Messaging
     tekton.dev/tags: messaging
     tekton.dev/displayName: "Send message to Microsoft Teams Channel"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     These tasks post a simple message to a Microsoft Teams Channel.
@@ -27,7 +28,7 @@ spec:
     description: The message to notify about
   steps:
   - name: post
-    image: docker.io/curlimages/curl:7.68.0@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151 #tag: 7.68.0
+    image: docker.io/curlimages/curl:7.70.0@sha256:031df77a11e5edded840bc761a845eab6e3c2edee22669fb8ad6d59484b6a1c4 #tag: 7.70.0
     script: |
       #!/usr/bin/env sh
       MESSAGE=$(echo "${MESSAGE}" | sed -e 's/\"/\\\\"/g')

--- a/task/send-to-telegram/0.1/README.md
+++ b/task/send-to-telegram/0.1/README.md
@@ -38,6 +38,10 @@ kubectl apply -f telegram-bot-token-secret.yaml
 
 * **chat-id**: The ID of the chat to send the message towards. See telegram documentation to get the correct ID.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun runs the Task to post a message to the the chat channel.

--- a/task/send-to-telegram/0.1/send-to-telegram.yaml
+++ b/task/send-to-telegram/0.1/send-to-telegram.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Messaging
     tekton.dev/tags: messaging
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     These tasks post a simple message to a telegram chat.
@@ -26,7 +27,7 @@ spec:
     description: The message to notify about
   steps:
   - name: post
-    image: docker.io/curlimages/curl:7.68.0@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151 #tag: 7.68.0
+    image: docker.io/curlimages/curl:7.70.0@sha256:031df77a11e5edded840bc761a845eab6e3c2edee22669fb8ad6d59484b6a1c4 #tag: 7.70.0
     script: |
       #!/bin/sh
       MESSAGE=`echo $MESSAGE | sed -e 's/\"/\\\\"/g'`

--- a/task/send-to-webex-room/0.1/README.md
+++ b/task/send-to-webex-room/0.1/README.md
@@ -38,6 +38,10 @@ kubectl apply -f webex-token-secret.yaml
 
 * **room-id**: The ID of the room to send the message. See [official documentation](https://developer.webex.com/docs/api/v1/rooms/list-rooms) or [medium article](https://medium.com/@ObjectIsAdvantag/everything-you-always-wanted-to-know-about-the-spark-room-id-june16-550a0e65c59d) for help to find your ID.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 Example Tekton CLI command

--- a/task/send-to-webex-room/0.1/send-to-webex-room.yaml
+++ b/task/send-to-webex-room/0.1/send-to-webex-room.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Messaging
     tekton.dev/tags: messaging
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This task posts a text message to a webex room.
@@ -27,7 +28,7 @@ spec:
       description: plain text message
   steps:
     - name: post
-      image: docker.io/curlimages/curl:7.68.0@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151 #tag: 7.68.0
+      image: docker.io/curlimages/curl:7.70.0@sha256:031df77a11e5edded840bc761a845eab6e3c2edee22669fb8ad6d59484b6a1c4 #tag: 7.70.0
       script: |
         #!/bin/sh
         /usr/bin/curl -X POST -H 'Content-type: application/json' -H 'Authorization: Bearer '$WEBEX_TOKEN --data '{"roomId":"$(params.room-id)","text":"$(params.message)"}' https://webexapis.com/v1/messages

--- a/task/send-to-webhook-slack/0.1/README.md
+++ b/task/send-to-webhook-slack/0.1/README.md
@@ -41,6 +41,10 @@ kubectl apply -f webhook-secret.yaml
 
 * **icon-emoji**: The emoji to use for the bot. For example you could import a tekton emoji and use `:tekton:` over here.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
 ## Usage
 
 This TaskRun runs the Task to post a message to the channel that the webhook URL is associated with.

--- a/task/send-to-webhook-slack/0.1/send-to-webhook-slack.yaml
+++ b/task/send-to-webhook-slack/0.1/send-to-webhook-slack.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Messaging
     tekton.dev/tags: messaging
     tekton.dev/displayName: "Send message to Slack Channel"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     These tasks post a simple message to a slack channel.
@@ -32,7 +33,7 @@ spec:
     default: ':robot_face:'
   steps:
   - name: post
-    image: docker.io/curlimages/curl:7.68.0@sha256:99a8e9629b3ae26efb977e1a98f4786d6bd730c5ab4dea64632e297d7c3e7151 #tag: 7.68.0
+    image: docker.io/curlimages/curl:7.70.0@sha256:031df77a11e5edded840bc761a845eab6e3c2edee22669fb8ad6d59484b6a1c4 #tag: 7.70.0
     script: |
       #!/usr/bin/env sh
       MESSAGE=$(echo "${MESSAGE}" | sed -e 's/\"/\\\\"/g')


### PR DESCRIPTION
# Changes

Annotation about linux/amd64, linux/s390x, and linux/ppc64le platforms is added to the latest versions of the send-to-* tasks.

Curl image used in the tasks is upgraded from 7.68.0 to 7.70.0 to use multi-arch version.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
