### PR TITLE
Add DOCKER_CONFIG env variable to jib-gradle

### DIFF
--- a/task/jib-gradle/0.1/jib-gradle.yaml
+++ b/task/jib-gradle/0.1/jib-gradle.yaml
@@ -63,6 +63,8 @@ spec:
     env:
     - name: HOME
       value: /workspace
+    - name: "DOCKER_CONFIG"
+      value: $(credentials.path)/.docker/
     volumeMounts:
     # empty volume required to make the Gradle home globally writable
     - name: empty-dir-volume

--- a/task/jib-gradle/0.2/jib-gradle.yaml
+++ b/task/jib-gradle/0.2/jib-gradle.yaml
@@ -73,6 +73,8 @@ spec:
     env:
     - name: HOME
       value: /workspace
+    - name: "DOCKER_CONFIG"
+      value: $(credentials.path)/.docker/
     volumeMounts:
     # empty volume required to make the Gradle home globally writable
     - name: empty-dir-volume

--- a/task/jib-gradle/0.3/jib-gradle.yaml
+++ b/task/jib-gradle/0.3/jib-gradle.yaml
@@ -77,6 +77,8 @@ spec:
     env:
     - name: HOME
       value: /workspace
+    - name: "DOCKER_CONFIG"
+      value: $(credentials.path)/.docker/
     volumeMounts:
     # empty volume required to make the Gradle home globally writable
     - name: empty-dir-volume


### PR DESCRIPTION
# Changes

Specification of Docker config location allows to point jib tool to the Docker config file with registry auth information, provided by Tekton via [service accounts](https://github.com/tektoncd/pipeline/blob/main/docs/auth.md#configuring-docker-authentication-for-docker).

Without this fix jib is not able to find credentials for private registries or registries will limited pulls and build fails.

Fix is provided for all 3 existing versions of the task.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
