### PR TITLE
remove blanks from receivers_email

### DIFF
--- a/task/sendmail/0.1/sendmail.yaml
+++ b/task/sendmail/0.1/sendmail.yaml
@@ -57,7 +57,7 @@ spec:
           server = smtplib.SMTP(smtp_server, port)
       if password != '':
           server.login(user, password)
-      for receiver in receiver_emails.split(' '):
+      for receiver in [item for item in receiver_emails.split(' ') if item]:
           server.sendmail(sender_email, receiver, message.encode('utf-8'))
       server.quit()
     env:


### PR DESCRIPTION
The recipients of the email are extracted from a variable using the
split() function on a blank space (' '). If there are additional blanks,
either before, after or in the middle of the receivers_email variable the
sendmail function will cause an exception. This patch makes sure that blanks
won't cause the exception.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- The recipients of the email are extracted from a variable using the
split() function on a blank space (' '). If there are additional blanks,
either before, after or in the middle of the receivers_email variable the
sendmail function will cause an exception. This patch makes sure that blanks
won't cause the exception.
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
