### PR TITLE
Added comments regarding id_rsa as default filename for private key

### DIFF
--- a/task/git-clone/0.5/README.md
+++ b/task/git-clone/0.5/README.md
@@ -143,6 +143,10 @@ hold your credentials and bind to this workspace.
       config: # ... base64-encoded ssh config file ...
     ```
 
+    It's highly recommended to use the default id_rsa as the secret name rather than
+    a custom name since id_rsa is the default used by SSH. If a custom name is desired
+    a ~/.ssh/config would need to be generated before the git-clone call.
+
     Including `known_hosts` is optional but strongly recommended. Without it
     the `git-clone` Task will blindly accept the remote server's identity.
 
@@ -204,7 +208,7 @@ as password and generally be able to use `git` as the username.
 On bitbucket server the token may have a / into it so you would need
 to urlquote them before in the `Secret`, see this stackoverflow answer :
 
-https://stackoverflow.com/a/24719496 
+https://stackoverflow.com/a/24719496
 
 To support basic-auth this Task exposes an optional `basic-auth` Workspace.
 The bound Workspace must contain a `.gitconfig` and `.git-credentials` file.
@@ -224,4 +228,3 @@ stringData:
   .git-credentials: |
     https://<user>:<pass>@<hostname>
 ```
-


### PR DESCRIPTION
# Changes
Added documentation to recommend the usage of id_rsa rather than a custom private key name. Using a custom private key name will result in an SSH error:

ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

"stacktrace":"github.com/tektoncd/pipeline/pkg/git.run\n\tgithub.com/tektoncd/pipeline/pkg/git/git.go:54\ngithub.com/tektoncd/pipeline/pkg/git.Fetch\n\tgithub.com/tektoncd/pipeline/pkg/git/git.go:149\nmain.main\n\tgithub.com/tektoncd/pipeline/cmd/git-init/main.go:53\nruntime.main\n\truntime/proc.go:204"

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
