### PR TITLE
Add linux/amd64 platform annotation to the rest of the tasks

### DIFF
--- a/pipeline/build-push-gke-deploy/0.1/README.md
+++ b/pipeline/build-push-gke-deploy/0.1/README.md
@@ -51,6 +51,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipelin
 
   If no value is provided, the target cluster is assumed to be in the same project as the cluster running this Pipeline.
 
+## Platforms
+
+The Pipeline can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### Authorizing the Pipeline

--- a/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
+++ b/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: '0.12.1'
     tekton.dev/tags: build, push, deploy
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Pipeline builds, pushes, and deploys your application to a Google Kubernetes

--- a/pipeline/buildpacks/0.1/README.md
+++ b/pipeline/buildpacks/0.1/README.md
@@ -69,6 +69,10 @@ _The following are the suggested [builders][builders] from the [Cloud Native Bui
 [builders]: (https://buildpacks.io/docs/concepts/components/builder/)
 [buildpacks-io]: (https://buildpacks.io)
 
+## Platforms
+
+The Pipeline can be run on `linux/amd64` platform.
+
 ## Usage
 
 See the following samples for usage:

--- a/pipeline/buildpacks/0.1/buildpacks.yaml
+++ b/pipeline/buildpacks/0.1/buildpacks.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: image-build
     tekton.dev/displayName: "Buildpacks"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The Buildpacks pipeline builds source from a Git repository into a container image and pushes it to a registry, using Cloud Native Buildpacks.

--- a/task/ansible-runner/0.1/README.md
+++ b/task/ansible-runner/0.1/README.md
@@ -26,6 +26,10 @@ tkn task ls
 
 * **runner-dir**: A [workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) to hold the `private_data_dir` as described in https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-input-directory-hierarchy[Runner Directory]
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 The TaskRun uses the repository https://github.com/kameshsampath/tektoncd-ansible-runner-example, that houses some example playbooks.

--- a/task/ansible-runner/0.1/ansible-runner.yaml
+++ b/task/ansible-runner/0.1/ansible-runner.yaml
@@ -12,6 +12,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: cli
     tekton.dev/displayName: 'Ansible Runner'
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Task to run Ansible playbooks using Ansible Runner

--- a/task/ansible-tower-cli/0.1/README.md
+++ b/task/ansible-tower-cli/0.1/README.md
@@ -53,6 +53,10 @@ You can do the former via `oc` and running the following command, replacing `<na
 oc policy add-role-to-user edit -z default -n <namespace>
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This is a pipeline example passing the required credentials, and a list of arguments to the ARGS array variable.

--- a/task/ansible-tower-cli/0.1/ansible-tower-cli.yaml
+++ b/task/ansible-tower-cli/0.1/ansible-tower-cli.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: ansible, cli
     tekton.dev/displayName: "ansible tower cli"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Ansible-tower-cli task simplifies starting jobs, workflow jobs,

--- a/task/argocd-task-sync-and-wait/0.1/README.md
+++ b/task/argocd-task-sync-and-wait/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ar
 
 * **flags:** Flags to append after commands, e.g. `--insecure` (_default:_ `--`)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `Pipeline` implements the typical CD flow using GitOps, as explained [here](https://argoproj.github.io/argo-cd/user-guide/ci_automation/). It runs a sample `Task` that makes and pushes a change to a Git repository, after which it runs the Argo CD `Task` to sync an application based on that repository.

--- a/task/argocd-task-sync-and-wait/0.1/argocd-task-sync-and-wait.yaml
+++ b/task/argocd-task-sync-and-wait/0.1/argocd-task-sync-and-wait.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Deployment
     tekton.dev/tags: deploy
     tekton.dev/displayName: "argocd"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task syncs (deploys) an Argo CD application and waits for it to be healthy.

--- a/task/aws-cli/0.1/README.md
+++ b/task/aws-cli/0.1/README.md
@@ -33,6 +33,9 @@ AWS `credentials` and `config` both should be provided in the form of `secret`.
 
 Refer [this](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html) guide for setting up AWS Credentials and Region.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/aws-cli/0.1/aws-cli.yaml
+++ b/task/aws-cli/0.1/aws-cli.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: cli
     tekton.dev/displayName: "aws cli"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task performs operations on Amazon Web Services resources using aws.

--- a/task/aws-cli/0.2/README.md
+++ b/task/aws-cli/0.2/README.md
@@ -34,6 +34,9 @@ AWS `credentials` and `config` both should be provided in the form of `secret`.
 
 Refer [this](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html) guide for setting up AWS Credentials and Region.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/aws-cli/0.2/aws-cli.yaml
+++ b/task/aws-cli/0.2/aws-cli.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: cli
     tekton.dev/displayName: "aws cli"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task performs operations on Amazon Web Services resources using aws.

--- a/task/aws-ecr-login/0.1/README.md
+++ b/task/aws-ecr-login/0.1/README.md
@@ -35,6 +35,10 @@ can be referred to create `aws-credentials`.
 Refer [aws docs](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html) 
 guide for setting up AWS Credentials and Region.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 AWS ECR login task will be used to authenticate to Amazon ECR registry. 

--- a/task/aws-ecr-login/0.1/aws-ecr-login.yaml
+++ b/task/aws-ecr-login/0.1/aws-ecr-login.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: aws, ecr
     tekton.dev/displayName: "Amazon ECR Login"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task retrieves an `authentication token` using the GetAuthorizationToken API

--- a/task/az/0.1/README.md
+++ b/task/az/0.1/README.md
@@ -18,6 +18,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/az/0.1/
 
 * **ARGS**: The arguments to pass to `az` CLI. This parameter is required to run this task.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### Running the Task

--- a/task/az/0.1/az.yaml
+++ b/task/az/0.1/az.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: cli
     tekton.dev/displayName: "azure cli"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task performs operations on Microsoft Azure resources using az.

--- a/task/bentoml/0.1/README.md
+++ b/task/bentoml/0.1/README.md
@@ -23,3 +23,7 @@ Use bentoml to retrieve a full ML build environment in the cwd:
 ```shell
 tkn task start bentoml -p ARGS="retrieve ServiceName:20200616152703_9E2AD7","YATAISERVICE=10.10.10.1:50051 --target_dir=/workspace/storage"
 ```
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/bentoml/0.1/bentoml.yaml
+++ b/task/bentoml/0.1/bentoml.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Automation, Integration & Delivery
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: cli
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task allows operations on BentoML services

--- a/task/black/0.1/README.md
+++ b/task/black/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bl
 
 - **shared-workspace**: The workspace containing python source code which we want to format. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/black/0.1/black.yaml
+++ b/task/black/0.1/black.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: formatter, python
     tekton.dev/displayName: "Python Black"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to format Python code

--- a/task/black/0.2/README.md
+++ b/task/black/0.2/README.md
@@ -19,6 +19,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bl
 
 - **shared-workspace**: The workspace containing python source code which we want to format. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/black/0.2/black.yaml
+++ b/task/black/0.2/black.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: formatter, python, black
     tekton.dev/displayName: "Python Black"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to format Python code

--- a/task/blue-green-deploy/0.1/README.md
+++ b/task/blue-green-deploy/0.1/README.md
@@ -28,6 +28,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bl
 - **NEW_VERSION**: The version of the deployment to be deployed in the green/blue zone
 - **MANIFEST**: The deployment manifest URL file path provided in case the manifest is present on Github. (_Example_: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/blue-green-deploy/0.1/samples/v1-deploy/blue-deployment.yaml")
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 # Usage
 
 This TaskRun runs the Task to deploy the given Kubernetes resource in the green/blue zone and toggle the service to point to the new zone.

--- a/task/blue-green-deploy/0.1/blue-green-deploy.yaml
+++ b/task/blue-green-deploy/0.1/blue-green-deploy.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Deployment
     tekton.dev/tags: deployment
     tekton.dev/displayName: "blue green deployment"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to do Blue-Green deployment

--- a/task/boskos-acquire/0.1/README.md
+++ b/task/boskos-acquire/0.1/README.md
@@ -29,6 +29,10 @@ with `pods` (see [service-account.yaml](samples/service-account.yaml) for an exa
 
 * **leased-resource**: The name of the leased resource
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 See [samples/pipelinerun.yaml](samples/pipelinerun.yaml) for an example of a Pipeline that obtains

--- a/task/boskos-acquire/0.1/boskos-acquire.yaml
+++ b/task/boskos-acquire/0.1/boskos-acquire.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Cloud
     tekton.dev/tags: "boskos,test"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: |
     Acquire a project using Boskos.

--- a/task/boskos-release/0.1/README.md
+++ b/task/boskos-release/0.1/README.md
@@ -24,6 +24,10 @@ serviceAccount that has the ability to delete `pods` (see [service-account.yaml]
 * **leased-resource**: The name of the leased resource. (_required_)
 * **owner-name**: A string that identifies the owner of the leased resource to request. (_required_)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 See [samples/pipelinerun.yaml](samples/pipelinerun.yaml) for an example of a Pipeline that obtains

--- a/task/boskos-release/0.1/boskos-release.yaml
+++ b/task/boskos-release/0.1/boskos-release.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Cloud
     tekton.dev/tags: "boskos,test"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: |
     Release a project acquired using Boskos.

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -35,6 +35,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bu
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Buildah task builds source into a container image and

--- a/task/buildkit-daemonless/0.1/README.md
+++ b/task/buildkit-daemonless/0.1/README.md
@@ -32,3 +32,7 @@ task.tekton.dev/buildkit-daemonless created
 
 * **image**: An `image`-type `PipelineResource` specifying the image that should be built.
   Currently, generating [`resourceResult`](https://github.com/tektoncd/pipeline/blob/main/docs/resources.md#image-resource) is not supported. ([`buildkit#993`](https://github.com/moby/buildkit/issues/993))
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/buildkit-daemonless/0.1/buildkit-daemonless.yaml
+++ b/task/buildkit-daemonless/0.1/buildkit-daemonless.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
     tekton.dev/displayName: "buildkit daemonless"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds source into a container image using Moby BuildKit.

--- a/task/buildkit/0.1/README.md
+++ b/task/buildkit/0.1/README.md
@@ -71,3 +71,7 @@ task.tekton.dev/buildkit created
 
 * **image**: An `image`-type `PipelineResource` specifying the image that should be built.
   Currently, generating [`resourceResult`](https://github.com/tektoncd/pipeline/blob/main/docs/resources.md#image-resource) is not supported. ([`buildkit#993`](https://github.com/moby/buildkit/issues/993))
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/buildkit/0.1/buildkit.yaml
+++ b/task/buildkit/0.1/buildkit.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds source into a container image using Moby BuildKit.

--- a/task/buildpacks-phases/0.1/README.md
+++ b/task/buildpacks-phases/0.1/README.md
@@ -45,6 +45,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bu
 
 The `source` workspace holds the source to build. See `SOURCE_SUBPATH` above if source is located within a subpath of this input.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` will use the `buildpacks` task to build the source code, then publish a container image.

--- a/task/buildpacks-phases/0.1/buildpacks-phases.yaml
+++ b/task/buildpacks-phases/0.1/buildpacks-phases.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: image-build
     tekton.dev/displayName: "buildpacks-phases"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The Buildpacks-Phases task builds source into a container image and pushes it to

--- a/task/buildpacks-phases/0.2/README.md
+++ b/task/buildpacks-phases/0.2/README.md
@@ -56,6 +56,10 @@ _The following are the suggested [builders][builders] from the [Cloud Native Bui
 [builders]: (https://buildpacks.io/docs/concepts/components/builder/)
 [buildpacks-io]: (https://buildpacks.io)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 See the following samples for usage:

--- a/task/buildpacks-phases/0.2/buildpacks-phases.yaml
+++ b/task/buildpacks-phases/0.2/buildpacks-phases.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: image-build
     tekton.dev/displayName: "Buildpacks (phases)"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The Buildpacks-Phases task builds source into a container image and pushes it to

--- a/task/buildpacks/0.1/README.md
+++ b/task/buildpacks/0.1/README.md
@@ -46,6 +46,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bu
 
 The `source` workspace holds the source to build. See `SOURCE_SUBPATH` above if source is located within a subpath of this input.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` will use the `buildpacks` task to build the source code, then publish a container image.

--- a/task/buildpacks/0.1/buildpacks.yaml
+++ b/task/buildpacks/0.1/buildpacks.yaml
@@ -11,6 +11,7 @@ metadata:
     tekton.dev/tags: image-build
     tekton.dev/deprecated: "true"
     tekton.dev/displayName: "buildpacks"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The Buildpacks task builds source into a container image and pushes it to a registry,

--- a/task/buildpacks/0.2/README.md
+++ b/task/buildpacks/0.2/README.md
@@ -46,6 +46,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bu
 
 The `source` workspace holds the source to build. See `SOURCE_SUBPATH` above if source is located within a subpath of this input.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` will use the `buildpacks` task to build the source code, then publish a container image.

--- a/task/buildpacks/0.2/buildpacks.yaml
+++ b/task/buildpacks/0.2/buildpacks.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: image-build
     tekton.dev/displayName: "buildpacks"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The Buildpacks task builds source into a container image and pushes it to a registry,

--- a/task/buildpacks/0.3/README.md
+++ b/task/buildpacks/0.3/README.md
@@ -57,6 +57,10 @@ _The following are the suggested [builders][builders] from the [Cloud Native Bui
 [builders]: (https://buildpacks.io/docs/concepts/components/builder/)
 [buildpacks-io]: (https://buildpacks.io)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 See the following samples for usage:

--- a/task/buildpacks/0.3/buildpacks.yaml
+++ b/task/buildpacks/0.3/buildpacks.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: image-build
     tekton.dev/displayName: "Buildpacks"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The Buildpacks task builds source into a container image and pushes it to a registry,

--- a/task/check-make/0.1/README.md
+++ b/task/check-make/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ch
 
 - **shared-workspace** : The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/check-make/0.1/check-make.yaml
+++ b/task/check-make/0.1/check-make.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
     tekton.dev/displayName: "Makefile linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on Makefiles

--- a/task/cloudevent/0.1/README.md
+++ b/task/cloudevent/0.1/README.md
@@ -29,3 +29,7 @@ Once you have ko, you can build the binary and resolve the task yaml into instal
 `ko resolve -f config/task.yaml > cloudevent.yaml`
 
 The go import path will be replaced in the yaml by the built container.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/cloudevent/0.1/cloudevent.yaml
+++ b/task/cloudevent/0.1/cloudevent.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Networking
     tekton.dev/tags: cloud
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task send a single CloudEvent to a specified sink.

--- a/task/codecov/0.1/README.md
+++ b/task/codecov/0.1/README.md
@@ -14,6 +14,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/co
 - **codecov-token-secret-key**: Name of the secret key holding the codecov token. (_Default_: `token`)
 - **args**: Extra arguments to be passed to the codecov script, more details [here](https://docs.codecov.io/docs/about-the-codecov-bash-uploader#arguments) (_Default_: [`-Z`])
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 Generate the code coverage file for your project inside your workspace, see here

--- a/task/codecov/0.1/codecov.yaml
+++ b/task/codecov/0.1/codecov.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: build,ci
     tekton.dev/displayName: "upload coverage report to codecov"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task publishes coverage report to Codecov.io.

--- a/task/conftest/0.1/README.md
+++ b/task/conftest/0.1/README.md
@@ -11,6 +11,10 @@ In order to use Conftest with Tekton you need to first install the task.
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/conftest/0.1/conftest.yaml
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 Once installed, the task can be used as follows:

--- a/task/conftest/0.1/conftest.yaml
+++ b/task/conftest/0.1/conftest.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Testing
     tekton.dev/tags: test
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     These tasks make it possible to use Conftest within your Tekton pipelines

--- a/task/create-github-release/0.1/README.md
+++ b/task/create-github-release/0.1/README.md
@@ -38,6 +38,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/cr
 
 Check [this](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to get personal access token for `Github`.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/create-github-release/0.1/create-github-release.yaml
+++ b/task/create-github-release/0.1/create-github-release.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: github
     tekton.dev/displayName: "create github release"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This `task` can be used to make a github release.

--- a/task/create-gitlab-release/0.1/README.md
+++ b/task/create-gitlab-release/0.1/README.md
@@ -34,6 +34,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/cr
 
 Check [this](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) to get personal access token for `Gitlab`.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This task expects a secret named gitlab-token to exists, with a Gitlab personal access token in `GITLAB_TOKEN` with enough privileges to create a release.

--- a/task/create-gitlab-release/0.1/create-gitlab-release.yaml
+++ b/task/create-gitlab-release/0.1/create-gitlab-release.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: gitlab
     tekton.dev/displayName: "create gitlab release"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This `task` can be used to make a gitlab release.

--- a/task/docker-build/0.1/README.md
+++ b/task/docker-build/0.1/README.md
@@ -29,6 +29,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/do
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) volume containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ### Usage
 

--- a/task/docker-build/0.1/docker-build.yaml
+++ b/task/docker-build/0.1/docker-build.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: docker, build-image, push-image, dind
     tekton.dev/displayName: docker-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task will build and push an image using docker.

--- a/task/eks-cluster-create/0.1/README.md
+++ b/task/eks-cluster-create/0.1/README.md
@@ -21,6 +21,10 @@ requests to the cluster.
 * **secrets**: A Secret containing the AWS credentials to run the create.
 * **kubeconfig**: A workspace into which a kubeconfig file called `kubeconfig` will be written that will contain the information required to access the cluster. The `kubeconfig` will expect to use [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator/) to authenticate, so in order for it to be used it must be run in a container which contains both `kubectl` and `aws-iam-authenticator`.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 See [samples/create-eks-cluster.yaml](https://github.com/tektoncd/catalog/tree/main/task/eks-cluster-create/0.1/samples/create-eks-cluster.yaml) for an example of a TaskRun that creates a EKS cluster and writes the kubeconfig to a PVC.

--- a/task/eks-cluster-create/0.1/eks-cluster-create.yaml
+++ b/task/eks-cluster-create/0.1/eks-cluster-create.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Kubernetes
     tekton.dev/tags: "aws, eks"
     tekton.dev/displayName: "EKS Cluster Create"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: |
     Create an EKS cluster.

--- a/task/eks-cluster-teardown/0.1/README.md
+++ b/task/eks-cluster-teardown/0.1/README.md
@@ -21,6 +21,10 @@ Refer [this](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-c
 
 The AWS user/role should have the [minimum IAM policies](https://eksctl.io/usage/minimum-iam-policies/) defined by `eksctl`.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 See [samples/teardown-eks-cluster.yaml](https://github.com/tektoncd/catalog/tree/main/task/eks-cluster-teardown/0.1/samples/teardown-eks-cluster.yaml) for an example of a TaskRun that tears down an EKS cluster.

--- a/task/eks-cluster-teardown/0.1/eks-cluster-teardown.yaml
+++ b/task/eks-cluster-teardown/0.1/eks-cluster-teardown.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Kubernetes
     tekton.dev/tags: "aws, eks"
     tekton.dev/displayName: "EKS Cluster Teardown"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: |
     Teardown an EKS cluster.

--- a/task/flake8/0.1/README.md
+++ b/task/flake8/0.1/README.md
@@ -20,6 +20,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/fl
 * **path**: The path to the module which should be analysed by flake8. (_Default_: `"."`)
 * **requirements_file**: The path to the requirements file to pip install for your application to be checked. (_Default_: `"requirements.txt"`)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` runs `flake8` in a python module directory called `module/`.

--- a/task/flake8/0.1/flake8.yaml
+++ b/task/flake8/0.1/flake8.yaml
@@ -10,7 +10,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: python, flake8, linter
     tekton.dev/displayName: flake8
-
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task will run flake8 on the provided input.

--- a/task/gcloud/0.1/README.md
+++ b/task/gcloud/0.1/README.md
@@ -23,6 +23,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gc
 
 * **ARGS**: The arguments to pass to `gcloud` CLI.  _default_: `["help"]`
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### Authorizing `gcloud` commands

--- a/task/gcloud/0.1/gcloud.yaml
+++ b/task/gcloud/0.1/gcloud.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: CLI
     tekton.dev/tags: gcp
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task performs operations on Google Cloud Platform resources using gcloud.

--- a/task/gcs-create-bucket/0.1/README.md
+++ b/task/gcs-create-bucket/0.1/README.md
@@ -55,3 +55,7 @@ spec:
   - name: region
     value: ASIA-SOUTHEAST1
 ```
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/gcs-create-bucket/0.1/gcs-create-bucket.yaml
+++ b/task/gcs-create-bucket/0.1/gcs-create-bucket.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Cloud, Storage
     tekton.dev/tags: cloud, gcs
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     A Task that creates a new GCS bucket.

--- a/task/gcs-delete-bucket/0.1/README.md
+++ b/task/gcs-delete-bucket/0.1/README.md
@@ -46,3 +46,7 @@ spec:
   - name: bucketName
     value: gs://my-fancy-new-test-bucket-12345
 ```
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/gcs-delete-bucket/0.1/gcs-delete-bucket.yaml
+++ b/task/gcs-delete-bucket/0.1/gcs-delete-bucket.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Cloud, Storage
     tekton.dev/tags: cloud, gcs
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     A Task that deletes a GCS bucket.

--- a/task/gcs-download/0.1/README.md
+++ b/task/gcs-download/0.1/README.md
@@ -26,6 +26,9 @@ on a Workspace.
 * **typeDir**: Set this to "true" if the object you are copying is a directory. (_default_: "false")
 * **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/gcs-download/0.1/gcs-download.yaml
+++ b/task/gcs-download/0.1/gcs-download.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Cloud, Storage
     tekton.dev/tags: cloud, gcs
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     A Task that downloads a GCS bucket.

--- a/task/gcs-generic/0.1/README.md
+++ b/task/gcs-generic/0.1/README.md
@@ -24,6 +24,10 @@ A `Task` that allows users customize and extend the gsutil command line based on
 * **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service_account.json")
 * **image**: The google cloud image that will be used in steps. (_default_: "google/cloud-sdk")
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 

--- a/task/gcs-generic/0.1/gcs-generic.yaml
+++ b/task/gcs-generic/0.1/gcs-generic.yaml
@@ -8,6 +8,7 @@ metadata:
   tekton.dev/pipelines.minVersion: "0.12.1"
   tekton.dev/categories: Cloud, Storage
   tekton.dev/tags: cloud, gcs
+  tekton.dev/platforms: "linux/amd64"
 spec:
  description: >-
   A Task that allows users to customize and extend the gsutil

--- a/task/gcs-upload/0.1/README.md
+++ b/task/gcs-upload/0.1/README.md
@@ -25,6 +25,9 @@ A `Task` that uploads files or directories from a Workspace to a GCS bucket.
 * **location**: The address (including "gs://") where you'd like to upload files to. (_required_)
 * **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/gcs-upload/0.1/gcs-upload.yaml
+++ b/task/gcs-upload/0.1/gcs-upload.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Cloud, Storage
     tekton.dev/tags: cloud, gcs
     tekton.dev/displayName: "Upload to GCS"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     A Task that uploads a GCS bucket.

--- a/task/generate-build-id/0.1/README.md
+++ b/task/generate-build-id/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ge
 
 The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### Include the task inside a taskrun

--- a/task/git-batch-merge/0.1/README.md
+++ b/task/git-batch-merge/0.1/README.md
@@ -38,6 +38,10 @@ There are 4 additional parameters in addition to the ones mentioned above for th
 * **commit**: The precise commit SHA that was fetched by this Task
 * **tree**: The [git tree][git-tree] object SHA that was created after batch merging the refs on HEAD.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ### Usage
 
 [git-ref](https://git-scm.com/book/en/v2/Git-Internals-Git-References)

--- a/task/git-batch-merge/0.1/git-batch-merge.yaml
+++ b/task/git-batch-merge/0.1/git-batch-merge.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: git
     tekton.dev/displayName: "git batch merge"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task takes a set of refspecs, fetches them and performs git operations

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -45,6 +45,10 @@ as well as
 
 * **commit**: The precise commit SHA that was fetched by this Task
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### `git-clone`

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: git
     tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     These Tasks are Git tasks to work with repositories used by other tasks

--- a/task/git-clone/0.2/README.md
+++ b/task/git-clone/0.2/README.md
@@ -46,6 +46,10 @@ as well as
 * **commit**: The precise commit SHA that was fetched by this Task
 * **url**: The precise URL that was fetched by this Task
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 If the `revision` is not provided in the param of the taskrun

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: git
     tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     These Tasks are Git tasks to work with repositories used by other tasks

--- a/task/git-clone/0.3/README.md
+++ b/task/git-clone/0.3/README.md
@@ -49,6 +49,10 @@ as well as
 * **commit**: The precise commit SHA that was fetched by this Task
 * **url**: The precise URL that was fetched by this Task
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 If the `revision` is not provided in the param of the taskrun

--- a/task/git-clone/0.3/git-clone.yaml
+++ b/task/git-clone/0.3/git-clone.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: git
     tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     These Tasks are Git tasks to work with repositories used by other tasks

--- a/task/git-rebase/0.1/README.md
+++ b/task/git-rebase/0.1/README.md
@@ -39,6 +39,10 @@ pull and rebase (_required_).
 
 The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64`, and `linux/ppc64le` platforms.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ### Usage
 
 This task needs authentication to git in order to push after the rebase.

--- a/task/github-add-comment/0.1/README.md
+++ b/task/github-add-comment/0.1/README.md
@@ -31,6 +31,10 @@ Check [this](https://help.github.com/en/github/authenticating-to-github/creating
 
 See GitHub's documentation on [Understanding scopes for OAuth Apps](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/) to figure out what scopes you need to give to this token to add comment to an issue or a pull request.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun add a comment to an issue.

--- a/task/github-add-comment/0.1/github-add-comment.yaml
+++ b/task/github-add-comment/0.1/github-add-comment.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "add github comment"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task will add a comment to a pull request or an issue.

--- a/task/github-add-comment/0.2/README.md
+++ b/task/github-add-comment/0.2/README.md
@@ -34,6 +34,9 @@ See GitHub's documentation on [Understanding scopes for OAuth Apps](https://deve
   contains the GitHub token. (_default:_ `github`).
 * **GITHUB_TOKEN_SECRET_KEY**: The key within the Kubernetes Secret that contains the GitHub token. (_default:_ `token`).
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/github-add-comment/0.2/github-add-comment.yaml
+++ b/task/github-add-comment/0.2/github-add-comment.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "add github comment"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task will add a comment to a pull request or an issue.

--- a/task/github-add-comment/0.3/README.md
+++ b/task/github-add-comment/0.3/README.md
@@ -49,6 +49,10 @@ See GitHub's documentation on [Understanding scopes for OAuth Apps](https://deve
 
 - **comment-file**: The optional workspace containing comment file to be posted.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun add a comment to an issue.

--- a/task/github-add-comment/0.3/github-add-comment.yaml
+++ b/task/github-add-comment/0.3/github-add-comment.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: github
     tekton.dev/displayName: "add github comment"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   workspaces:
     - name: comment-file

--- a/task/github-app-token/0.1/README.md
+++ b/task/github-app-token/0.1/README.md
@@ -30,6 +30,9 @@ Refer [this](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-c
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-app-token/0.1/github-app-token.yaml
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/github-app-token/0.1/github-app-token.yaml
+++ b/task/github-app-token/0.1/github-app-token.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: github
     tekton.dev/displayName: "github app token"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Retrive a user token from a GitHub application

--- a/task/github-app-token/0.2/README.md
+++ b/task/github-app-token/0.2/README.md
@@ -32,6 +32,9 @@ Refer [this](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-c
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-app-token/0.2/github-app-token.yaml
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/github-app-token/0.2/github-app-token.yaml
+++ b/task/github-app-token/0.2/github-app-token.yaml
@@ -11,6 +11,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: github
     tekton.dev/displayName: "github app token"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Retrieve a user token from a GitHub application

--- a/task/github-close-issue/0.1/README.md
+++ b/task/github-close-issue/0.1/README.md
@@ -30,6 +30,10 @@ See GitHub's documentation on [Understanding scopes for OAuth Apps](https://deve
 * **REQUEST_URL:**: The GitHub pull request or issue url, (_e.g:_
   `https://github.com/tektoncd/catalog/issues/46`)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun close an issue on a task.

--- a/task/github-close-issue/0.1/github-close-issue.yaml
+++ b/task/github-close-issue/0.1/github-close-issue.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "close github issue"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task will close a pull request or an issue.

--- a/task/github-create-deployment/0.1/README.md
+++ b/task/github-create-deployment/0.1/README.md
@@ -40,6 +40,10 @@ See GitHub's documentation on [Understanding scopes for OAuth Apps](https://deve
   contains the GitHub token. (_default:_ `github`).
 - **GITHUB_TOKEN_SECRET_KEY**: The key within the Kubernetes Secret that contains the GitHub token. (_default:_ `token`).
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun creates a GitHub deployment for the given repository.

--- a/task/github-create-deployment/0.1/github-create-deployment.yaml
+++ b/task/github-create-deployment/0.1/github-create-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "create github deployment"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task will create a GitHub deployment for a repository.

--- a/task/github-set-status/0.1/README.md
+++ b/task/github-set-status/0.1/README.md
@@ -45,6 +45,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gi
 * **STATE**: The state of the status. Can be one of the following `error`,
   `failure`, `pending`, or `success`.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun sets a commit on GitHub to `pending` getting tested by the CI.

--- a/task/github-set-status/0.1/github-set-status.yaml
+++ b/task/github-set-status/0.1/github-set-status.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: github
     tekton.dev/displayName: "set github status"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task will set the status of the CI job to the specified value along

--- a/task/gitlab-add-label/0.1/README.md
+++ b/task/gitlab-add-label/0.1/README.md
@@ -51,6 +51,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gi
 
 * `Secret` to provide Gitlab `access token` to authenticate to the Gitlab.
 
+### Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ### Usage
 

--- a/task/gitlab-add-label/0.1/gitlab-add-label.yaml
+++ b/task/gitlab-add-label/0.1/gitlab-add-label.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: gitlab
     tekton.dev/displayName: "gitlab add label"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task will add a label to an issue in Gitlab.

--- a/task/gitlab-set-status/0.1/README.md
+++ b/task/gitlab-set-status/0.1/README.md
@@ -34,3 +34,6 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gi
 * **CONTEXT**: The GitLab context, A string label to differentiate this status
   from the status of other systems. _e.g:_ `continuous-integration/tekton`
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/gitlab-set-status/0.1/gitlab-set-status.yaml
+++ b/task/gitlab-set-status/0.1/gitlab-set-status.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Git
     tekton.dev/tags: gitlab, git
     tekton.dev/displayName: "Set Gitlab commit status"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task will set the status of the CI job to the specified value along

--- a/task/gitleaks/0.1/README.md
+++ b/task/gitleaks/0.1/README.md
@@ -28,6 +28,9 @@ https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-c
 
 > _Note_ :  Gitleaks provides some default rulesets for detecting secrets which you can find [here](https://github.com/zricethezav/gitleaks/blob/master/config/default.go). However, user is free to create rulesets as per his requirement by defining them inside (.toml) format file. To know how to write these config file, you can visit this [link](https://github.com/zricethezav/gitleaks#rules-summary). Also, if you want to checkout an example config file, please head over to this [link](https://raw.githubusercontent.com/urvashigupta7/secret_detection/master/gitleaks.toml). The config file can exist in the repository to be scanned or some other repository, if the config file is present in some other repository, you would need to provide url of **config_file_url** and the **config_file_path** where config file would be saved after fetching else you need to provide **config_file_path** only.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/gitleaks/0.1/gitleaks.yaml
+++ b/task/gitleaks/0.1/gitleaks.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Security
     tekton.dev/tags: Security, Secrets
     tekton.dev/displayName: "Gitleaks"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task makes it possible to use Gitleaks within your Tekton pipelines.

--- a/task/gke-cluster-create/0.1/README.md
+++ b/task/gke-cluster-create/0.1/README.md
@@ -37,6 +37,10 @@ NodePort default range (https://kubernetes.io/docs/concepts/services-networking/
 
 * **cluster-name** The name of the cluster that was created.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 See [samples/create-gke-cluster.yaml](samples/create-gke-cluster.yaml) for an example of a TaskRun

--- a/task/gke-cluster-create/0.1/gke-cluster-create.yaml
+++ b/task/gke-cluster-create/0.1/gke-cluster-create.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/tags: "gke,test"
     tekton.dev/displayName: "GKE Cluster Create"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: |
     Create a GKE cluster.

--- a/task/gke-deploy/0.1/README.md
+++ b/task/gke-deploy/0.1/README.md
@@ -21,6 +21,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gk
 
 * **source**: The Git source repository that contains your application's Kubernetes configs.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### Authorizing `gke-deploy` commands

--- a/task/gke-deploy/0.1/gke-deploy.yaml
+++ b/task/gke-deploy/0.1/gke-deploy.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Deployment
     tekton.dev/tags: deploy
     tekton.dev/displayName: "gke deploy"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task deploys an application to a Google Kubernetes Engine

--- a/task/golang-build/0.1/README.md
+++ b/task/golang-build/0.1/README.md
@@ -24,6 +24,9 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
 
 ## Usage
 

--- a/task/golang-build/0.1/golang-build.yaml
+++ b/task/golang-build/0.1/golang-build.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Build Tools
     tekton.dev/tags: build-tool
     tekton.dev/displayName: "golang build"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task is Golang task to build Go projects.

--- a/task/golang-test/0.1/README.md
+++ b/task/golang-test/0.1/README.md
@@ -23,6 +23,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to run unit-tests on

--- a/task/golang-test/0.1/golang-test.yaml
+++ b/task/golang-test/0.1/golang-test.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Testing
     tekton.dev/tags: test
     tekton.dev/displayName: "golang test"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task is Golang task to test Go projects.

--- a/task/golangci-lint/0.1/README.md
+++ b/task/golangci-lint/0.1/README.md
@@ -23,6 +23,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to validate

--- a/task/golangci-lint/0.1/golangci-lint.yaml
+++ b/task/golangci-lint/0.1/golangci-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: lint
     tekton.dev/displayName: "golangci lint"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task is Golang task to validate Go projects.

--- a/task/golangci-lint/0.2/README.md
+++ b/task/golangci-lint/0.2/README.md
@@ -26,6 +26,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to validate

--- a/task/golangci-lint/0.2/golangci-lint.yaml
+++ b/task/golangci-lint/0.2/golangci-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: lint
     tekton.dev/displayName: "golangci lint"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task is Golang task to validate Go projects.

--- a/task/goreleaser/0.1/README.md
+++ b/task/goreleaser/0.1/README.md
@@ -19,6 +19,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 - **source**: The workspace containing the Go source code which needs to be released. The default `mountPath` is `/workspace/src/$(params.package)`
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the GitHub token by following the steps from [here](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)

--- a/task/goreleaser/0.1/goreleaser.yaml
+++ b/task/goreleaser/0.1/goreleaser.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Automation, Publishing
     tekton.dev/tags: golang, release-automation, package
     tekton.dev/displayName: "GoReleaser"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     GoReleaser builds Go binaries for several platforms.

--- a/task/goreleaser/0.2/README.md
+++ b/task/goreleaser/0.2/README.md
@@ -20,6 +20,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/go
 
 - **source**: The workspace containing the Go source code which needs to be released. The default `mountPath` is `/workspace/src/$(params.package)`
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the GitHub token by following the steps from [here](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)

--- a/task/goreleaser/0.2/goreleaser.yaml
+++ b/task/goreleaser/0.2/goreleaser.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Automation, Publishing
     tekton.dev/tags: golang, release-automation, package
     tekton.dev/displayName: "GoReleaser"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     GoReleaser builds Go binaries for several platforms.

--- a/task/helm-conftest/0.1/README.md
+++ b/task/helm-conftest/0.1/README.md
@@ -45,3 +45,7 @@ spec:
 ## Workspaces
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/helm-conftest/0.1/helm-conftest.yaml
+++ b/task/helm-conftest/0.1/helm-conftest.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Testing
     tekton.dev/tags: test
     tekton.dev/displayName: "helm conftest"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     These tasks make it possible to use Conftest within your Tekton pipelines

--- a/task/helm-upgrade-from-repo/0.1/README.md
+++ b/task/helm-upgrade-from-repo/0.1/README.md
@@ -23,6 +23,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/he
 - **overwrite_values**: The values to be overwritten (*default: ""*)
 - **helm_version**: The helm version which should be used (*default: latest*)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### PipelineRun

--- a/task/helm-upgrade-from-repo/0.1/helm-upgrade-from-repo.yaml
+++ b/task/helm-upgrade-from-repo/0.1/helm-upgrade-from-repo.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Deployment
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: helm
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     These tasks will install / upgrade a helm chart into your Kubernetes /

--- a/task/helm-upgrade-from-source/0.1/README.md
+++ b/task/helm-upgrade-from-source/0.1/README.md
@@ -23,6 +23,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/he
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the helm chart.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### PipelineRun

--- a/task/helm-upgrade-from-source/0.1/helm-upgrade-from-source.yaml
+++ b/task/helm-upgrade-from-source/0.1/helm-upgrade-from-source.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Deployment
     tekton.dev/tags: helm
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     These tasks will install / upgrade a helm chart into your Kubernetes /

--- a/task/ibmcloud/0.1/README.md
+++ b/task/ibmcloud/0.1/README.md
@@ -18,6 +18,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ib
 
 * **ARGS**: The arguments to pass to `ibmcloud` CLI. This parameter is required to run this task.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ### Running the Task

--- a/task/ibmcloud/0.1/ibmcloud.yaml
+++ b/task/ibmcloud/0.1/ibmcloud.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Cloud
     tekton.dev/tags: cloud
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task performs operations on IBM Cloud using the ibmcloud.

--- a/task/istio-canary-release/0.1/README.md
+++ b/task/istio-canary-release/0.1/README.md
@@ -41,6 +41,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/is
 
 **Note**: The above parameters are used in case we need to do traffic splitting using virtual service and for creating a `VirtualService` then use the `ConfigMap` as shown below.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 # Usage
 
 1. Create `ConfigMap` for `Istio` manifests

--- a/task/istio-canary-release/0.1/istio-canary-release.yaml
+++ b/task/istio-canary-release/0.1/istio-canary-release.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Deployment
     tekton.dev/tags: canary deployment, istio
     tekton.dev/displayName: "istio canary release"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform deployment of an application

--- a/task/jenkins/0.1/README.md
+++ b/task/jenkins/0.1/README.md
@@ -70,6 +70,10 @@ stringData:
   apitoken: api-token
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Start a job without parameters

--- a/task/jenkins/0.1/jenkins.yaml
+++ b/task/jenkins/0.1/jenkins.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Automation
     tekton.dev/tags: jenkins, build
     tekton.dev/displayName: "jenkins operation"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The following task can be used to interact with the the Jenkins REST API.

--- a/task/jib-gradle/0.1/README.md
+++ b/task/jib-gradle/0.1/README.md
@@ -26,6 +26,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ji
 
 * **image**: The Docker image name to apply to the newly built image.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/jib-gradle/0.1/jib-gradle.yaml
+++ b/task/jib-gradle/0.1/jib-gradle.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
     tekton.dev/displayName: "jib gradle"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google’s Jib tool.

--- a/task/jib-maven/0.1/README.md
+++ b/task/jib-maven/0.1/README.md
@@ -26,6 +26,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ji
 
 * **image**: The Docker image name to apply to the newly built image.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/jib-maven/0.1/jib-maven.yaml
+++ b/task/jib-maven/0.1/jib-maven.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
     tekton.dev/displayName: "jib maven"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google’s Jib tool.

--- a/task/jib-maven/0.2/README.md
+++ b/task/jib-maven/0.2/README.md
@@ -26,6 +26,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ji
 
 - **IMAGE_DIGEST**: Digest of the image just built.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/jib-maven/0.2/jib-maven.yaml
+++ b/task/jib-maven/0.2/jib-maven.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
     tekton.dev/displayName: "jib maven"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google's Jib tool.

--- a/task/jib-maven/0.3/README.md
+++ b/task/jib-maven/0.3/README.md
@@ -29,6 +29,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ji
 
 - **IMAGE_DIGEST**: Digest of the image just built.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/jib-maven/0.3/jib-maven.yaml
+++ b/task/jib-maven/0.3/jib-maven.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
     tekton.dev/displayName: "jib maven"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google's Jib tool.

--- a/task/kaniko/0.1/README.md
+++ b/task/kaniko/0.1/README.md
@@ -46,6 +46,10 @@ DockerHub, see the
 [Authentication](https://github.com/tektoncd/pipeline/blob/main/docs/auth.md#basic-authentication-docker)
 documentation page.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/kaniko/0.1/kaniko.yaml
+++ b/task/kaniko/0.1/kaniko.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds source into a container image using Google's kaniko tool.

--- a/task/kaniko/0.2/README.md
+++ b/task/kaniko/0.2/README.md
@@ -45,6 +45,10 @@ DockerHub, see the
 [Authentication](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker)
 documentation page.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/kaniko/0.2/kaniko.yaml
+++ b/task/kaniko/0.2/kaniko.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds source into a container image using Google's kaniko tool.

--- a/task/kaniko/0.3/README.md
+++ b/task/kaniko/0.3/README.md
@@ -52,6 +52,10 @@ the docker `config.json`.
 When using a workspace, the workspace shall be bound to a secret that embeds the
 configuration file in a key called `config.json`.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/kaniko/0.3/kaniko.yaml
+++ b/task/kaniko/0.3/kaniko.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds source into a container image using Google's kaniko tool.

--- a/task/kind/0.1/README.md
+++ b/task/kind/0.1/README.md
@@ -22,6 +22,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/
 | image   | kind runtime image to use. Users must override this for their particular runtime environment needed for their kind tests. |
 | command | command to run                                                                                                            |
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This task sets up settings needed to run `kind` in a Tekton Task using

--- a/task/kind/0.1/kind.yaml
+++ b/task/kind/0.1/kind.yaml
@@ -23,6 +23,7 @@ metadata:
     tekton.dev/categories: Kubernetes
     tekton.dev/displayName: "kind"
     tekton.dev/tags: "kind"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Sets up and executes commands in KinD (Kubernetes in Docker) environment.

--- a/task/kube-linter/0.1/README.md
+++ b/task/kube-linter/0.1/README.md
@@ -28,6 +28,10 @@ https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-c
 
 > _Note_ :  If you want to create your own custom checks using templates and built-in checks, you can create a config file containing all the checks. An example config file can be seen [here](https://raw.githubusercontent.com/tektoncd/catalog/main/task/kube-linter/0.1/samples/config_sample2.yaml). Otherwise, you can provide a string with comma-separated built-in checks to be included or excluded in `includelist` and `exludelist` param.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 ```yaml

--- a/task/kube-linter/0.1/kube-linter.yaml
+++ b/task/kube-linter/0.1/kube-linter.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: Kubernetes, Misconfiguration
     tekton.dev/displayName: "Kube-Linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task makes it possible to use kube-linter within Tekton Pipeline.

--- a/task/kubectl-deploy-pod/0.1/README.md
+++ b/task/kubectl-deploy-pod/0.1/README.md
@@ -46,6 +46,10 @@ The extracted value will be write to`/tekton/results/$(name)`.
 
 - **set-ownerreference**: Set the `ownerReferences` for the resource as pod of `step`, default to false.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to deploy the given Kubernetes resource.

--- a/task/kubectl-deploy-pod/0.1/kubectl-deploy-pod.yaml
+++ b/task/kubectl-deploy-pod/0.1/kubectl-deploy-pod.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Kubernetes
     tekton.dev/tags: deploy, delete
+    tekton.dev/platforms: "linux/amd64"
   namespace: default
 spec:
   description: >-

--- a/task/kubernetes-actions/0.1/README.md
+++ b/task/kubernetes-actions/0.1/README.md
@@ -21,6 +21,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ku
 - **kubeconfig-dir**: If you want to deploy you application to another cluster then you can mount your `kubeconfig` file via this `workspace`. (Default: _emptyDir:{}_ in case `kubeconfig` is not mounted)
 - **manifest-dir**: Manifest files can be provided via the workspaces.(Default: _emptyDir:{}_ in case no manifest is provided)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 In case no manifests are mounted

--- a/task/kubernetes-actions/0.1/kubernetes-actions.yaml
+++ b/task/kubernetes-actions/0.1/kubernetes-actions.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Kubernetes
     tekton.dev/tags: CLI, kubectl, generic
     tekton.dev/displayName: "kubernetes actions"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task is the generic kubectl CLI task which can be used

--- a/task/kubernetes-actions/0.2/README.md
+++ b/task/kubernetes-actions/0.2/README.md
@@ -25,6 +25,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ku
 
 - **output-result**: If you want to emit some result which can be used in decision making. One such case is when using [whenExpressions](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#guard-task-execution-using-whenexpressions).
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 In case no manifests are mounted

--- a/task/kubernetes-actions/0.2/kubernetes-actions.yaml
+++ b/task/kubernetes-actions/0.2/kubernetes-actions.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Kubernetes
     tekton.dev/tags: CLI, kubectl
     tekton.dev/displayName: "kubernetes actions"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task is the generic kubectl CLI task which can be used

--- a/task/kubeval/0.1/README.md
+++ b/task/kubeval/0.1/README.md
@@ -11,6 +11,10 @@ In order to use Kubeval with Tekton you need to first install the task.
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubeval/0.1/kubeval.yaml
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 Once installed, the task can be used as follows:

--- a/task/kubeval/0.1/kubeval.yaml
+++ b/task/kubeval/0.1/kubeval.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Code Quality, Kubernetes
     tekton.dev/tags: test
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task makes it possible to use Kubeval within your Tekton pipelines.

--- a/task/kythe-go/0.1/README.md
+++ b/task/kythe-go/0.1/README.md
@@ -16,3 +16,7 @@ for the given package, placing the resulting kzips in the `output` workspace.
 ### Parameters
 
 - **package**: Go package pattern to analyze.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/kythe-go/0.1/kythe-go.yaml
+++ b/task/kythe-go/0.1/kythe-go.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Build Tools
     tekton.dev/tags: annotations
     tekton.dev/displayName: "kythe go"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task generates annotations for source code.

--- a/task/makisu/0.1/README.md
+++ b/task/makisu/0.1/README.md
@@ -61,6 +61,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ma
 
 * **image**: An `image`-type `PipelineResource` specify the image that should be built.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a container

--- a/task/makisu/0.1/makisu.yaml
+++ b/task/makisu/0.1/makisu.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task builds source into a container image using uber’s

--- a/task/markdown-lint/0.1/README.md
+++ b/task/markdown-lint/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ma
 
 - **shared-workspace** : The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/markdown-lint/0.1/markdown-lint.yaml
+++ b/task/markdown-lint/0.1/markdown-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
     tekton.dev/displayName: "Markdown linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on Markdown files

--- a/task/maven/0.1/README.md
+++ b/task/maven/0.1/README.md
@@ -37,6 +37,10 @@ spec:
       storage: 500Mi
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This Pipeline and PipelineRun runs a Maven build

--- a/task/maven/0.1/maven.yaml
+++ b/task/maven/0.1/maven.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Build Tools
     tekton.dev/tags: build-tool
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task can be used to run a Maven build.

--- a/task/mypy-lint/0.1/README.md
+++ b/task/mypy-lint/0.1/README.md
@@ -18,6 +18,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/my
 
 - **shared-workspace**: The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/mypy-lint/0.1/mypy-lint.yaml
+++ b/task/mypy-lint/0.1/mypy-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
     tekton.dev/displayName: "Mypy(Python) linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on python files

--- a/task/mypy-lint/0.2/README.md
+++ b/task/mypy-lint/0.2/README.md
@@ -20,6 +20,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/my
 
 - **shared-workspace**: The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/mypy-lint/0.2/mypy-lint.yaml
+++ b/task/mypy-lint/0.2/mypy-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter, mypy
     tekton.dev/displayName: "Mypy(Python) linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on python files

--- a/task/openshift-client-kubecfg/0.1/README.md
+++ b/task/openshift-client-kubecfg/0.1/README.md
@@ -32,6 +32,10 @@ You can do the former via `oc` and running the following command, replacing `<na
 oc policy add-role-to-user edit -z default -n <namespace>
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 The following `TaskRun` runs the commands against a different cluster than the one the `TaskRun` is running on. The cluster credentials are provided via a `PipelineResource` called `stage-cluster`.

--- a/task/openshift-client-kubecfg/0.1/openshift-client-kubecfg.yaml
+++ b/task/openshift-client-kubecfg/0.1/openshift-client-kubecfg.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Openshift
     tekton.dev/tags: cli
     tekton.dev/displayName: "openshift client kubecfg"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task runs commands against any cluster that is provided to

--- a/task/openshift-client-python/0.1/README.md
+++ b/task/openshift-client-python/0.1/README.md
@@ -85,3 +85,7 @@ spec:
       secret:
         secretName: kubeconfig
 ```
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/openshift-client-python/0.1/openshift-client-python.yaml
+++ b/task/openshift-client-python/0.1/openshift-client-python.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Openshift
     tekton.dev/tags: cli
     tekton.dev/displayName: "openshift client python"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to interact with the openshift cluster via

--- a/task/openshift-client/0.1/README.md
+++ b/task/openshift-client/0.1/README.md
@@ -33,6 +33,10 @@ You can do the former via `oc` and running the following command, replacing `<na
 oc policy add-role-to-user edit -z default -n <namespace>
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` runs an `oc rollout` command to deploy the latest image version for `myapp` on OpenShift.

--- a/task/openshift-client/0.1/openshift-client.yaml
+++ b/task/openshift-client/0.1/openshift-client.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: cli
     tekton.dev/displayName: "openshift client"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task runs commands against the cluster where the task run is

--- a/task/openshift-client/0.2/README.md
+++ b/task/openshift-client/0.2/README.md
@@ -41,6 +41,10 @@ You can do the former via `oc` and running the following command, replacing `<na
 oc policy add-role-to-user edit -z default -n <namespace>
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 We can refer to the following [sample](./samples/run-with-workspace.yaml) of how to use this task.

--- a/task/openshift-client/0.2/openshift-client.yaml
+++ b/task/openshift-client/0.2/openshift-client.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/tags: cli
     tekton.dev/displayName: "openshift client"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   workspaces:
     - name: manifest-dir

--- a/task/openshift-install/0.1/README.md
+++ b/task/openshift-install/0.1/README.md
@@ -50,6 +50,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/op
   cat ~/.ssh/openshift-dev.pub
   ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 Taking example of AWS :-

--- a/task/openshift-install/0.1/openshift-install.yaml
+++ b/task/openshift-install/0.1/openshift-install.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Openshift
     tekton.dev/tags: openshift
     tekton.dev/displayName: "openshift install"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task is used to create the cluster.

--- a/task/openshift-uninstall/0.1/README.md
+++ b/task/openshift-uninstall/0.1/README.md
@@ -24,6 +24,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/op
 
 - **OPENSHIFT_INSTALLER_IMAGE**: OpenShift installer base image for UPI installation (_default_: quay.io/openshift/origin-upi-installer:4.6)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 Taking example of AWS :-

--- a/task/openshift-uninstall/0.1/openshift-uninstall.yaml
+++ b/task/openshift-uninstall/0.1/openshift-uninstall.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Openshift
     tekton.dev/tags: openshift
     tekton.dev/displayName: "openshift uninstall"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task is used to destroy the cluster.

--- a/task/orka-deploy/0.1/README.md
+++ b/task/orka-deploy/0.1/README.md
@@ -8,6 +8,10 @@ This `Task`, along with `orka-init` and `orka-teardown`, allows you to utilize m
 
 A `Task` that deploys a VM instance from a specified VM template. Usually, you would use the VM template created with `orka-init`.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Prerequisites
 
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.

--- a/task/orka-deploy/0.1/orka-deploy.yaml
+++ b/task/orka-deploy/0.1/orka-deploy.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.16.0"
     tekton.dev/tags: "orka, macstadium, deploy, build"
     tekton.dev/displayName: "MacStadium Orka Deploy"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     With this set of Tasks, you can use your Orka environment

--- a/task/orka-full/0.1/README.md
+++ b/task/orka-full/0.1/README.md
@@ -8,6 +8,10 @@ This `Task` is for utilizing a single macOS build agent in your [Orka environmen
 
 A `Task` that creates a VM template with the specified configuration, deploys a VM instance from it, and then cleans up the environment. All operations in this `Task` are performed against an Orka environment.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Prerequisites
 
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.

--- a/task/orka-full/0.1/orka-full.yaml
+++ b/task/orka-full/0.1/orka-full.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     With this Task, you can use your Orka environment

--- a/task/orka-init/0.1/README.md
+++ b/task/orka-init/0.1/README.md
@@ -8,6 +8,10 @@ This `Task`, along with `orka-deploy` and `orka-teardown`, allows you to utilize
 
 A `Task` that creates a VM template with the specified configuration. All operations in this `Task` are performed against an Orka environment.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Prerequisites
 
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.

--- a/task/orka-init/0.1/orka-init.yaml
+++ b/task/orka-init/0.1/orka-init.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.16.0"
     tekton.dev/tags: "orka, macstadium, init, setup"
     tekton.dev/displayName: "MacStadium Orka Init"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     With this set of Tasks, you can use your Orka environment

--- a/task/orka-teardown/0.1/README.md
+++ b/task/orka-teardown/0.1/README.md
@@ -8,6 +8,10 @@ This `Task`, along with `orka-init` and `orka-deploy`, allows you to utilize mul
 
 A `Task` that cleans up the Orka environment after your workload completes. This `Task` deletes the VM instances deployed with `orka-deploy` and their related template.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Prerequisites
 
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.

--- a/task/orka-teardown/0.1/orka-teardown.yaml
+++ b/task/orka-teardown/0.1/orka-teardown.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.16.0"
     tekton.dev/tags: "orka, macstadium, teardown, cleanup"
     tekton.dev/displayName: "MacStadium Orka Teardown"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     With this set of Tasks, you can use your Orka environment

--- a/task/powershell/0.1/README.md
+++ b/task/powershell/0.1/README.md
@@ -14,6 +14,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/po
 - **command**: Powershell command
 - **verbose**: Verbosity level for command (_default_: `SilentlyContinue`)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` runs `Write-Output 'Hello World'` command using `latest` powershell image and verbose logs enabled.

--- a/task/powershell/0.1/powershell.yaml
+++ b/task/powershell/0.1/powershell.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: powershell, pwsh
     tekton.dev/displayName: powershell
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task will run powershell commands

--- a/task/prettier/0.1/README.md
+++ b/task/prettier/0.1/README.md
@@ -11,6 +11,10 @@ This `Task` is for running [Prettier](https://prettier.io/) code formatter again
  - **args**: Prettier arguments used to run Prettier. See [Prettier CLI](https://prettier.io/docs/en/cli.html) for the arguments. (_default:_ `--check .`)
  - **prettierImage**: Prettier image used to run Prettier. (_default:_ elnebuloso/prettier:latest)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 The following pipeline uses the `prettier-check` `Task` to format the file `build.yaml` from [`catalog/golang`](https://github.com/tektoncd/catalog/tree/v1beta1/golang). The pipeline has two tasks: the [`git-clone`](https://github.com/tektoncd/catalog/blob/v1beta1/git/git-clone.yaml) `Task` is the first task to clone the repository to the "shared-workspace"; the `prettier-check` `Task` runs after `git-clone` `Task` to format the source code.

--- a/task/prettier/0.1/prettier.yaml
+++ b/task/prettier/0.1/prettier.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Code Quality
     tekton.dev/tags: editor
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task is for running Prettier code formatter against the provided

--- a/task/prometheus-gate/0.1/README.md
+++ b/task/prometheus-gate/0.1/README.md
@@ -25,3 +25,7 @@ The gate can make use of any valid [range query](https://prometheus.io/docs/prom
 * **target_strategy:**: min, max or equals. p95/99 not supported yet
 * **timeout:**: Maximum ticker time for gate
 * **tick_time:**: How often to try to assert the desired SLO
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/prometheus-gate/0.1/prometheus-gate.yaml
+++ b/task/prometheus-gate/0.1/prometheus-gate.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: gate, prometheus
     tekton.dev/displayName: prometheus gate
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     A gate task which will query the prometheus API in a loop and await a matching status for N length of time.

--- a/task/pylint/0.1/pylint.yaml
+++ b/task/pylint/0.1/pylint.yaml
@@ -10,7 +10,6 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: python, pylint
     tekton.dev/displayName: pylint
-
 spec:
   description: >-
     This task will run pylint on the provided input.

--- a/task/pylint/0.2/README.md
+++ b/task/pylint/0.2/README.md
@@ -19,6 +19,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/py
 * **path**: The path to the module which should be analysed by pylint. (_Default_: `"."`)
 * **requirements_file**: The path to the requirements file to pip install for your application to be checked. (_Default_: `"requirements.txt"`)
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` runs `pylint` in a python module directory called `module/`.

--- a/task/pylint/0.2/pylint.yaml
+++ b/task/pylint/0.2/pylint.yaml
@@ -10,7 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: python, pylint
     tekton.dev/displayName: pylint
-
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task will run pylint on the provided input.

--- a/task/redhat-codeready-dependency-analysis/0.1/README.md
+++ b/task/redhat-codeready-dependency-analysis/0.1/README.md
@@ -107,6 +107,10 @@ The link to detailed report will take users to a browser window having similar f
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/redhat-codeready-dependency-analysis/0.1/redhat-codeready-dependency-analysis.yaml -n <NAMESPACE>
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This task expects a secret named `crda` to exist with a valid CRDA user key in `crda-key`, an attached workspace having target manifest file and its dependencies installed in a directory.

--- a/task/redhat-codeready-dependency-analysis/0.1/redhat-codeready-dependency-analysis.yaml
+++ b/task/redhat-codeready-dependency-analysis/0.1/redhat-codeready-dependency-analysis.yaml
@@ -10,7 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.19.0"
     tekton.dev/tags: Security, Vulnenrability, CVE
     tekton.dev/displayName: "RedHat CodeReady Dependency Analysis"
-
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The RedHat CodeReady Dependency Analysis task is an interface between Tekton and Red Hat CodeReady Dependency Analytics platform.

--- a/task/remote-ssh-commands/0.1/README.md
+++ b/task/remote-ssh-commands/0.1/README.md
@@ -26,6 +26,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/re
   - **fingerprint**: Fingerprint SHA256 of the host public key, default is to skip verification.
   - **ciphers**: The allowed cipher algorithms. If unspecified then a sensible.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `Secret` by putting in the required values

--- a/task/remote-ssh-commands/0.1/remote-ssh-commands.yaml
+++ b/task/remote-ssh-commands/0.1/remote-ssh-commands.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Developer Tools
     tekton.dev/tags: ssh, ssh remote
     tekton.dev/displayName: "ssh remote commands"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The following task can be used to execute commands on remote machine.

--- a/task/replace-tokens/0.1/README.md
+++ b/task/replace-tokens/0.1/README.md
@@ -60,6 +60,10 @@ spec:
       storage: 500Mi
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This task will use the input param `inputFilePath`, this is provided by the [git clone](https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml) task, which clones the target repository containing the json or yaml file to be replaced.

--- a/task/replace-tokens/0.1/replace-tokens.yaml
+++ b/task/replace-tokens/0.1/replace-tokens.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Developer Tools
     tekton.dev/tags: tokens
     tekton.dev/displayName: "replace tokens"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to replace tokens in a file.

--- a/task/robot-framework/0.1/README.md
+++ b/task/robot-framework/0.1/README.md
@@ -22,6 +22,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ro
 - **TEST_DIR**: Directory that contains robot tests
 - **VARIABLES_FILE**: Optional: Name of the variable file provided in the workspace. A .py extension is necessary.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 Basic usage without installing extra requirements or using a variables file:

--- a/task/robot-framework/0.1/robot-framework.yaml
+++ b/task/robot-framework/0.1/robot-framework.yaml
@@ -10,7 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: python, robot-framework
     tekton.dev/displayName: robot-framework
-
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task will run Robot Framework tests in the source workspace.

--- a/task/ruby-lint/0.1/README.md
+++ b/task/ruby-lint/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ru
 
 - **shared-workspace** : The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/ruby-lint/0.1/ruby-lint.yaml
+++ b/task/ruby-lint/0.1/ruby-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
     tekton.dev/displayName: "Ruby linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on Ruby files

--- a/task/s2i/0.1/README.md
+++ b/task/s2i/0.1/README.md
@@ -57,6 +57,10 @@ oc adm policy add-scc-to-user privileged -z pipeline
 oc adm policy add-role-to-user edit -z pipeline
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and push a

--- a/task/s2i/0.1/s2i.yaml
+++ b/task/s2i/0.1/s2i.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Source-to-Image (S2I) is a toolkit and workflow for building reproducible

--- a/task/s2i/0.2/README.md
+++ b/task/s2i/0.2/README.md
@@ -56,6 +56,10 @@ oc adm policy add-scc-to-user privileged -z pipeline
 oc adm policy add-role-to-user edit -z pipeline
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This PipelineRun runs the Task to fetch a Git repo, and build and push a

--- a/task/s2i/0.2/s2i.yaml
+++ b/task/s2i/0.2/s2i.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Source-to-Image (S2I) is a toolkit and workflow for building reproducible

--- a/task/scorecard/0.1/README.md
+++ b/task/scorecard/0.1/README.md
@@ -13,6 +13,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sc
 - **REPO**: The url to the repository to inspect.
 - **GITHUB-OAUTH_SECRET**: The name of the secret storing GitHub credentials. They should be in the `token` field.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This `TaskRun` runs `scorecard` on a repository:

--- a/task/scorecard/0.1/scorecard.yaml
+++ b/task/scorecard/0.1/scorecard.yaml
@@ -10,7 +10,7 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: scorecard
     tekton.dev/displayName: OSSF scorecard
-
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to calculate the scorecard results for a repository

--- a/task/shellcheck/0.1/README.md
+++ b/task/shellcheck/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sh
 
 - **shared-workspace** : The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/shellcheck/0.1/shellcheck.yaml
+++ b/task/shellcheck/0.1/shellcheck.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
     tekton.dev/displayName: "Shellcheck"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on Shell Script files

--- a/task/sonarqube-scanner/0.1/README.md
+++ b/task/sonarqube-scanner/0.1/README.md
@@ -54,6 +54,10 @@ https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml
 
 Sample IPAddress we will obtain using above command is like http://172.17.0.2:9000
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. `sonar-project.properties` present in Github Repository. For example :- following [repo](https://github.com/vinamra28/sonartest) contains the properties file and Sonar Host URL needs to be updated via the `params`.

--- a/task/sonarqube-scanner/0.1/sonarqube-scanner.yaml
+++ b/task/sonarqube-scanner/0.1/sonarqube-scanner.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Security
     tekton.dev/tags: security
     tekton.dev/displayName: "sonarqube scanner"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     The following task can be used to perform static analysis on the source code

--- a/task/terraform-cli/0.1/README.md
+++ b/task/terraform-cli/0.1/README.md
@@ -63,6 +63,10 @@ You can do the former via `oc` and running the following command, replacing `<na
 oc policy add-role-to-user edit -z default -n <namespace>
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This is a pipeline example passing the required credentials, and a list of arguments to the ARGS array variable.

--- a/task/terraform-cli/0.1/terraform-cli.yaml
+++ b/task/terraform-cli/0.1/terraform-cli.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: cli
     tekton.dev/displayName: "terraform cli"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Terraform is an open-source infrastructure as codesoftware tool created by HashiCorp.

--- a/task/terraform-cli/0.2/README.md
+++ b/task/terraform-cli/0.2/README.md
@@ -70,6 +70,10 @@ You can do the former via `oc` and running the following command, replacing `<na
 oc policy add-role-to-user edit -z default -n <namespace>
 ```
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This is a pipeline example passing the required credentials, and a list of arguments to the ARGS array variable.

--- a/task/terraform-cli/0.2/terraform-cli.yaml
+++ b/task/terraform-cli/0.2/terraform-cli.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/categories: CLI
     tekton.dev/tags: cli
     tekton.dev/displayName: "terraform cli"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Terraform is an open-source infrastructure as code software tool created by HashiCorp.

--- a/task/trivy-scanner/0.1/README.md
+++ b/task/trivy-scanner/0.1/README.md
@@ -33,3 +33,7 @@ tkn task start trivy-scanner -p ARGS="image,--exit-code,0" -p IMAGE_PATH="docker
 ```
 
 For Pipeline Example See <https://github.com/MoOyeg/trivy-tekton-example>
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/trivy-scanner/0.1/trivy-scanner.yaml
+++ b/task/trivy-scanner/0.1/trivy-scanner.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/categories: Security
     tekton.dev/tags: CLI, trivy
     tekton.dev/displayName: "trivy scanner"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     Trivy is a simple and comprehensive scanner for

--- a/task/ts-lint/0.1/README.md
+++ b/task/ts-lint/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ts
 
 - **shared-workspace** : The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/ts-lint/0.1/ts-lint.yaml
+++ b/task/ts-lint/0.1/ts-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
     tekton.dev/displayName: "TypeScript linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on TypeScript files

--- a/task/upload-pypi/0.1/README.md
+++ b/task/upload-pypi/0.1/README.md
@@ -30,6 +30,10 @@ stringData:
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and publishes a python module.

--- a/task/upload-pypi/0.1/upload-pypi.yaml
+++ b/task/upload-pypi/0.1/upload-pypi.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/categories: Publishing
     tekton.dev/tags: build
     tekton.dev/displayName: "upload pypi"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task publishes Python packages to PyPI index using Twine utility module.

--- a/task/upload-pypi/0.2/README.md
+++ b/task/upload-pypi/0.2/README.md
@@ -46,6 +46,10 @@ stringData:
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 This TaskRun runs the Task to fetch a Git repo, and build and publishes a python module.

--- a/task/upload-pypi/0.2/upload-pypi.yaml
+++ b/task/upload-pypi/0.2/upload-pypi.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/categories: Publishing
     tekton.dev/tags: build
     tekton.dev/displayName: "upload pypi"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This Task publishes Python packages to PyPI index using Twine utility module.

--- a/task/yaml-lint/0.1/README.md
+++ b/task/yaml-lint/0.1/README.md
@@ -16,6 +16,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ya
 
 - **shared-workspace** : The workspace containing files on which we want to apply linter check. It can be a shared workspace with the `git-clone` task or a `ConfigMap` mounted containing some files.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 1. Create the `git-clone` task

--- a/task/yaml-lint/0.1/yaml-lint.yaml
+++ b/task/yaml-lint/0.1/yaml-lint.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
     tekton.dev/displayName: "YAML linter"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to perform lint check on YAML files

--- a/task/yq/0.1/README.md
+++ b/task/yq/0.1/README.md
@@ -18,6 +18,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/yq
 
 - **source** : The workspace containing files on which we want to do the replacement on a single file.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 For a real usage example checkout the tests directory of this task for an example on how this task can be used on a Github repository. This can be used together with other git actions to commit such changes towards a GitOps repository for example which is automatically reconciled towards your infrastructure.

--- a/task/yq/0.1/yq.yaml
+++ b/task/yq/0.1/yq.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Developer Tools
     tekton.dev/tags: yq
     tekton.dev/displayName: "YQ replace"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to replace fields in YAML files. For example for altering helm charts on GitOps repos.

--- a/task/yq/0.2/README.md
+++ b/task/yq/0.2/README.md
@@ -18,6 +18,10 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/yq
 
 - **source** : The workspace containing files on which we want to do the replacement on a single file.
 
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
 ## Usage
 
 For a real usage example checkout the [tests directory](https://github.com/tektoncd/catalog/tree/main/task/yq/0.2/tests) of this task for an example on how this task can be used on a Github repository. This can be used together with other git actions to commit such changes towards a GitOps repository for example which is automatically reconciled towards your infrastructure.

--- a/task/yq/0.2/yq.yaml
+++ b/task/yq/0.2/yq.yaml
@@ -9,6 +9,7 @@ metadata:
     tekton.dev/categories: Developer Tools
     tekton.dev/tags: yq
     tekton.dev/displayName: "YQ replace"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
     This task can be used to replace fields in YAML files. For example for altering helm charts on GitOps repos.


### PR DESCRIPTION

# Changes

At this moment all tasks which can be executed on `linux/s390x` or `linux/ppc64le` are tested and labelled accordingly.
The rest of the tasks can be labelled as `linux/amd64`, which is default platform and where tasks are already tested via
default PR testing cycle.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
