### PR TITLE
Add platforms annotation to golang-* tasks

### DIFF
--- a/task/golang-build/0.2/README.md
+++ b/task/golang-build/0.2/README.md
@@ -26,6 +26,11 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`,  and `linux/ppc64le` platforms.
+
+Specify value for `GOARCH` parameter according to the desired target architecture.
 
 ## Usage
 

--- a/task/golang-build/0.2/golang-build.yaml
+++ b/task/golang-build/0.2/golang-build.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Build Tools
     tekton.dev/tags: build-tool
     tekton.dev/displayName: "golang build"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task is Golang task to build Go projects.

--- a/task/golang-fuzz/0.1/README.md
+++ b/task/golang-fuzz/0.1/README.md
@@ -25,6 +25,12 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to fuzz.
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+Specify value for `GOARCH` parameter according to the desired target architecture.
+
 ## Usage
 
 This TaskRun runs the Task fuzz the source code on

--- a/task/golang-fuzz/0.1/golang-fuzz.yaml
+++ b/task/golang-fuzz/0.1/golang-fuzz.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Testing
     tekton.dev/tags: fuzz
     tekton.dev/displayName: "golang fuzz"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task is Golang task to fuzz Go projects.

--- a/task/golang-test/0.2/README.md
+++ b/task/golang-test/0.2/README.md
@@ -25,6 +25,13 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+Specify value for `GOARCH` parameter according to the desired target architecture.
+Do not use `-race` flag in `flags` parameter for `linux/s390x` platform.
+
 ## Usage
 
 This TaskRun runs the Task to run unit-tests on

--- a/task/golang-test/0.2/golang-test.yaml
+++ b/task/golang-test/0.2/golang-test.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Testing
     tekton.dev/tags: test
     tekton.dev/displayName: "golang test"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
 spec:
   description: >-
     This Task is Golang task to test Go projects.


### PR DESCRIPTION
# Changes

Annotation about linux/amd64, linux/s390x, and linux/ppc64le platforms was added to the latest versions of the golang-* tasks.

The tasks were tested for linux/amd64, linux/s390x, and linux/ppc64le.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
