### PR TITLE
Add Robot Framework task

### DIFF
--- a/task/robot-framework/0.1/README.md
+++ b/task/robot-framework/0.1/README.md
@@ -1,0 +1,70 @@
+# Robot Framework
+
+This task runs [Robot Framework](https://robotframework.org/) tests that are provided in the source workspace. Additional configuration is possible with a [variable file](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#resource-and-variable-files).
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/robot-framework/0.1/robot-framework.yaml
+```
+
+## Workspaces
+
+- source: A workspace containing Robot Framework tests. Results are written to `/reports`.
+
+- variables-file: An optional workspace to add a variable file. Useful if you have want to use a secret for credentials, url's, etc.
+
+## Parameters
+
+- **IMAGE**: Optional: Default uses a basic python image and installs test requirements during runtime. It's also possible to use your own image which has requirements pre-installed.
+- **REQUIREMENTS_FILE**: Optional: Requirements file to use for installing test requirements
+- **ROBOT_OPTIONS**: Optional: Arguments to use with the robot command
+- **TEST_DIR**: Directory that contains robot tests
+- **VARIABLES_FILE**: Optional: Name of the variable file provided in the workspace. A .py extension is necessary.
+
+## Usage
+
+Basic usage without installing extra requirements or using a variables file:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: robot-framework
+  params:          
+    - name: TEST_DIR
+      value: ./rf-tests
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+Using a secret that contains a variable file (called `variables.py`):
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: robot-framework
+  params:          
+    - name: TEST_DIR
+      value: ./rf-tests
+    - name: VARIABLES_FILE
+      value: variables.py
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  - name: variables-file
+    secret:
+      secretName: variables
+```
+
+Result files are written to `/reports` in the source workspace. If you want to store the files long-term make sure to upload them to S3 or something similar.

--- a/task/robot-framework/0.1/robot-framework.yaml
+++ b/task/robot-framework/0.1/robot-framework.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: robot-framework
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Testing
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: python, robot-framework
+    tekton.dev/displayName: robot-framework
+
+spec:
+  description: >-
+    This task will run Robot Framework tests in the source workspace.
+
+  workspaces:
+    - name: source
+      description: A workspace containing .robot test files
+    - name: variables-file
+      optional: true
+      description: A Workspace containing a Robot Framework variables file (usually a secret)
+  params:
+    - name: IMAGE
+      description: The image used to run the tests. This can be a base python image, or an image that already has pre-requirements installed.
+      type: string
+      default: "python@sha256:4ec7de21666118edfa1b90c79b34c282624d03e2e560fa1b542b2069a65b367f"
+    - name: REQUIREMENTS_FILE
+      description: Optional requirements file to use for installing test requirements
+      type: string
+      default: ""
+    - name: ROBOT_OPTIONS
+      description: Arguments to use with the robot command
+      type: string
+      default: ""
+    - name: TEST_DIR
+      description: Directory that contains robot tests
+      type: string
+    - name: VARIABLES_FILE
+      description: Name of the variable file provided in the workspace. A .py extension is necessary.
+      type: string
+      default: "variables.py"
+  steps:
+    - name: robot-tests
+      image: $(params.IMAGE)
+      workingDir: $(workspaces.source.path)
+      script: |
+        export PATH=$PATH:$HOME/.local/bin
+
+        if [ -n "$(inputs.params.REQUIREMENTS_FILE)" ];
+        then
+          if [ -e "$(workspaces.source.path)"/"$(inputs.params.REQUIREMENTS_FILE)" ];
+          then
+            pip install -r "$(workspaces.source.path)"/"$(inputs.params.REQUIREMENTS_FILE)"
+            pip show robotframework || {
+              printf "###\nWarning: Robot Framework is missing in your test requirements file\n###";
+              pip install robotframework
+            }
+          else
+            printf "###\nError: Parameter for requirements file was provided, but file was not found in source workspace. Exiting.\n###";
+            exit 1
+          fi
+        else
+          printf "###\nInfo: No parameter for requirements file was provided, only Robot Framework will be installed.\n###";
+          pip install robotframework
+        fi
+
+        if [ -n '$(workspaces.variables-file.path)' ];
+        then
+          if [ -e "$(workspaces.variables-file.path)"/"$(inputs.params.VARIABLES_FILE)" ];
+          then
+            robot --outputdir ./reports -V $(workspaces.variables-file.path)/$(params.VARIABLES_FILE) $(params.ROBOT_OPTIONS) $(params.TEST_DIR)
+          else
+            printf "\nERROR: Variables file $(params.VARIABLES_FILE) not found in workspace. Exiting."
+            exit 1
+          fi
+        else
+          robot --outputdir ./reports $(params.ROBOT_OPTIONS) $(params.TEST_DIR)
+        fi

--- a/task/robot-framework/0.1/tests/pre-apply-task-hook.sh
+++ b/task/robot-framework/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add write-file
+add_task write-file latest

--- a/task/robot-framework/0.1/tests/run.yaml
+++ b/task/robot-framework/0.1/tests/run.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: robot-framework-test-
+spec:
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Mi
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+    tasks:
+      - name: write-file
+        taskRef:
+          name: write-file
+        params:
+          - name: path
+            value: ./robot/test.robot
+          - name: contents
+            value: |
+              *** Test Cases ***
+              Testcase 1
+                Log To Console  'Testcase 1'
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+      - name: robot-framework
+        runAfter: [write-file]
+        taskRef:
+          name: robot-framework
+        params:
+          - name: TEST_DIR
+            value: "./"
+        workspaces:
+          - name: source
+            workspace: shared-workspace


### PR DESCRIPTION
# Changes

Added a task to run Robot Framework tests using either a generic python image or user-generated image with pre-installed requirements. Further configuration is possible by using a test-requirements file, using a variable file from a secret (or configmap) and adding arguments for the Robot command.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

