### PR TITLE
Add new jib-gradle version with optional arguments

### DIFF
--- a/task/jib-gradle/0.3/README.md
+++ b/task/jib-gradle/0.3/README.md
@@ -1,0 +1,60 @@
+# Jib Gradle
+
+This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google's [Jib](https://github.com/GoogleContainerTools/jib) tool.
+
+Jib works with [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin) and [Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin) projects, and this template is for Gradle projects.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-gradle/0.3/jib-gradle.yaml
+```
+
+## Parameters
+
+- **BUILDER_IMAGE**: The location of the gradle builder image. (*default: gcr.io/cloud-builders/gradle@sha256:96d6343589392afd9eab8c4463ec899b8b1c972e7cd70678a70a4821c16eb4c9*)
+- **IMAGE**: Reference of the image gradle will produce.
+- **DIRECTORY**: The directory in the source repository where source should be found. (*default: .*)
+- **CACHE**: The name of the volume for caching Gradle artifacts, local Maven repository, and base image layers (*default: empty-dir-volume*)
+- **INSECUREREGISTRY**: Whether to allow insecure registry. (*default: "false"*)
+- **EXTRA_ARGS**: Provides extra arguments to the gradle jib build (*default: ""*)
+
+## Workspaces
+
+- **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+## Results
+
+- **IMAGE_DIGEST**: The digest of the image just built.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+For `linux/s390x` and `linux/ppc64le` platforms specify **BUILDER_IMAGE** parameter with `gradle:5.6.2-jdk11` value in TaskRun or PipelineRun.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container image using Jib (Gradle).
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-jib-gradle
+spec:
+  taskRef:
+    name: jib-gradle
+  params:
+  - name: IMAGE
+    value: gcr.io/my-repo/my-image
+  - name: DIRECTORY
+    value: ./examples/helloworld
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+If you would like to customize the container, configure the `jib-gradle-plugin` in your `build.gradle`.
+See [setup instructions for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#setup) for more information.

--- a/task/jib-gradle/0.3/jib-gradle.yaml
+++ b/task/jib-gradle/0.3/jib-gradle.yaml
@@ -1,0 +1,106 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: jib-gradle
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Image Build
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "jib gradle"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google’s Jib tool.
+
+    Jib works with Gradle and Maven projects, and this template is for Gradle projects.
+
+  params:
+  - name: BUILDER_IMAGE
+    description: The location of the gradle builder image
+    default: gcr.io/cloud-builders/gradle@sha256:96d6343589392afd9eab8c4463ec899b8b1c972e7cd70678a70a4821c16eb4c9  # 5.6.2-jdk-8
+  - name: IMAGE
+    description: Reference of the image gradle will produce
+  - name: DIRECTORY
+    description: The directory containing the app, relative to the source repository root
+    default: .
+  - name: CACHE
+    description: The name of the volume for caching Gradle artifacts, local Maven repository, and base image layers
+    default: empty-dir-volume
+  - name: INSECUREREGISTRY
+    description: Whether to allow insecure registry
+    default: "false"
+  - name: EXTRA_ARGS
+    description: Extra arguments to add to the gradle jib build
+    default: ""
+
+  workspaces:
+  - name: source
+
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+
+  steps:
+  - name: build-and-push
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)/$(params.DIRECTORY)
+    script: |
+      #!/bin/sh
+      set -o errexit
+
+      # Adds Gradle init script that applies the Jib Gradle plugin.
+      echo "initscript {
+              repositories { maven { url 'https://plugins.gradle.org/m2' } }
+              dependencies { classpath 'gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:+' }
+            }
+            rootProject {
+              afterEvaluate {
+                if (!project.plugins.hasPlugin('com.google.cloud.tools.jib')) {
+                  project.apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
+                }
+              }
+            }" > "$HOME"/init-script.gradle
+
+      # Runs the Gradle Jib build.
+      gradle jib \
+        --stacktrace --console=plain \
+        --init-script="$HOME"/init-script.gradle \
+        --gradle-user-home="$HOME"/.gradle \
+        -Dgradle.user.home="$HOME"/.gradle \
+        -Duser.home="$HOME" \
+        -Djib.allowInsecureRegistries="$(params.INSECUREREGISTRY)" \
+        -Djib.to.image="$(params.IMAGE)" \
+        -Djib.outputPaths.digest="$(workspaces.source.path)/$(params.DIRECTORY)/image-digest" \
+        $(params.EXTRA_ARGS)
+    env:
+    - name: HOME
+      value: /workspace
+    volumeMounts:
+    # empty volume required to make the Gradle home globally writable
+    - name: empty-dir-volume
+      mountPath: /workspace/.gradle
+      subPath: gradle-user-home
+    - name: $(params.CACHE)
+      mountPath: /workspace/.gradle/caches
+      subPath: gradle-caches
+    - name: $(params.CACHE)
+      mountPath: /workspace/.gradle/wrapper
+      subPath: gradle-wrapper
+    - name: $(params.CACHE)
+      mountPath: /workspace/.m2
+      subPath: m2-cache
+    - name: $(params.CACHE)
+      mountPath: /workspace/.cache
+      subPath: jib-cache
+    securityContext:
+      runAsUser: 0
+
+  - name: digest-to-results
+    image: $(params.BUILDER_IMAGE)
+    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/image-digest | tee /tekton/results/IMAGE_DIGEST
+
+  volumes:
+  - name: empty-dir-volume
+    emptyDir: {}

--- a/task/jib-gradle/0.3/tests/pre-apply-task-hook.sh
+++ b/task/jib-gradle/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests withouth having to go to an external registry.
+add_sidecar_registry ${TMPF}
+
+# Add git-clone
+add_task git-clone latest

--- a/task/jib-gradle/0.3/tests/resources.yaml
+++ b/task/jib-gradle/0.3/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jib-gradle-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/jib-gradle/0.3/tests/run.yaml
+++ b/task/jib-gradle/0.3/tests/run.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: jib-gradle-test-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/che-samples/console-java-simple
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: jib-gradle
+    taskRef:
+      name: jib-gradle
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: IMAGE
+      value: localhost:5000/tekton-pipelines/console-java-simple
+    - name: INSECUREREGISTRY
+      value: "true"
+  - name: verify-digest
+    runAfter:
+    - jib-gradle
+    params:
+    - name: digest
+      value: $(tasks.jib-gradle.results.IMAGE_DIGEST)
+    taskSpec:
+      params:
+      - name: digest
+      steps:
+      - name: bash
+        image: ubuntu
+        script: |
+          echo $(params.digest)
+          case .$(params.digest) in
+            ".sha"*) exit 0 ;;
+            *)       echo "Digest value is not correct" && exit 1 ;;
+          esac
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: jib-gradle-test-pipeline-run
+spec:
+  pipelineRef:
+    name: jib-gradle-test-pipeline
+  workspaces:
+  - name: shared-workspace
+    persistentVolumeClaim:
+      claimName: jib-gradle-source-pvc


### PR DESCRIPTION
# Changes

Adds a parameter to the jib-gradle task in order to provide extra arguments to the gradle jib build. For instance to provide credentials for a private image repository.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

