### PR TITLE
Directory not handled in digest-to-results step

### DIFF
--- a/task/jib-maven/0.1/tests/run.yaml
+++ b/task/jib-maven/0.1/tests/run.yaml
@@ -48,7 +48,7 @@ spec:
     name: jib-maven-test-pipeline
   workspaces:
   - name: shared-workspace
-    persistentvolumeclaim:
+    persistentVolumeClaim:
       claimName: jib-maven-source-pvc
   resources:
   - name: build-image

--- a/task/jib-maven/0.2/tests/run.yaml
+++ b/task/jib-maven/0.2/tests/run.yaml
@@ -61,5 +61,5 @@ spec:
     name: jib-maven-test-pipeline
   workspaces:
   - name: shared-workspace
-    persistentvolumeclaim:
+    persistentVolumeClaim:
       claimName: jib-maven-source-pvc

--- a/task/jib-maven/0.3/tests/run.yaml
+++ b/task/jib-maven/0.3/tests/run.yaml
@@ -64,7 +64,7 @@ spec:
     name: jib-maven-test-pipeline
   workspaces:
   - name: shared-workspace
-    persistentvolumeclaim:
+    persistentVolumeClaim:
       claimName: jib-maven-source-pvc
   - name: ssl-certs
     configMap:

--- a/task/jib-maven/0.4/jib-maven.yaml
+++ b/task/jib-maven/0.4/jib-maven.yaml
@@ -77,7 +77,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.MAVEN_IMAGE)
-    script: cat $(workspaces.source.path)/target/jib-image.digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/target/jib-image.digest | tee /tekton/results/IMAGE_DIGEST
 
   volumes:
   - name: empty-dir-volume

--- a/task/jib-maven/0.4/tests/run.yaml
+++ b/task/jib-maven/0.4/tests/run.yaml
@@ -64,7 +64,7 @@ spec:
     name: jib-maven-test-pipeline
   workspaces:
   - name: shared-workspace
-    persistentvolumeclaim:
+    persistentVolumeClaim:
       claimName: jib-maven-source-pvc
   - name: ssl-certs
     configMap:


### PR DESCRIPTION
This will fix the issue of jib-maven task not passing digest to results
if the clone has happened in sub-directory and directory passed to
jib-maven task

It is because the directory param is not handled in path creation for digest

It will not break the existing the behaviour but fixing the issue for directory scenario
so doing the change in latest version

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
