### PR TITLE
bump goreleaser to latest

### DIFF
--- a/task/goreleaser/0.2/goreleaser.yaml
+++ b/task/goreleaser/0.2/goreleaser.yaml
@@ -35,7 +35,7 @@ spec:
       default: --timeout=30m
     - name: image
       description: container image location for goreleaser
-      default: docker.io/goreleaser/goreleaser@sha256:0e87d0e33840a556d3b9c10a7f71a3a69bcd9c29b86a180cbbf7d7ad1f3fa280
+      default: docker.io/goreleaser/goreleaser@sha256:2cb5e816cb9d093f436de4b79d6aeef1cde6a4f8fd028f37fff0a687729dd82f
   steps:
     - name: pull
       image: $(params.image)


### PR DESCRIPTION
Use latest goreleaser version, willl be able to release to homebrew without producing this warning : 

```
Updated 2 casks.
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the tektoncd/tools tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/tektoncd/homebrew-tools/Formula/tektoncd-cli.rb:6
```