### PR TITLE
[pytest] Fix issue when no args are passed

### DIFF
--- a/task/pytest/0.1/pytest.yaml
+++ b/task/pytest/0.1/pytest.yaml
@@ -53,4 +53,8 @@ spec:
           fi
           pip install pytest
         fi
-        pytest "$(inputs.params.ARGS)" "$(inputs.params.SOURCE_PATH)"
+        if [ -z "$(inputs.params.ARGS)" ]; then
+          pytest "$(inputs.params.SOURCE_PATH)"
+        else
+          pytest "$(inputs.params.ARGS)" "$(inputs.params.SOURCE_PATH)"
+        fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When no args are passed, we run pytest "" <path> which does not
work as expected. Only pass the args to pytest when there are
some defined.

Fixes #864

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
