### PR TITLE
Hadolint improve ignore rules

### DIFF
--- a/task/hadolint/0.1/hadolint.yaml
+++ b/task/hadolint/0.1/hadolint.yaml
@@ -33,14 +33,16 @@ spec:
       name: output-format
       type: string
   steps:
-    - image: 'ghcr.io/hadolint/hadolint:v2.8.0-alpine@sha256:6c4b7c23f96339489dd35f21a711996d7ce63047467a9a562287748a03ad5242'
+    - image: 'ghcr.io/hadolint/hadolint:v2.8.0-debian@sha256:50b0e60aa2b4aba5a26eeb4ad08c96ed7a828fca996632e29114aabea18345f4'
       name: lint-dockerfile
       script: |
+        #!/bin/bash
         set -e
-
         if [ -n "$RULES" ]
         then
-          command_to_run="hadolint --ignore=${RULES} "
+          IFS="," read -a RULES <<< "$RULES"
+          for rule in ${RULES[@]}; do ignore_rules="--ignore $rule $ignore_rules"; done
+          command_to_run="hadolint ${ignore_rules}"
         else
           command_to_run="hadolint"
         fi


### PR DESCRIPTION
# Changes

Improve ignore rules. 
Multiple rules do not need to indicate the "--ignore" parameter for each one.
Example:

```
  - name: ignore-rules
    value: 'DL3013,DL3018,DL3042,DL4006,SC2086'
```


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
