### PR TITLE
Fix the README to reflect actual defaults.

### DIFF
--- a/task/kn/0.1/README.md
+++ b/task/kn/0.1/README.md
@@ -13,7 +13,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn
 
 * **kn-image**: `kn` CLI container image to run this task.
 
-  _default_: `gcr.io/knative-releases/knative.dev/client/cmd/kn:v0.10.0`
+  _default_: `gcr.io/knative-releases/knative.dev/client/cmd/kn:latest`
 
   You can use nightly build of the `kn` CLI using
   `gcr.io/knative-nightly/knative.dev/client/cmd/kn`.


### PR DESCRIPTION
Helping a user in Knative slack, I noticed that the documented default on TektonHub (and the catalog) was different from what was actually in the task.  This corrects the README.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [N/A] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [N/A] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [N/A] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [N/A] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [N/A] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [N/A] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [N/A] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [N/A] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [N/A] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [N/A] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
