### PR TITLE
Fix pytest args

### DIFF
--- a/task/pytest/0.1/pytest.yaml
+++ b/task/pytest/0.1/pytest.yaml
@@ -56,5 +56,5 @@ spec:
         if [ -z "$(inputs.params.ARGS)" ]; then
           pytest "$(inputs.params.SOURCE_PATH)"
         else
-          pytest "$(inputs.params.ARGS)" "$(inputs.params.SOURCE_PATH)"
+          pytest $(inputs.params.ARGS) "$(inputs.params.SOURCE_PATH)"
         fi


### PR DESCRIPTION
The quotation marks are breaking the proper execution of args in the pytest task.

Given these args:

```
- name: ARGS
  value: -rfs --junitxml build/results.xml --cov-config .coveragerc --cov app --cov-report xml:coverage-reports/coverage-results.xml
```

This results in the following yaml for the taskrun pod:

```
pytest "-rfs --junitxml build/results.xml --cov-config .coveragerc --cov app --cov-report xml:coverage-reports/coverage-results.xml" "."
```

# Changes

Removed the quotation marks around the args parameter in the script

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention
