### PR TITLE
Change platforms annotation to git-* tasks

### DIFF
--- a/task/git-batch-merge/0.2/README.md
+++ b/task/git-batch-merge/0.2/README.md
@@ -38,6 +38,10 @@ There are 4 additional parameters in addition to the ones mentioned above for th
 * **commit**: The precise commit SHA that was fetched by this Task
 * **tree**: The [git tree][git-tree] object SHA that was created after batch merging the refs on HEAD.
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64`, and `linux/ppc64le` platforms.
+
 ### Usage
 
 [git-ref](https://git-scm.com/book/en/v2/Git-Internals-Git-References)

--- a/task/git-batch-merge/0.2/git-batch-merge.yaml
+++ b/task/git-batch-merge/0.2/git-batch-merge.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: git
     tekton.dev/displayName: "git batch merge"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 spec:
   description: >-
     This task takes a set of refspecs, fetches them and performs git operations

--- a/task/git-clone/0.4/README.md
+++ b/task/git-clone/0.4/README.md
@@ -59,6 +59,10 @@ clone takes place. This behaviour can be disabled by setting the
 * **commit**: The precise commit SHA that was fetched by this Task
 * **url**: The precise URL that was fetched by this Task
 
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64`, and `linux/ppc64le` platforms.
+
 ## Usage
 
 If the `revision` is not provided in the param of the taskrun

--- a/task/git-clone/0.4/git-clone.yaml
+++ b/task/git-clone/0.4/git-clone.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: git
     tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 spec:
   description: >-
     These Tasks are Git tasks to work with repositories used by other tasks

--- a/task/git-rebase/0.1/README.md
+++ b/task/git-rebase/0.1/README.md
@@ -35,6 +35,10 @@ pull and rebase (_required_).
 
 * **commit**: The precise commit SHA after the rebase.
 
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64`, and `linux/ppc64le` platforms.
+
 ### Usage
 
 This task needs authentication to git in order to push after the rebase.

--- a/task/git-rebase/0.1/git-rebase.yaml
+++ b/task/git-rebase/0.1/git-rebase.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: git
     tekton.dev/displayName: "git rebase"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 spec:
   description: >-
     These Tasks are Git tasks to work with repositories used by other tasks

--- a/task/git-version/0.1/README.md
+++ b/task/git-version/0.1/README.md
@@ -28,4 +28,4 @@ Git clone with a depth of "0" is therefore needed.
 
 ## Platforms
 
-The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+The Task can be run on `linux/amd64` platform.

--- a/task/git-version/0.1/git-version.yaml
+++ b/task/git-version/0.1/git-version.yaml
@@ -10,7 +10,7 @@ metadata:
     tekton.dev/displayName: "git version"
     tekton.dev/categories: Git
     tekton.dev/tags: git
-    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to create a version from git history


### PR DESCRIPTION
# Changes

Annotation about `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms was added to the latest versions of the `git-batch-merge`, `git-clone`, `git-rebase` tasks.

Platforms annotation was changed for `git-version` task, leaving only `linux/amd64`, because the `mcr.microsoft.com/dotnet/sdk:3.1-focal` image which is used for the task exists only for `linux/amd64` platform

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
