### PR TITLE
Use multi-arch go-rest-api-test image

### DIFF
--- a/task/orka-full/0.1/tests/mods/mod_task.py
+++ b/task/orka-full/0.1/tests/mods/mod_task.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     # Modify Task YAML
     sidecars.append({
         "name": "go-rest-api",
-        "image": "quay.io/chmouel/go-rest-api-test",
+        "image": "gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest",
         "env": [
             {
                 "name": "CONFIG",

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -256,7 +256,7 @@ EOF
             fi
             cat <<EOF >>${TMPF}
   sidecars:
-  - image: quay.io/chmouel/go-rest-api-test
+  - image: gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest
     name: go-rest-api
     volumeMounts:
     - name: fixtures


### PR DESCRIPTION
# Changes

The `go-rest-api-test` image is used in many catalog tests. To run the tests on many platforms, the image should be the multi-arch one, which is introduced in this PR. At this moment platforms of `gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest` image are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, `linux/arm64`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
