### PR TITLE
Task golang-build add extra build params allowing for static golang builds.

### DIFF
--- a/task/golang-build/0.3/README.md
+++ b/task/golang-build/0.3/README.md
@@ -1,0 +1,58 @@
+# Golang Build
+
+This Task is Golang task to build Go projects.
+
+## Install the task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.3/golang-build.yaml
+
+```
+
+
+### Parameters
+
+* **package**: base package under test
+* **packages**: packages to test (_default:_ ./...)
+* **version**: golang version to use for tests (_default:_ latest)
+* **flags**: flags to use for `go build` command (_default:_ -v)
+* **GOOS**: operating system target (_default:_ linux)
+* **GOARCH**: architecture target (_default:_ amd64)
+* **GO111MODULE**: value of module support (_default:_ auto)
+* **GOCACHE**: value for go caching path (_default:_ "")
+* **GOMODCACHE**: value for go module caching path (_default:_ "")
+* **CGO_ENABLED**: value for go cgo tool toggle (_default:_ "")
+* **GOSUMDB**: value for go checksum database url (_default:_ "")
+
+### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`,  and `linux/ppc64le` platforms.
+
+Specify value for `GOARCH` parameter according to the desired target architecture.
+
+## Usage
+
+This TaskRun runs the Task to compile commands from
+[`tektoncd/pipeline`](https://github.com/tektoncd/pipeline).
+`golangci-lint`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: build-my-code
+spec:
+  taskRef:
+    name: golang-build
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  params:
+  - name: package
+    value: github.com/tektoncd/pipeline
+```

--- a/task/golang-build/0.3/golang-build.yaml
+++ b/task/golang-build/0.3/golang-build.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: golang-build
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Build Tools
+    tekton.dev/tags: build-tool
+    tekton.dev/displayName: "golang build"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This Task is Golang task to build Go projects.
+
+  params:
+  - name: package
+    description: base package to build in
+  - name: packages
+    description: "packages to build (default: ./cmd/...)"
+    default: "./cmd/..."
+  - name: version
+    description: golang version to use for builds
+    default: "latest"
+  - name: flags
+    description: flags to use for the test command
+    default: -v
+  - name: GOOS
+    description: "running program's operating system target"
+    default: linux
+  - name: GOARCH
+    description: "running program's architecture target"
+    default: amd64
+  - name: GO111MODULE
+    description: "value of module support"
+    default: auto
+  - name: GOCACHE
+    description: "Go caching directory path"
+    default: ""
+  - name: GOMODCACHE
+    description: "Go mod caching directory path"
+    default: ""
+  - name: CGO_ENABLED
+    description: "Toggle cgo tool during Go build. Use value '0' to disable cgo (for static builds)."
+    default: ""
+  - name: GOSUMDB
+    description: "Go checksum database url. Use value 'off' to disable checksum validation."
+    default: ""
+  workspaces:
+  - name: source
+  steps:
+  - name: build
+    image: docker.io/library/golang:$(params.version)
+    workingDir: $(workspaces.source.path)
+    script: |
+      if [ ! -e $GOPATH/src/$(params.package)/go.mod ];then
+        SRC_PATH="$GOPATH/src/$(params.package)"
+        mkdir -p $SRC_PATH
+        cp -R "$(workspaces.source.path)"/* $SRC_PATH
+        cd $SRC_PATH
+      fi
+      go build $(params.flags) $(params.packages)
+    env:
+    - name: GOOS
+      value: "$(params.GOOS)"
+    - name: GOARCH
+      value: "$(params.GOARCH)"
+    - name: GO111MODULE
+      value: "$(params.GO111MODULE)"
+    - name: GOCACHE
+      value: "$(params.GOCACHE)"
+    - name: GOMODCACHE
+      value: "$(params.GOMODCACHE)"
+    - name: CGO_ENABLED
+      value: "$(params.CGO_ENABLED)"
+    - name: GOSUMDB
+      value: "$(params.GOSUMDB)"

--- a/task/golang-build/0.3/tests/pre-apply-task-hook.sh
+++ b/task/golang-build/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Add git-clone
+add_task git-clone latest

--- a/task/golang-build/0.3/tests/resources.yaml
+++ b/task/golang-build/0.3/tests/resources.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: golang-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/golang-build/0.3/tests/run.yaml
+++ b/task/golang-build/0.3/tests/run.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: golang-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/chmouel/go-rest-api-test
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: run-build
+      taskRef:
+        name: golang-build
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: package
+          value: github.com/chmouel/go-rest-api-test
+        - name: packages
+          value: "./"
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: golang-test-pipeline-run
+spec:
+  pipelineRef:
+    name: golang-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: golang-source-pvc


### PR DESCRIPTION
# Changes
Adding CGO_ENABLED and GOSUMDB as task parameters to be used as environment variables during the go `build` command. This allows for static builds that can run in a different base-image than the image used for the golang build.

# Submitter Checklist
These are the criteria that every PR should meet, please check them off as you
review them:

- [V] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [V] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [V] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [V] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [V] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [V] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [V] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [V] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [V] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
