### PR TITLE
Make github-set-status fail if it was unsuccessful

### DIFF
--- a/task/github-set-status/0.3/README.md
+++ b/task/github-set-status/0.3/README.md
@@ -1,0 +1,129 @@
+# GitHub Set Status
+
+GitHub Set Status is part of a collection of GitHub tasks to help working
+with the [GitHub API](https://docs.github.com/en/rest/reference).
+
+## GitHub token
+
+This task expects a secret set in the kubernetes secret `github`
+with a GitHub token in the key `token`; you can easily create it on the
+command line with `kubectl` like this :
+
+```
+kubectl create secret generic github --from-literal token="MY_TOKEN"
+```
+
+## Set Status on a Commit/PR
+
+The `github-set-status` task uses the [status api](https://docs.github.com/en/rest/reference/repos#statuses)
+to mark GitHub commits with an `error`, `failure`, `pending`, or `success`
+state, which is then reflected in pull requests involving those commits.
+
+Statuses include as well a `description` and a `target_url`, to give the user
+informations about the CI statuses or a direct link to the full log.
+
+### Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-set-status/0.3/github-set-status.yaml
+```
+
+### Parameters
+
+* **REPO_FULL_NAME**: The GitHub repository full name, _e.g:_ `tektoncd/catalog`
+* **GITHUB_HOST_URL**: The GitHub host domain _default:_ `api.github.com`
+* **API_PATH_PREFIX**: The GitHub Enterprise has a prefix for the API path. _e.g:_ `/api/v3`
+* **SHA**: The commit SHA to set the status for _e.g_: `tektoncd/catalog`
+* **TARGET_URL**: The target URL to associate with this status. This URL will
+  be linked from the GitHub UI to allow users to easily see the source of the
+  status. For example you can link to a
+  [dashboard](https://github.com/tektoncd/dashboard) URL so users can follow a
+  Pipeline/Task run.
+* **DESCRIPTION**: A short description of the status. _e.g:_ `Building your PR`
+* **CONTEXT**: The GitHub context, A string label to differentiate this status
+  from the status of other systems. _e.g:_ `continuous-integration/tekton`
+* **STATE**: The state of the status. Can be one of the following `error`,
+  `failure`, `pending`, or `success`.
+* **AUTH_TYPE**: The type of authentication to use. You could use the less secure "Basic"
+      for example. See https://docs.github.com/en/rest/overview/other-authentication-methods for more information.
+* **GITHUB_TOKEN_SECRET_NAME** \[optional\]: The name of the kubernetes secret that
+  contains the GitHub token. Default value: `github`
+* **GITHUB_TOKEN_SECRET_KEY** \[optional\]: The key within the kubernetes secret that
+  contains the GitHub token. Default value: `token`
+
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+## Usage for Bearer authentication
+
+This TaskRun sets a commit on GitHub to `pending` getting tested by the CI.
+
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: github-set-status
+  name: github-set-status-run-on-commit-bd93
+spec:
+  taskRef:
+    kind: Task
+    name: github-set-status
+  params:
+    - name: REPO_FULL_NAME
+      value: tektoncd/catalog
+     - name: SHA
+      value: bd93869b489258cef567ccf85e7ef6bc0d6949ea
+    - name: DESCRIPTION
+      value: "Build has started"
+    - name: STATE
+      value: pending
+    - name: TARGET_URL
+      value: https://tekton/dashboard/taskrun/log
+```
+
+
+## Usage for Basic authentication
+
+Make sure the token is fabricated by base64 encoding the username and password with a semicolon in between.
+Example shell script to use:
+
+```bash
+#!/bin/bash
+echo "${1}:${2}" | base64
+```
+
+Calling this script like this `./script.sh githubuser reallyinsecurepassword` would result in `Z2l0aHVidXNlcjpyZWFsbHlpbnNlY3VyZXBhc3N3b3JkCg==`.
+
+Place the result in a secret in the way as the token-based authenticaton.
+
+The following TaskRun shows the usage of Basic authentication. Adding the `AUTH_TYPE` parameter.
+
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: github-set-status
+  name: github-set-status-run-on-commit-bd93
+spec:
+  taskRef:
+    kind: Task
+    name: github-set-status-with-basic-auth
+  params:
+    - name: REPO_FULL_NAME
+      value: tektoncd/catalog
+    - name: SHA
+      value: bd93869b489258cef567ccf85e7ef6bc0d6949ea
+    - name: DESCRIPTION
+      value: "Build has started"
+    - name: STATE
+      value: pending
+    - name: AUTH_TYPE
+      value: Basic
+    - name: TARGET_URL
+      value: https://tekton/dashboard/taskrun/log
+```

--- a/task/github-set-status/0.3/github-set-status.yaml
+++ b/task/github-set-status/0.3/github-set-status.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-set-status
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: github
+    tekton.dev/displayName: "set github status"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This task will set the status of the CI job to the specified value along
+    witha link to the specified target URL where developers can follow the
+    progress of the CI job.
+
+    The `github-set-status` task allows external services to mark GitHub commits
+    with an `error`, `failure`, `pending`, or `success` state, which is then
+    reflected in pull requests involving those commits. Statuses include as well a
+    `description` and a `target_url`, to give the user informations about the CI
+    statuses or a direct link to the full log.
+
+  params:
+  - name: GITHUB_HOST_URL
+    description: |
+      The GitHub host, adjust this if you run a GitHub enteprise.
+    default: "api.github.com"
+    type: string
+
+  - name: API_PATH_PREFIX
+    description: |
+      The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+    default: ""
+    type: string
+
+  - name: REPO_FULL_NAME
+    description: |
+      The GitHub repository full name, e.g.: tektoncd/catalog
+    type: string
+
+  - name: GITHUB_TOKEN_SECRET_NAME
+    description: |
+      The name of the kubernetes secret that contains the GitHub token, default: github
+    type: string
+    default: github
+
+  - name: GITHUB_TOKEN_SECRET_KEY
+    description: |
+      The key within the kubernetes secret that contains the GitHub token, default: token
+    type: string
+    default: token
+
+  - name: SHA
+    description: |
+      Commit SHA to set the status for.
+    type: string
+
+  - name: TARGET_URL
+    description: |
+      The target URL to associate with this status. This URL will be linked
+      from the GitHub UI to allow users to easily see the source of the
+      status.
+    type: string
+
+  - name: DESCRIPTION
+    description: |
+      A short description of the status.
+    type: string
+
+  - name: CONTEXT
+    description: |
+      The GitHub context, A string label to differentiate this status from
+      the status of other systems. ie: "continuous-integration/tekton"
+    default: "continuous-integration/tekton"
+    type: string
+
+  - name: STATE
+    description: |
+      The state of the status. Can be one of the following `error`,
+      `failure`, `pending`, or `success`.
+    type: string
+
+  - name: AUTH_TYPE
+    description: |
+      The type of authentication to use. You could use the less secure "Basic" for example
+    type: string
+    default: Bearer
+
+  volumes:
+    - name: githubtoken
+      secret:
+        secretName: $(params.GITHUB_TOKEN_SECRET_NAME)
+
+  steps:
+    - name: set-status
+      volumeMounts:
+        - name: githubtoken
+          mountPath: /etc/github-set-status
+
+      image: registry.access.redhat.com/ubi8/python-38:1-34.1599745032
+      script: |
+        #!/usr/libexec/platform-python
+
+        """This script will set the CI status on GitHub PR"""
+
+        import json
+        import sys
+        import http.client
+
+        github_token = open("/etc/github-set-status/$(params.GITHUB_TOKEN_SECRET_KEY)", "r").read()
+
+        status_url = "$(params.API_PATH_PREFIX)" + "/repos/$(params.REPO_FULL_NAME)/" + \
+            "statuses/$(params.SHA)"
+
+        data = {
+            "state": "$(params.STATE)",
+            "target_url": "$(params.TARGET_URL)",
+            "description": "$(params.DESCRIPTION)",
+            "context": "$(params.CONTEXT)"
+        }
+        print("Sending this data to GitHub: ")
+        print(data)
+
+        authHeader = "$(params.AUTH_TYPE) " + github_token
+
+        conn = http.client.HTTPSConnection("$(params.GITHUB_HOST_URL)")
+        conn.request(
+            "POST",
+            status_url,
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": authHeader,
+                "Accept": "application/vnd.github.v3+json ",
+            })
+        resp = conn.getresponse()
+        if not str(resp.status).startswith("2"):
+            print("Error: %d" % (resp.status))
+            print(resp.read())
+            sys.exit(1)
+        else:
+            print("GitHub status '$(params.STATE)' has been set on "
+                "$(params.REPO_FULL_NAME)#$(params.SHA) ")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Basically just a mirror of this PR: https://github.com/tektoncd/catalog/pull/827

Complete change overview:
````diff
$ git diff --no-index 0.2 0.3
diff --git a/0.2/README.md b/0.3/README.md
index d41d705..1b32cea 100644
--- a/0.2/README.md
+++ b/0.3/README.md
@@ -25,7 +25,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task

```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-set-status/0.2/github-set-status.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-set-status/0.3/github-set-status.yaml
```

 ### Parameters
diff --git a/0.2/github-set-status.yaml b/0.3/github-set-status.yaml
index b2d9e3c..9202c18 100644
--- a/0.2/github-set-status.yaml
+++ b/0.3/github-set-status.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: github-set-status
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/categories: Git
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -107,6 +107,7 @@ spec:
         """This script will set the CI status on GitHub PR"""

         import json
+        import sys
         import http.client

         github_token = open("/etc/github-set-status/$(params.GITHUB_TOKEN_SECRET_KEY)", "r").read()
@@ -139,6 +140,7 @@ spec:
         if not str(resp.status).startswith("2"):
             print("Error: %d" % (resp.status))
             print(resp.read())
+            sys.exit(1)
         else:
             print("GitHub status '$(params.STATE)' has been set on "
                 "$(params.REPO_FULL_NAME)#$(params.SHA) ")
````

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
