### PR TITLE
Use secrets through volume mounts

### DIFF
--- a/task/github-open-pr/0.1/github-open-pr.yaml
+++ b/task/github-open-pr/0.1/github-open-pr.yaml
@@ -79,14 +79,18 @@ spec:
     - name: URL
       description: URL of the created deployment.
 
+  volumes:
+  - name: githubtoken
+    secret:
+      secretName: $(params.GITHUB_TOKEN_SECRET_NAME)
+
   steps:
     - name: open-pr
+      volumeMounts:
+        - name: githubtoken
+          readOnly: true
+          mountPath: /etc/github-open-pr
       env:
-        - name: GITHUBTOKEN
-          valueFrom:
-            secretKeyRef:
-              name: $(params.GITHUB_TOKEN_SECRET_NAME)
-              key: $(params.GITHUB_TOKEN_SECRET_KEY)
         - name: PULLREQUEST_NUMBER_PATH
           value: $(results.NUMBER.path)
         - name: PULLREQUEST_URL_PATH
@@ -102,6 +106,8 @@ spec:
         import os
         import http.client
 
+        github_token = open("/etc/github-open-pr/$(params.GITHUB_TOKEN_SECRET_KEY)", "r").read()
+
         open_pr_url = "$(params.API_PATH_PREFIX)" + "/repos/$(params.REPO_FULL_NAME)/pulls"
 
         data = {
@@ -113,7 +119,7 @@ spec:
         print("Sending this data to GitHub: ")
         print(data)
 
-        authHeader = "$(params.AUTH_TYPE) " + os.environ["GITHUBTOKEN"]
+        authHeader = "$(params.AUTH_TYPE) " + github_token
 
         # This is for our fake github server
         if "$(params.GITHUB_HOST_URL)".startswith("http://"):


### PR DESCRIPTION
Fix indenting and add readonly

# Changes

Fixes for github open PR after https://github.com/tektoncd/catalog/pull/778 got merged

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

