### PR TITLE
Change sonarqube scanner workspace name + tests

### DIFF
--- a/task/sonarqube-scanner/0.2/README.md
+++ b/task/sonarqube-scanner/0.2/README.md
@@ -1,0 +1,121 @@
+# SonarQube
+
+SonarQube™ is the leading tool for continuously inspecting the Code Quality and Security™ of your codebases, all while empowering development teams. Analyze over 25 popular programming languages including C#, VB.Net, JavaScript, TypeScript and C++. It detects bugs, vulnerabilities and code smells across project branches and pull requests.
+
+The following task can be used to perform static analysis on the source code provided the SonarQube server is hosted.
+
+For creating your own `sonar-project.properties` please follow the guide [here](https://docs.sonarqube.org/latest/analysis/analysis-parameters/). Sample properties file can be found [here](./samples/sonar-project.properties)
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sonarqube-scanner/0.1/sonarqube-scanner.yaml
+```
+
+## Pre-requisite
+
+Install the `git-clone` task from the catalog
+
+```
+https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml
+```
+
+## Parameters
+
+- **SONAR_HOST_URL**: Host URL where the sonarqube server is running
+- **SONAR_PROJECT_KEY**: Project's unique key
+
+> _Note_ : Parameters are provided in that case when we want to override the corresponding values in `sonar-project.properties` or there is no `sonar-project.properties` present for the project which needs to be analyzed
+
+## Workspaces
+
+- **source**: `PersistentVolumeClaim`-type so that volume can be shared among git-clone and sonarqube task. Sample PVC can be found [here](../0.1/samples/pvc.yaml)
+- **sonar-settings**: To mount the `sonar-project.properties` via the `ConfigMap`. (_Default_ : `emptyDir:{}`)
+
+  To mount via the `ConfigMap`:
+
+  ```
+  kubectl create configmap sonar-properties --from-file="sonar-project.properties"
+  ```
+
+## Running SonarQube Server locally using Docker
+
+1. Boot SonarQube
+
+   ```
+   docker run --name="sonarqube" -d sonarqube
+   ```
+
+2. Get the IP address exposed by docker image to access sonarqube server
+
+   ```
+   docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <container_id or container_name>
+   ```
+
+Sample IPAddress we will obtain using above command is like http://172.17.0.2:9000
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+1. `sonar-project.properties` present in Github Repository. For example :- following [repo](https://github.com/vinamra28/sonartest) contains the properties file and Sonar Host URL needs to be updated via the `params`.
+   The sample run for this scenario can be found [here](../0.1/samples/run.yaml)
+
+2. In case when no `sonar-project.properties` file is present then above two parameters are mandatory to create a `sonar-project.properties` file with the required fields or the file can be mounted via the `ConfigMap`.
+
+```
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: sonarqube-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: sonar-settings
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/vinamra28/replace-tokens-plugin
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: code-analysis
+      taskRef:
+        name: sonarqube-scanner
+      runAfter:
+        - fetch-repository
+      params:
+        - name: SONAR_HOST_URL
+          value: http://172.17.0.2:9000
+        - name: SONAR_PROJECT_KEY
+          value: testapp
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: sonar-settings
+          workspace: sonar-settings
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: sonarqube-run
+spec:
+  pipelineRef:
+    name: sonarqube-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: sonar-source-pvc
+    - name: sonar-settings
+      emptyDir: {}
+```

--- a/task/sonarqube-scanner/0.2/sonarqube-scanner.yaml
+++ b/task/sonarqube-scanner/0.2/sonarqube-scanner.yaml
@@ -1,0 +1,81 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: sonarqube-scanner
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Security
+    tekton.dev/tags: security
+    tekton.dev/displayName: "sonarqube scanner"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    The following task can be used to perform static analysis on the source code
+    provided the SonarQube server is hosted
+
+    SonarQube is the leading tool for continuously inspecting the Code Quality and Security
+    of your codebases, all while empowering development teams. Analyze over 25 popular
+    programming languages including C#, VB.Net, JavaScript, TypeScript and C++. It detects
+    bugs, vulnerabilities and code smells across project branches and pull requests.
+
+  workspaces:
+    - name: source
+    - name: sonar-settings
+  params:
+    - name: SONAR_HOST_URL
+      description: Host URL where the sonarqube server is running
+      default: ""
+    - name: SONAR_PROJECT_KEY
+      description: Project's unique key
+      default: ""
+  steps:
+    - name: sonar-properties-create
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+
+        replaceValues() {
+          filename=$1
+          thekey=$2
+          newvalue=$3
+
+          if ! grep -R "^[#]*\s*${thekey}=.*" $filename >/dev/null; then
+            echo "APPENDING because '${thekey}' not found"
+            echo "" >>$filename
+            echo "$thekey=$newvalue" >>$filename
+          else
+            echo "SETTING because '${thekey}' found already"
+            sed -ir "s|^[#]*\s*${thekey}=.*|$thekey=$newvalue|" $filename
+          fi
+        }
+
+        if [[ -f $(workspaces.sonar-settings.path)/sonar-project.properties ]]; then
+          echo "using user provided sonar-project.properties file"
+          cp -RL $(workspaces.sonar-settings.path)/sonar-project.properties $(workspaces.source.path)/sonar-project.properties
+        fi
+
+        if [[ -f $(workspaces.source.path)/sonar-project.properties ]]; then
+          if [[ -n "$(params.SONAR_HOST_URL)" ]]; then
+            replaceValues $(workspaces.source.path)/sonar-project.properties sonar.host.url $(params.SONAR_HOST_URL)
+          fi
+          if [[ -n "$(params.SONAR_PROJECT_KEY)" ]]; then
+            replaceValues $(workspaces.source.path)/sonar-project.properties sonar.projectKey $(params.SONAR_PROJECT_KEY)
+          fi
+        else
+          touch sonar-project.properties
+          echo "sonar.projectKey=$(params.SONAR_PROJECT_KEY)" >> sonar-project.properties
+          echo "sonar.host.url=$(params.SONAR_HOST_URL)" >> sonar-project.properties
+          echo "sonar.sources=." >> sonar-project.properties
+        fi
+
+        echo "---------------------------"
+        cat $(workspaces.source.path)/sonar-project.properties
+
+    - name: sonar-scan
+      image: docker.io/sonarsource/sonar-scanner-cli:4.5@sha256:b8c95a37025f3c13162118cd55761ea0b2a13d1837f9deec51b7b6d82c52040a #tag: 4.5
+      workingDir: $(workspaces.source.path)
+      command:
+        - sonar-scanner

--- a/task/sonarqube-scanner/0.2/tests/pre-apply-task-hook.sh
+++ b/task/sonarqube-scanner/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Add git-clone
+add_task git-clone latest
+add_task write-file latest

--- a/task/sonarqube-scanner/0.2/tests/resources.yaml
+++ b/task/sonarqube-scanner/0.2/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonar-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/task/sonarqube-scanner/0.2/tests/run.yaml
+++ b/task/sonarqube-scanner/0.2/tests/run.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: sonarqube-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: sonar-settings
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/vinamra28/sonartest
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: create-sonar-properties
+      params:
+        - name: path
+          value: ./sonar-project.properties
+        - name: contents
+          value: |
+            sonar.projectKey=sonarqube-scanner
+            sonar.projectName=sonarqube-scanner
+            sonar.projectVersion=1.0
+            sonar.host.url=https://sonarcloud.io/
+            sonar.sources=.
+            sonar.organization=tekton-catalog-test
+      runAfter:
+        - fetch-repository
+      taskRef:
+        kind: Task
+        name: write-file
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: code-analysis
+      taskRef:
+        name: sonarqube-scanner
+      runAfter:
+        - create-sonar-properties
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: sonar-settings
+          workspace: sonar-settings
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: sonarqube-run
+spec:
+  pipelineRef:
+    name: sonarqube-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: sonar-source-pvc
+    - name: sonar-settings
+      emptyDir: {}


### PR DESCRIPTION
# Changes

Changes the source workspace name to `source` instead of `source-dir`. When running code-coverage analysis in pytest (possibly other tasks) the workspace dir is hardcoded into the coverage file. This change makes sure the source workspace path sonarqube-scanner is the same path as in the coverage file.

I also added a test (as there was none). This uses a public sonarcloud project as it's very resource intensive to run an entire sonarqube as a sidecar.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

