### PR TITLE
Add new task trivy-scanner - replaces PR https://github.com/tektoncd/catalog/pull/819

### DIFF
--- a/task/trivy-scanner/0.1/README.md
+++ b/task/trivy-scanner/0.1/README.md
@@ -1,0 +1,35 @@
+# trivy-scanner
+
+This task allows the use of the trivy vulnerlability scanner for Tekton Pipelines.See <https://github.com/aquasecurity/trivy>
+
+## What's Trivy?
+
+Trivy (tri pronounced like trigger, vy pronounced like envy) is a simple and comprehensive scanner for vulnerabilities in container images, file systems, and Git repositories, as well as for configuration issues. Trivy detects vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and language-specific packages (Bundler, Composer, npm, yarn, etc.). In addition, Trivy scans Infrastructure as Code (IaC) files such as Terraform, Dockerfile and Kubernetes, to detect potential configuration issues that expose your deployments to the risk of attack. Trivy is easy to use. Just install the binary and you're ready to scan
+
+## Parameters
+
+* **TRIVY_IMAGE**: Optional address of the trivy container image to be used for task.
+
+  _default_: "docker.io/aquasec/trivy@sha256:dea76d4b50c75125cada676a87ac23de2b7ba4374752c6f908253c3b839201d9"
+
+* **ARGS**: The arguments to pass to `trivy` CLI. This parameter is required to run this task.
+
+* **IMAGE_PATH**: The image or path to pass to `trivy` CLI for scanning. This parameter is required to run this task.
+
+### Examples
+
+Run `trivy --help` for Trivy usage.
+
+Using the [Tekton CLI](https://github.com/tektoncd/cli/blob/main/docs/cmd/tkn_task_start.md) (`tkn`):
+
+```shell
+tkn task start trivy-scanner -p ARGS="--help" -p IMAGE_PATH="" --workspace name=manifest-dir,emptyDir=""
+```
+
+Scan Alpine Image:
+
+```shell
+tkn task start trivy-scanner -p ARGS="image,--exit-code,0" -p IMAGE_PATH="docker.io/alpine:3.13" --workspace name=manifest-dir,emptyDir=""
+```
+
+For Pipeline Example See <https://github.com/MoOyeg/trivy-tekton-example>

--- a/task/trivy-scanner/0.1/tests/pvc.yaml
+++ b/task/trivy-scanner/0.1/tests/pvc.yaml
@@ -1,0 +1,12 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-trivy-test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  volumeMode: Filesystem

--- a/task/trivy-scanner/0.1/tests/run.yaml
+++ b/task/trivy-scanner/0.1/tests/run.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-trivy-test
+spec:
+  workspaces:
+    - name: pipeline-pvc
+      optional: false
+  params:
+    - name: ARGS
+      type: array
+      description: The Arguments to be passed to Trivy command for config image.
+  description: Test Pipeline for Trivy
+  tasks:
+    - name: trivy-scan-local-image
+      taskRef:
+        name: trivy-scanner
+        kind: Task
+      params:
+        - name: ARGS
+          value: ["$(params.ARGS[*])"]
+        - name: IMAGE_PATH
+          value: "/usr/lib"
+      workspaces:
+        - name: manifest-dir
+          workspace: pipeline-pvc
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-trivy-test
+spec:
+  params:
+    - name: ARGS
+      value:
+        - "fs"
+        - "--exit-code"
+        - "0"
+  pipelineRef:
+    name: pipeline-trivy-test
+  timeout: 1h0m0s
+  workspaces:
+    - name: pipeline-pvc
+      persistentVolumeClaim:
+        claimName: pvc-trivy-test

--- a/task/trivy-scanner/0.1/trivy-scanner.yaml
+++ b/task/trivy-scanner/0.1/trivy-scanner.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: trivy-scanner
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Security
+    tekton.dev/tags: CLI, trivy
+    tekton.dev/displayName: "trivy scanner"
+spec:
+  description: >-
+    Trivy is a simple and comprehensive scanner for
+    vulnerabilities in container images,file systems
+    ,and Git repositories, as well as for configuration issues.
+
+    This task can be used to scan for vulnenrabilities on the source code
+    in stand alone mode.
+  workspaces:
+    - name: manifest-dir
+  params:
+    - name: ARGS
+      description: The Arguments to be passed to Trivy command.
+      type: array
+    - name: TRIVY_IMAGE
+      default: docker.io/aquasec/trivy@sha256:dea76d4b50c75125cada676a87ac23de2b7ba4374752c6f908253c3b839201d9
+      description: Trivy scanner image to be used
+    - name: IMAGE_PATH
+      description: Image or Path to be scanned by trivy.
+      type: string
+  steps:
+    - name: trivy-scan
+      image: $(params.TRIVY_IMAGE)
+      workingDir: $(workspaces.manifest-dir.path)
+      script: |
+        #!/usr/bin/env sh
+          cmd="trivy $* $(params.IMAGE_PATH)"
+          echo "Running trivy task with command below"
+          echo "$cmd"
+          eval "$cmd"
+      args:
+        - "$(params.ARGS)"

--- a/task/trivy-scanner/OWNERS
+++ b/task/trivy-scanner/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- MoOyeg
+reviewers:
+- MoOyeg


### PR DESCRIPTION
- Task provides a scanner that can be used in CI/CD pIpelines.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
