### PR TITLE
Add 'plain' option to kube-linter output formatting

### DIFF
--- a/task/kube-linter/0.1/README.md
+++ b/task/kube-linter/0.1/README.md
@@ -23,7 +23,7 @@ https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-c
 * **includelist** : checks to be included.
 * **excludelist** : checks to be excluded.
 * **default_option** : provides two options (adding all built-in checks or disabling all default checks): add-all-built-in and/do-not-auto-add-defaults.
-* **output_format** : format in which report will be generated. (json|sarif) (default: `json`)
+* **output_format** : format in which report will be generated. (json|sarif|plain) (default: `json`)
 * **args** : args. (default: `[]`)
 
 > _Note_ :  If you want to create your own custom checks using templates and built-in checks, you can create a config file containing all the checks. An example config file can be seen [here](https://raw.githubusercontent.com/tektoncd/catalog/main/task/kube-linter/0.1/samples/config_sample2.yaml). Otherwise, you can provide a string with comma-separated built-in checks to be included or excluded in `includelist` and `exludelist` param.

--- a/task/kube-linter/0.1/kube-linter.yaml
+++ b/task/kube-linter/0.1/kube-linter.yaml
@@ -46,7 +46,7 @@ spec:
       default: ""
     - name: output_format
       type: string
-      description: format in which report will be generated. (json|sarif) (default:"json")
+      description: format in which report will be generated. (json|sarif|plain) (default:"json")
       default: json
     - name: args
       type: array


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `plain` option allows for a human-readable output from the kube-linter task. `json` and `sarif` is more meant to be programmatically consumed. This is a standard option for kube-linter, so no change in the task was required, just a documentation update.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
