### PR TITLE
Fix git-cli recursive copy command and support GIT_SSH_COMMAND

### DIFF
--- a/task/git-cli/0.4/README.md
+++ b/task/git-cli/0.4/README.md
@@ -1,0 +1,163 @@
+# Git Task
+
+This `Task` is Git task to work with repositories used by other tasks
+in your Pipeline.
+
+## `git-cli`
+
+This [task](../0.3/git-cli.yaml) can be used to perform `git operations`.
+All git commands can be found [here](https://git-scm.com/docs).
+
+Command that needs to be run can be passed as a script to the task.
+
+### Workspaces
+
+* **source**: A workspace that contains the fetched git repository.
+* **input**: An optional workspace that contains the files that need to be added to git. You can
+    access the workspace from your script using `$(workspaces.input.path)`, for instance:
+
+      cp $(workspaces.input.path)/file_that_i_want .
+      git add file_that_i_want
+      # etc
+
+* **ssh-directory**: An optional workspace to provide SSH credentials. At
+  minimum this should include a private key but can also include other common
+  files from `.ssh` including `config` and `known_hosts`. It is **strongly**
+  recommended that this workspace be bound to a Kubernetes `Secret`.
+  For details on the correct format of the files in this Workspace
+  see [Using SSH credentials](#using-ssh-credentials) below.
+
+* **basic-auth**: An optional workspace containing `.gitconfig` and
+  `.git-credentials` files. This allows username/password/access token to be
+  provided for basic auth.
+
+  It is **strongly** recommended that this workspace be bound to a Kubernetes
+  `Secret`. For details on the correct format of the files in this Workspace
+  see [Using basic-auth Credentials](#using-basic-auth-credentials) below.
+
+### Parameters
+
+* **BASE_IMAGE**: The base image for the task.
+(_default_: `alpine/git:latest`)
+* **GIT_USER_NAME**: Git user name for performing git operation.
+* **GIT_USER_EMAIL**:  Git user email for performing git operation.
+* **GIT_SCRIPT**: The git script to run. (_required_)
+* **VERBOSE**: Log the commands that are executed during `git-cli`'s operation. (_default_: true)
+* **USER_HOME**: The user's home directory. Set this explicitly if you are running the image as a non-root user. (_default_: "/root")
+
+### Results
+
+* **commit**: The precise commit SHA after git operation is performed.
+
+### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+### Usage
+
+This task needs authentication to git in order to push after the git operation.
+
+After creating the task, you should now be able to execute `git` commands by
+specifying the command you would like to run as the `GIT_SCRIPT` param.
+
+`Example`:
+
+```yaml
+  params:
+    - name: GIT_SCRIPT
+      value: |
+        git init
+        git remote add origin https://github.com/kelseyhightower/nocode
+        git pull origin master
+```
+
+## Using SSH credentials
+
+This Task supports fetching private repositories using SSH credentials.
+
+If you are a bit rusty on your SSH and don't know what a typical .ssh directory should look like,
+there are tons of good guides to be found online, see for instance [this article by Digital Ocean](https://www.digitalocean.com/community/tutorials/ssh-essentials-working-with-ssh-servers-clients-and-keys).
+
+1. Bind an `ssh-directory` workspace to this Task.
+The workspace should contain private keys (e.g. `id_rsa`), `config`
+and `known_hosts` files - anything you need to interact with your git remote
+via SSH. It's **strongly** recommended that you use Kubernetes `Secrets` to
+hold your credentials and bind to this workspace.
+
+    In a TaskRun that would look something like this:
+
+    ```yaml
+    kind: TaskRun
+    spec:
+      workspaces:
+      - name: ssh-directory
+        secret:
+          secretName: my-ssh-credentials
+    ```
+
+    And in a Pipeline and PipelineRun it would look like this:
+
+    ```yaml
+    kind: Pipeline
+    spec:
+      workspaces:
+      - name: ssh-creds
+      # ...
+      tasks:
+      - name: use-git-cli
+        taskRef:
+          name: git-cli
+        workspaces:
+        - name: ssh-directory
+          workspace: ssh-creds
+      # ...
+    ---
+    kind: PipelineRun
+    spec:
+      workspaces:
+      - name: ssh-creds
+        secret:
+          secretName: my-ssh-credentials
+      # ...
+    ```
+
+    The `Secret` would appear the same in both cases - structured like a `.ssh`
+    directory:
+
+    ```yaml
+    kind: Secret
+    apiVersion: v1
+    metadata:
+      name: my-ssh-credentials
+    data:
+      id_rsa: # ... base64-encoded private key ...
+      known_hosts: # ... base64-encoded known_hosts file ...
+      config: # ... base64-encoded ssh config file ...
+    ```
+
+    Including `known_hosts` is optional but strongly recommended. Without it
+    the `git-cli` Task will blindly accept the remote server's identity.
+
+## Using basic-auth Credentials
+
+**Note**: It is strongly advised that you use `ssh` credentials when the
+option is available to you before using basic auth.
+
+To support basic-auth this Task exposes an optional `basic-auth` Workspace.
+The bound Workspace must contain a `.gitconfig` and `.git-credentials` file.
+Any other files on this Workspace are ignored. A typical `Secret` containing
+these credentials looks as follows:
+
+```yaml
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-basic-auth-secret
+type: Opaque
+stringData:
+  .gitconfig: |
+    [credential "https://<hostname>"]
+      helper = store
+  .git-credentials: |
+    https://<user>:<pass>@<hostname>
+```

--- a/task/git-cli/0.4/README.md
+++ b/task/git-cli/0.4/README.md
@@ -44,7 +44,7 @@ Command that needs to be run can be passed as a script to the task.
 * **GIT_SCRIPT**: The git script to run. (_required_)
 * **VERBOSE**: Log the commands that are executed during `git-cli`'s operation. (_default_: true)
 * **USER_HOME**: The user's home directory. Set this explicitly if you are running the image as a non-root user. (_default_: "/root")
-* **GIT_SSH_COMMAND**: SSH command git uses when connecting to the remote.
+* **GIT_EXTRA_ENV_VARS**: Additional environment variables to set for git operations
 
 ### Results
 

--- a/task/git-cli/0.4/README.md
+++ b/task/git-cli/0.4/README.md
@@ -44,6 +44,7 @@ Command that needs to be run can be passed as a script to the task.
 * **GIT_SCRIPT**: The git script to run. (_required_)
 * **VERBOSE**: Log the commands that are executed during `git-cli`'s operation. (_default_: true)
 * **USER_HOME**: The user's home directory. Set this explicitly if you are running the image as a non-root user. (_default_: "/root")
+* **GIT_SSH_COMMAND**: SSH command git uses when connecting to the remote.
 
 ### Results
 

--- a/task/git-cli/0.4/git-cli.yaml
+++ b/task/git-cli/0.4/git-cli.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-cli
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.21.0"
+    tekton.dev/categories: Git
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git cli"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This task can be used to perform git operations.
+
+    Git command that needs to be run can be passed as a script to
+    the task. This task needs authentication to git in order to push
+    after the git operation.
+
+  workspaces:
+    - name: source
+      description: A workspace that contains the fetched git repository.
+
+    - name: input
+      optional: true
+      description: |
+        An optional workspace that contains the files that need to be added to git. You can
+        access the workspace from your script using `$(workspaces.input.path)`, for instance:
+
+          cp $(workspaces.input.path)/file_that_i_want .
+          git add file_that_i_want
+          # etc
+
+    - name: ssh-directory
+      optional: true
+      description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+
+    - name: basic-auth
+      optional: true
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+  params:
+    - name: BASE_IMAGE
+      description: |
+        The base image for the task.
+      type: string
+      default: docker.io/alpine/git:v2.26.2@sha256:23618034b0be9205d9cc0846eb711b12ba4c9b468efdd8a59aac1d7b1a23363f #tag: v2.26.2
+
+    - name: GIT_USER_NAME
+      type: string
+      description: |
+        Git user name for performing git operation.
+      default: ""
+
+    - name: GIT_USER_EMAIL
+      type: string
+      description: |
+        Git user email for performing git operation.
+      default: ""
+
+    - name: GIT_SCRIPT
+      description: The git script to run.
+      type: string
+      default: |
+        git help
+
+    - name: USER_HOME
+      description: |
+        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
+        the gitInitImage param with an image containing custom user configuration.
+      type: string
+      default: "/root"
+
+    - name: VERBOSE
+      description: Log the commands that are executed during `git-clone`'s operation.
+      type: string
+      default: "true"
+
+  results:
+    - name: commit
+      description: The precise commit SHA after the git operation.
+
+  steps:
+    - name: git
+      image: $(params.BASE_IMAGE)
+      workingDir: $(workspaces.source.path)
+      env:
+      - name: PARAM_VERBOSE
+        value: $(params.VERBOSE)
+      - name: PARAM_USER_HOME
+        value: $(params.USER_HOME)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
+      - name: WORKSPACE_SSH_DIRECTORY_BOUND
+        value: $(workspaces.ssh-directory.bound)
+      - name: WORKSPACE_SSH_DIRECTORY_PATH
+        value: $(workspaces.ssh-directory.path)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+        value: $(workspaces.basic-auth.bound)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+        value: $(workspaces.basic-auth.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ] ; then
+          set -x
+        fi
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        # Setting up the config for the git.
+        git config --global user.email "$(params.GIT_USER_EMAIL)"
+        git config --global user.name "$(params.GIT_USER_NAME)"
+
+        $(params.GIT_SCRIPT)
+
+        RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
+        EXIT_CODE="$?"
+        if [ "$EXIT_CODE" != 0 ]
+        then
+          exit $EXIT_CODE
+        fi
+        # Make sure we don't add a trailing newline to the result!
+        echo -n "$RESULT_SHA" > $(results.commit.path)

--- a/task/git-cli/0.4/git-cli.yaml
+++ b/task/git-cli/0.4/git-cli.yaml
@@ -88,7 +88,7 @@ spec:
 
     - name: GIT_EXTRA_ENV_VARS
       description: |
-          Additional environment variables for git-cli operations
+          Additional environment variables to set for git-cli operations
       type: string
       default: ""
 

--- a/task/git-cli/0.4/git-cli.yaml
+++ b/task/git-cli/0.4/git-cli.yaml
@@ -86,6 +86,12 @@ spec:
       type: string
       default: "true"
 
+    - name: GIT_SSH_COMMAND
+      description: |
+        SSH command git uses when connecting to the remote.
+      type: string
+      default: ""
+
   results:
     - name: commit
       description: The precise commit SHA after the git operation.
@@ -109,6 +115,8 @@ spec:
         value: $(workspaces.basic-auth.bound)
       - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
         value: $(workspaces.basic-auth.path)
+      - name: GIT_SSH_COMMAND
+        value: $(params.GIT_SSH_COMMAND)
       script: |
         #!/usr/bin/env sh
         set -eu
@@ -125,8 +133,9 @@ spec:
         fi
 
         if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
-          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          mkdir -p "${PARAM_USER_HOME}"/.ssh
           chmod 700 "${PARAM_USER_HOME}"/.ssh
+          cp -RL "${WORKSPACE_SSH_DIRECTORY_PATH}"/* "${PARAM_USER_HOME}"/.ssh
           chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
         fi
 

--- a/task/git-cli/0.4/git-cli.yaml
+++ b/task/git-cli/0.4/git-cli.yaml
@@ -115,8 +115,6 @@ spec:
         value: $(workspaces.basic-auth.bound)
       - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
         value: $(workspaces.basic-auth.path)
-      - name: GIT_SSH_COMMAND
-        value: $(params.GIT_SSH_COMMAND)
       script: |
         #!/usr/bin/env sh
         set -eu

--- a/task/git-cli/0.4/git-cli.yaml
+++ b/task/git-cli/0.4/git-cli.yaml
@@ -86,9 +86,9 @@ spec:
       type: string
       default: "true"
 
-    - name: GIT_SSH_COMMAND
+    - name: GIT_EXTRA_ENV_VARS
       description: |
-        SSH command git uses when connecting to the remote.
+          Additional environment variables for git-cli operations
       type: string
       default: ""
 
@@ -123,6 +123,10 @@ spec:
 
         if [ "${PARAM_VERBOSE}" = "true" ] ; then
           set -x
+        fi
+
+        if [ ! -z "$(params.GIT_EXTRA_ENV_VARS)" ]; then
+            export "$(params.GIT_EXTRA_ENV_VARS)"
         fi
 
         if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then

--- a/task/git-cli/0.4/git-cli.yaml
+++ b/task/git-cli/0.4/git-cli.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: git-cli
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.21.0"
     tekton.dev/categories: Git

--- a/task/git-cli/0.4/tests/run.yaml
+++ b/task/git-cli/0.4/tests/run.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-cli-run
+spec:
+  taskRef:
+    name: git-cli
+  workspaces:
+    - name: source
+      emptyDir: {}
+    - name: input
+      emptyDir: {}
+  params:
+    - name: GIT_SCRIPT
+      value: |
+        git init
+        git remote add origin https://github.com/kelseyhightower/nocode
+        git pull origin master


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

 * Fixes problem with cp -R described in https://github.com/tektoncd/catalog/issues/878
 * Support GIT_SSH_COMMAND to be able to override SSH command

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
