### PR TITLE
Make builpacks task Chains compliant

### DIFF
--- a/task/buildpacks/0.4/README.md
+++ b/task/buildpacks/0.4/README.md
@@ -1,0 +1,103 @@
+# Buildpacks
+
+This task builds source into a container image using [Cloud Native Buildpacks](https://buildpacks.io). To do that, it uses [builders](https://buildpacks.io/docs/concepts/components/builder/#what-is-a-builder) to run buildpacks against your application source.
+
+> _**What are Cloud Native Buildpacks?**_
+>
+> _Cloud Native Buildpacks are pluggable, modular tools that transform application source code into OCI images. They replace Dockerfiles in the app development lifecycle, and enable for swift rebasing of images and modular control over images (through the use of builders), among other benefits._
+
+See also [`buildpacks-phases`](../../buildpacks-phases) for the deconstructed version of this task, which runs each of the [lifecycle phases](https://buildpacks.io/docs/concepts/components/lifecycle/#phases) individually. This task uses the [creator binary](https://github.com/buildpacks/spec/blob/platform/0.4/platform.md#operations), which coordinates and runs all of the phases.
+
+## Compatibility
+
+- **Tekton** v0.17.0 and above
+- **[Platform API][platform-api]** 0.4
+    - For other versions, see [previous versions](#previous-versions).
+
+## Install
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/buildpacks/0.4/buildpacks.yaml
+```
+
+## Workspaces
+
+ - **`source`**: Directory where application source is located. _(REQUIRED)_
+ - **`cache`**: Directory where cache is stored (when no cache image is provided). _(optional)_
+
+## Parameters
+
+ - **`APP_IMAGE`**: The name of where to store the app image. _(REQUIRED)_
+ - **`BUILDER_IMAGE`**: The image on which builds will run (must include lifecycle and compatible buildpacks). _(REQUIRED)_
+ - **`SOURCE_SUBPATH`**: A subpath within the `source` input where the source to build is located. _(optional, default: "")_
+ - **`ENV_VARS`**: Environment variables to set during _build-time_. _(optional, default: [])_
+ - **`PROCESS_TYPE`**: The default process type to set on the image. _(optional, default: "web")_
+ - **`RUN_IMAGE`**: Reference to a run image to use. _(optional, default: "")_
+ - **`CACHE_IMAGE`**: The name of the persistent app cache image (if no cache workspace is provided). _(optional, default: "")_
+ - **`SKIP_RESTORE`**: Do not write layer metadata or restore cached layers. _(optional, default: "false")_
+ - **`USER_ID`**: The user ID of the builder image user. _(optional, default: "1000")_
+ - **`GROUP_ID`**: The group ID of the builder image user. _(optional, default: "1000")_
+ - **`PLATFORM_DIR`**: The name of the platform directory. _(optional, default: "empty-dir")_
+
+## Results
+
+ - **`APP_IMAGE_DIGEST`**: The digest of the built `APP_IMAGE`.
+ - **`APP_IMAGE_URL`**: The URL of the built `APP_IMAGE`.
+
+## Builders
+
+_The following are the suggested [builders][builders] from the [Cloud Native Buildpacks][buildpacks-io] project. This is only a subset of builders available._
+
+ - **`gcr.io/buildpacks/builder:v1`**: Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js, and Python
+ - **`heroku/buildpacks:18`**: Base builder for Heroku-18 stack, based on ubuntu:18.04 base image
+ - **`heroku/buildpacks:20`**: Base builder for Heroku-20 stack, based on ubuntu:20.04 base image
+ - **`paketobuildpacks/builder:base`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, Ruby, NGINX and Procfile
+ - **`paketobuildpacks/builder:full`**: Ubuntu bionic base image with buildpacks for Java, .NET Core, NodeJS, Go, PHP, Ruby, Apache HTTPD, NGINX and Procfile
+ - **`paketobuildpacks/builder:tiny`**: Tiny base image (bionic build image, distroless-like run image) with buildpacks for Java Native Image and Go
+
+[builders]: (https://buildpacks.io/docs/concepts/components/builder/)
+[buildpacks-io]: (https://buildpacks.io)
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+See the following samples for usage:
+
+ - **[`env-vars.yaml`](samples/env-vars.yaml)**: A PipelineRun configured to provide _build-time_ environment variables.
+ - **[`results.yaml`](samples/results.yaml)**: A PipelineRun configured to demonstrate usage of task results.
+
+## Support
+
+The [Buildpacks Community](http://buildpacks.io/community/) is always here to help.
+
+We can be found in our [discussion board][discussion-board] or [slack][slack] (`#tekton`).
+
+[discussion-board]: https://github.com/buildpacks/community/discussions
+[slack]: https://slack.buildpacks.io
+
+## Contributing
+
+We ❤ contributions.
+
+This task is maintained at [buildpacks/tekton-integration](https://github.com/buildpacks/tekton-integration). Issues, pull requests and other contributions can be made there.
+
+To learn more, read the [CONTRIBUTING][contributing] and [DEVELOPMENT][development] documents.
+
+[contributing]: https://github.com/buildpacks/.github/blob/main/CONTRIBUTING.md
+[development]: https://github.com/buildpacks/tekton-integration/blob/main/DEVELOPMENT.md
+
+## Previous Versions
+
+For support of previous [Platform API][platform-api]s use a previous version of this task.
+
+> Be sure to also supply a compatible builder image (`BUILDER_IMAGE` input) when running the task (i.e. one that has a lifecycle that supports the platform API).
+
+| Version        | Platform API
+|----            |-----
+| [0.2](../0.2/) | [0.3][platform-api-0.3]
+
+[platform-api]: https://buildpacks.io/docs/reference/spec/platform-api/
+[platform-api-0.3]: https://github.com/buildpacks/spec/blob/platform/0.3/platform.md

--- a/task/buildpacks/0.4/buildpacks.yaml
+++ b/task/buildpacks/0.4/buildpacks.yaml
@@ -1,0 +1,167 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildpacks
+  labels:
+    app.kubernetes.io/version: "0.4"
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "Buildpacks"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    The Buildpacks task builds source into a container image and pushes it to a registry,
+    using Cloud Native Buildpacks.
+
+  workspaces:
+    - name: source
+      description: Directory where application source is located.
+    - name: cache
+      description: Directory where cache is stored (when no cache image is provided).
+      optional: true
+
+  params:
+    - name: APP_IMAGE
+      description: The name of where to store the app image.
+    - name: BUILDER_IMAGE
+      description: The image on which builds will run (must include lifecycle and compatible buildpacks).
+    - name: SOURCE_SUBPATH
+      description: A subpath within the `source` input where the source to build is located.
+      default: ""
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      default: []
+    - name: PROCESS_TYPE
+      description: The default process type to set on the image.
+      default: "web"
+    - name: RUN_IMAGE
+      description: Reference to a run image to use.
+      default: ""
+    - name: CACHE_IMAGE
+      description: The name of the persistent app cache image (if no cache workspace is provided).
+      default: ""
+    - name: SKIP_RESTORE
+      description: Do not write layer metadata or restore cached layers.
+      default: "false"
+    - name: USER_ID
+      description: The user ID of the builder image user.
+      default: "1000"
+    - name: GROUP_ID
+      description: The group ID of the builder image user.
+      default: "1000"
+    - name: PLATFORM_DIR
+      description: The name of the platform directory.
+      default: empty-dir
+
+  results:
+    - name: APP_IMAGE_DIGEST
+      description: The digest of the built `APP_IMAGE`.
+    - name: APP_IMAGE_URL
+      description: The URL of the built `APP_IMAGE`.
+
+  stepTemplate:
+    env:
+      - name: CNB_PLATFORM_API
+        value: "0.4"
+
+  steps:
+    - name: prepare
+      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      args:
+        - "--env-vars"
+        - "$(params.ENV_VARS[*])"
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        if [[ "$(workspaces.cache.bound)" == "true" ]]; then
+          echo "> Setting permissions on '$(workspaces.cache.path)'..."
+          chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$(workspaces.cache.path)"
+        fi
+
+        for path in "/tekton/home" "/layers" "$(workspaces.source.path)"; do
+          echo "> Setting permissions on '$path'..."
+          chown -R "$(params.USER_ID):$(params.GROUP_ID)" "$path"
+        done
+
+        echo "> Parsing additional configuration..."
+        parsing_flag=""
+        envs=()
+        for arg in "$@"; do
+            if [[ "$arg" == "--env-vars" ]]; then
+                echo "-> Parsing env variables..."
+                parsing_flag="env-vars"
+            elif [[ "$parsing_flag" == "env-vars" ]]; then
+                envs+=("$arg")
+            fi
+        done
+
+        echo "> Processing any environment variables..."
+        ENV_DIR="/platform/env"
+
+        echo "--> Creating 'env' directory: $ENV_DIR"
+        mkdir -p "$ENV_DIR"
+
+        for env in "${envs[@]}"; do
+            IFS='=' read -r key value string <<< "$env"
+            if [[ "$key" != "" && "$value" != "" ]]; then
+                path="${ENV_DIR}/${key}"
+                echo "--> Writing ${path}..."
+                echo -n "$value" > "$path"
+            fi
+        done
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
+      securityContext:
+        privileged: true
+
+    - name: create
+      image: $(params.BUILDER_IMAGE)
+      imagePullPolicy: Always
+      command: ["/cnb/lifecycle/creator"]
+      args:
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
+        - "-cache-dir=$(workspaces.cache.path)"
+        - "-cache-image=$(params.CACHE_IMAGE)"
+        - "-uid=$(params.USER_ID)"
+        - "-gid=$(params.GROUP_ID)"
+        - "-layers=/layers"
+        - "-platform=/platform"
+        - "-report=/layers/report.toml"
+        - "-process-type=$(params.PROCESS_TYPE)"
+        - "-skip-restore=$(params.SKIP_RESTORE)"
+        - "-previous-image=$(params.APP_IMAGE)"
+        - "-run-image=$(params.RUN_IMAGE)"
+        - "$(params.APP_IMAGE)"
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: $(params.PLATFORM_DIR)
+          mountPath: /platform
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+
+    - name: results
+      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        cat /layers/report.toml | grep "digest" | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee $(results.APP_IMAGE_DIGEST.path)
+        echo $(params.APP_IMAGE) | tee $(results.APP_IMAGE_URL.path)
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+
+  volumes:
+    - name: empty-dir
+      emptyDir: {}
+    - name: layers-dir
+      emptyDir: {}

--- a/task/buildpacks/0.4/buildpacks.yaml
+++ b/task/buildpacks/0.4/buildpacks.yaml
@@ -107,7 +107,7 @@ spec:
         mkdir -p "$ENV_DIR"
 
         for env in "${envs[@]}"; do
-            IFS='=' read -r key value string <<< "$env"
+            IFS='=' read -r key value <<< "$env"
             if [[ "$key" != "" && "$value" != "" ]]; then
                 path="${ENV_DIR}/${key}"
                 echo "--> Writing ${path}..."
@@ -154,8 +154,11 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -e
-        cat /layers/report.toml | grep "digest" | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee $(results.APP_IMAGE_DIGEST.path)
-        echo $(params.APP_IMAGE) | tee $(results.APP_IMAGE_URL.path)
+        grep "digest" /layers/report.toml | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee $(results.APP_IMAGE_DIGEST.path)
+
+        # Disable shellcheck here since $() is use for variable substitution and not command execution.
+        # shellcheck disable=SC2005
+        echo "$(params.APP_IMAGE)" | tee $(results.APP_IMAGE_URL.path)
       volumeMounts:
         - name: layers-dir
           mountPath: /layers

--- a/task/buildpacks/0.4/buildpacks.yaml
+++ b/task/buildpacks/0.4/buildpacks.yaml
@@ -154,11 +154,11 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -e
-        grep "digest" /layers/report.toml | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee $(results.APP_IMAGE_DIGEST.path)
+        grep "digest" /layers/report.toml | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' | tee "$(results.APP_IMAGE_DIGEST.path)"
 
         # Disable shellcheck here since $() is use for variable substitution and not command execution.
         # shellcheck disable=SC2005
-        echo "$(params.APP_IMAGE)" | tee $(results.APP_IMAGE_URL.path)
+        echo "$(params.APP_IMAGE)" | tee "$(results.APP_IMAGE_URL.path)"
       volumeMounts:
         - name: layers-dir
           mountPath: /layers

--- a/task/buildpacks/0.4/samples/env-vars.yaml
+++ b/task/buildpacks/0.4/samples/env-vars.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: env-vars-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: env-vars-pipeline-run
+  labels:
+    description: A PipelineRun configured to provide _build-time_ environment variables.
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: source-ws
+      - name: cache-ws
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source-ws
+        params:
+          - name: url
+            value: https://github.com/buildpacks/samples
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: buildpacks
+        taskRef:
+          name: buildpacks
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source-ws
+          - name: cache
+            workspace: cache-ws
+        params:
+          - name: APP_IMAGE
+            value: <IMAGE_NAME>
+          - name: SOURCE_SUBPATH
+            value: apps
+          - name: BUILDER_IMAGE
+            value: docker.io/cnbs/sample-builder:alpine@sha256:b51367258b3b6fff1fe8f375ecca79dab4339b177efb791e131417a5a4357f42
+          - name: ENV_VARS
+            value:
+              - "ENV_VAR_1=VALUE_1"
+              - "ENV_VAR_2=VALUE 2"
+          - name: PROCESS_TYPE
+            value: ""
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: env-vars-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: env-vars-ws-pvc

--- a/task/buildpacks/0.4/samples/results.yaml
+++ b/task/buildpacks/0.4/samples/results.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: results-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: results-pipeline-run
+  labels:
+    app.kubernetes.io/description: A PipelineRun configured to demonstrate usage of task results.
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: source-ws
+      - name: cache-ws
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: source-ws
+        params:
+          - name: url
+            value: https://github.com/buildpacks/samples
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: buildpacks
+        taskRef:
+          name: buildpacks
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source-ws
+          - name: cache
+            workspace: cache-ws
+        params:
+          - name: APP_IMAGE
+            value: <IMAGE_NAME>
+          - name: SOURCE_SUBPATH
+            value: apps/ruby-bundler
+          - name: BUILDER_IMAGE
+            value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+      - name: display-results
+        runAfter:
+          - buildpacks
+        taskSpec:
+          steps:
+            - name: print
+              image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+              script: |
+                #!/usr/bin/env bash
+                set -e
+                echo "Digest of created app image: $(params.DIGEST)"
+          params:
+            - name: DIGEST
+        params:
+          - name: DIGEST
+            value: $(tasks.buildpacks.results.APP_IMAGE_DIGEST)
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: results-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: results-ws-pvc

--- a/task/buildpacks/0.4/tests/pre-apply-task-hook.sh
+++ b/task/buildpacks/0.4/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests without having to go to an external registry.
+add_sidecar_registry ${TMPF}
+
+# Add git-clone
+add_task git-clone latest

--- a/task/buildpacks/0.4/tests/resources.yaml
+++ b/task/buildpacks/0.4/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildpacks-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/buildpacks/0.4/tests/run.yaml
+++ b/task/buildpacks/0.4/tests/run.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: buildpacks-test-pipeline
+spec:
+  workspaces:
+    - name: source-ws
+    - name: cache-ws
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: source-ws
+      params:
+        - name: url
+          value: https://github.com/buildpacks/samples
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: buildpacks
+      taskRef:
+        name: buildpacks
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: source-ws
+        - name: cache
+          workspace: cache-ws
+      params:
+        - name: APP_IMAGE
+          value: localhost:5000/buildpacks-app
+        - name: SOURCE_SUBPATH
+          value: apps/java-maven
+        - name: BUILDER_IMAGE
+          value: cnbs/sample-builder:alpine@sha256:b51367258b3b6fff1fe8f375ecca79dab4339b177efb791e131417a5a4357f42
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildpacks-test-pipeline-run
+spec:
+  pipelineRef:
+    name: buildpacks-test-pipeline
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: buildpacks-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: buildpacks-pvc
+---


### PR DESCRIPTION
Adds the Chains type hinting to the task to ensure it can be used by
Chains.

This problem came up based on the following issue in the Chains
repository
https://github.com/tektoncd/chains/issues/273#issuecomment-956411302.
