### PR TITLE
Fix Readme hadolint task 0.1

### DIFF
--- a/task/hadolint/0.1/README.md
+++ b/task/hadolint/0.1/README.md
@@ -2,13 +2,9 @@
 
 Tekton Task for hadolint https://github.com/hadolint/hadolint
 
-<img align="right" alt="pipecat" width="150"
-src="https://hadolint.github.io/hadolint/img/cat_container.png" />
-
-A smarter Dockerfile linter that helps you build [best practice][] Docker
-images. The linter parses the Dockerfile into an AST and performs rules on
-top of the AST. It stands on the shoulders of [ShellCheck][] to lint
-the Bash code inside `RUN` instructions.
+A smarter Dockerfile linter that helps you build Docker images. 
+The linter parses the Dockerfile into an AST and performs rules on top of the AST. 
+It stands on the shoulders of ShellCheck to lint the Bash code inside `RUN` instructions.
 
 ## Install the Task
 ```
@@ -43,8 +39,6 @@ In the [tests](../0.1/tests/run.yaml), folder there is an example of the executi
 
 An incomplete list of implemented rules. Click on the error code to get more
 detailed information.
-
-<!--lint disable maximum-line-length-->
 
 | Rule                                                         | Default Severity | Description                                                                                                                                         |
 | :----------------------------------------------------------- | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -146,5 +140,3 @@ detailed information.
 | [SC2154](https://github.com/koalaman/shellcheck/wiki/SC2154) |                  | var is referenced but not assigned.                                                                                                                 |
 | [SC2155](https://github.com/koalaman/shellcheck/wiki/SC2155) |                  | Declare and assign separately to avoid masking return values.                                                                                       |
 | [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164) |                  | Use <code>cd ... &#124;&#124; exit</code> in case `cd` fails.                                                                                       |
-
-<!--lint enable maximum-line-length-->


### PR DESCRIPTION
# Changes

Fix Readme hadolint task 0.1, tekton web catalog no compatible with some markdown syntax.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
