### PR TITLE
Make secret workspace optional for ecr-login task

### DIFF
--- a/task/aws-ecr-login/0.1/aws-ecr-login.yaml
+++ b/task/aws-ecr-login/0.1/aws-ecr-login.yaml
@@ -25,6 +25,7 @@ spec:
   workspaces:
     - name: secrets
       mountPath: /tekton/home/.aws
+      optional: true
   params:
     - name: region
       type: string


### PR DESCRIPTION
# Changes

Added `optional: true` flag for the secret workspace in `aws-ecr-login` task. In some cases the credentials are already provided without using a secret (same as aws-cli task).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

