### PR TITLE
Don't omit params.context in source path construction

### DIFF
--- a/task/golang-test/0.2/golang-test.yaml
+++ b/task/golang-test/0.2/golang-test.yaml
@@ -54,7 +54,7 @@ spec:
       if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
          SRC_PATH="$GOPATH/src/$(params.package)"
          mkdir -p $SRC_PATH
-         cp -R "$(workspaces.source.path)"/* $SRC_PATH
+         cp -R "$(workspaces.source.path)/$(params.context)"/* $SRC_PATH
          cd $SRC_PATH
       fi
       go test $(params.flags) $(params.packages)


### PR DESCRIPTION
Looks like the `context` param is never used in 0.2 which fails builds that don't have the golang sources at the workspace root. Seems like a regression from 0.1.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Append $(params.context) during source dir construction.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
