### PR TITLE
Make diff-task handle code blocks

### DIFF
--- a/hack/diff-task-version
+++ b/hack/diff-task-version
@@ -98,9 +98,9 @@ type -p pbcopy >/dev/null 2>/dev/null && copier=pbcopy
 (
     echo "<details><summary>Diff between version ${previous_task_version} and ${task_version}</summary>"
     echo
-    echo "\`\`\`diff"
+    echo "\`\`\`\`diff"
     diff -urN task/${task_name}/${previous_task_version} task/${task_name}/${task_version} 
-    echo "\`\`\`"
+    echo "\`\`\`\`"
     echo
     echo "</details>"
 )| tee ${difffilename} | ${copier}


### PR DESCRIPTION
Github markdown allows using 4 (or more) backticks to differentiate
between triple backticks inside the code blocks. Seeing as how most
task-diffs will probably have some form of markdown with codeblocks
inside them, this will escape that.

Of course, if there are code blocks inside the diff with 4 backticks, we're back to square one. We could combat that by using 5 backticks and so on. But I guess let's just start with 4 for now 😃 

DISCLAIMER: I have not run it to verify that it works correctly, as I don't have everything set up for this. If someone is able to do so that would be great!


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
