### PR TITLE
Buildah 0.4: Make buildah image run by default as user to build images

### DIFF
--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -1,0 +1,67 @@
+# Buildah
+
+This Task builds source into a container image using Project Atomic's
+[Buildah](https://github.com/projectatomic/buildah) build tool. It uses
+Buildah's support for building from
+[`Dockerfile`](https://docs.docker.com/engine/reference/builder/)s, using its
+`buildah bud` command. This command executes the directives in the `Dockerfile`
+to assemble a container image, then pushes that image to a container registry.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.2/buildah.yaml
+```
+
+## Parameters
+
+* **IMAGE**: The name (reference) of the image to build.
+* **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
+  note below.  (_default:_ quay.io/buildah/stable:v1.17.0)
+* **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
+  `./Dockerfile`)
+* **CONTEXT**: Path to the directory to use as context (_default:_
+  `.`)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+* **FORMAT**: The format of the built container, oci or docker (_default:_
+ `oci`)
+* **BUILD_EXTRA_ARGS**: Extra parameters passed for the build command when
+  building images. (_default:_ `""`)
+* **PUSH_EXTRA_ARGS**: Extra parameters passed for the push command when
+  pushing images. (_default:_ `""`)
+* **SKIP_PUSH**: Skip pushing the built image (_default:_ `false`)
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+* **sslcertdir**: An [*optional* Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry. Buildah will look for files ending with *.crt, *.cert, *.key into this workspace. See [this sample](./samples/openshift-internal-registry.yaml) for a complete example on how to use it with OpenShift internal registry.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Buildah.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: buildah-build-my-repo
+spec:
+  taskRef:
+    name: buildah
+  params:
+  - name: IMAGE
+    value: gcr.io/my-repo/my-image
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+In this example, the Git repo being built is expected to have a `Dockerfile` at
+the root of the repository.

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -10,14 +10,14 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.2/buildah.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.4/buildah.yaml
 ```
 
 ## Parameters
 
 * **IMAGE**: The name (reference) of the image to build.
 * **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
-  note below.  (_default:_ quay.io/buildah/stable:v1.17.0)
+  note below.  (_default:_ registry.access.redhat.com/ubi8/buildah:8.5-8)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 * **CONTEXT**: Path to the directory to use as context (_default:_
@@ -36,6 +36,14 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bu
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 * **sslcertdir**: An [*optional* Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry. Buildah will look for files ending with *.crt, *.cert, *.key into this workspace. See [this sample](./samples/openshift-internal-registry.yaml) for a complete example on how to use it with OpenShift internal registry.
+
+## Build user id
+
+By default the buildah task will reuse the `build` user inside the image to
+build as user using [user
+namespaces](https://man7.org/linux/man-pages/man7/user_namespaces.7.html). If
+you need to run as root you will need to modify the `securityContext` and
+`runAsUser` 0.
 
 ## Platforms
 

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    Buildah task builds source into a container image and
+    then pushes it to a container registry.
+
+    Buildah Task builds source into a container image using Project Atomic's
+    Buildah build tool.It uses Buildah's support for building from Dockerfiles,
+    using its buildah bud command.This command executes the directives in the
+    Dockerfile to assemble a container image, then pushes that image to a
+    container registry.
+
+  params:
+  - name: IMAGE
+    description: Reference of the image buildah will produce.
+  - name: BUILDER_IMAGE
+    description: The location of the buildah builder image.
+    default: quay.io/buildah/stable:v1.18.0
+  - name: STORAGE_DRIVER
+    description: Set buildah storage driver
+    default: overlay
+  - name: DOCKERFILE
+    description: Path to the Dockerfile to build.
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: Path to the directory to use as context.
+    default: .
+  - name: TLSVERIFY
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    default: "true"
+  - name: FORMAT
+    description: The format of the built container, oci or docker
+    default: "oci"
+  - name: BUILD_EXTRA_ARGS
+    description: Extra parameters passed for the build command when building images.
+    default: ""
+  - name: PUSH_EXTRA_ARGS
+    description: Extra parameters passed for the push command when pushing images.
+    type: string
+    default: ""
+  - name: SKIP_PUSH
+    description: Skip pushing the built image
+    default: "false"
+  workspaces:
+  - name: source
+  - name: sslcertdir
+    optional: true
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+  steps:
+  - name: build
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)
+    script: |
+      [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+      buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) bud \
+        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+        --tls-verify=$(params.TLSVERIFY) --no-cache \
+        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    securityContext:
+      privileged: true
+
+  - name: push
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)
+    script: |
+      [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+      [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+      buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) push \
+        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+        docker://$(params.IMAGE)
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    securityContext:
+      privileged: true
+
+  - name: digest-to-results
+    image: $(params.BUILDER_IMAGE)
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+
+  volumes:
+  - name: varlibcontainers
+    emptyDir: {}

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: buildah
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/categories: Image Build
     tekton.dev/pipelines.minVersion: "0.17.0"
@@ -26,10 +26,10 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: quay.io/buildah/stable:v1.18.0
+    default: "registry.access.redhat.com/ubi8/buildah:8.5-8"
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
-    default: overlay
+    default: vfs
   - name: DOCKERFILE
     description: Path to the Dockerfile to build.
     default: ./Dockerfile
@@ -64,37 +64,22 @@ spec:
     image: $(params.BUILDER_IMAGE)
     workingDir: $(workspaces.source.path)
     script: |
+      echo "Running as USER ID `id`"
       [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
       buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) bud \
         $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
         --tls-verify=$(params.TLSVERIFY) --no-cache \
         -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
-    volumeMounts:
-    - name: varlibcontainers
-      mountPath: /var/lib/containers
-    securityContext:
-      privileged: true
 
-  - name: push
-    image: $(params.BUILDER_IMAGE)
-    workingDir: $(workspaces.source.path)
-    script: |
       [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
       [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
       buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) push \
         $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
         --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
-    volumeMounts:
-    - name: varlibcontainers
-      mountPath: /var/lib/containers
     securityContext:
-      privileged: true
+      runAsUser: 1000
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)
     script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
-
-  volumes:
-  - name: varlibcontainers
-    emptyDir: {}

--- a/task/buildah/0.4/samples/openshift-internal-registry.yaml
+++ b/task/buildah/0.4/samples/openshift-internal-registry.yaml
@@ -1,0 +1,87 @@
+# Your custom CA, on OpenShift to be able to get the internal registry custom
+# certificates you can just import it to your namespace with :
+# oc get configmaps \
+#   -n openshift-controller-manager openshift-service-ca -o yaml | \
+#   sed '/namespace/d'|kubectl apply -f-
+---
+kind: ConfigMap
+metadata:
+  name: openshift-service-ca
+apiVersion: v1
+data:
+  service-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDUTCCAjmgAwIB................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ....................................................
+    -----END CERTIFICATE-----
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: buildah-custom-ca-
+spec:
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  # Make sure the path ends up as ca.crt or buildah would not be able to find
+  # it.
+  - name: sslcertdir
+    configMap:
+      name: openshift-service-ca
+      defaultMode: 420
+      items:
+      - key: service-ca.crt
+        path: ca.crt
+      namespace: openshift-controller-manager
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+        - name: output
+          workspace: shared-workspace
+        params:
+        - name: url
+          value: https://github.com/kelseyhightower/nocode
+      - name: buildah
+        taskRef:
+          name: buildah
+        runAfter:
+        - fetch-repository
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: sslcertdir
+          workspace: sslcertdir
+        params:
+        # This will push to the openshift internal registry
+        - name: IMAGE
+          value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(context.pipelineRun.name)

--- a/task/buildah/0.4/tests/internal-registry/internal-registry.yaml
+++ b/task/buildah/0.4/tests/internal-registry/internal-registry.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+spec:
+  selector:
+    matchLabels:
+      run: registry
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: registry
+    spec:
+      containers:
+      - name: registry
+        image: docker.io/registry:2
+        ports:
+        - containerPort: 5000
+        volumeMounts:
+          - name: sslcert
+            mountPath: /certs
+        env:
+          - name: REGISTRY_HTTP_TLS_CERTIFICATE
+            value: "/certs/ca.crt"
+          - name: REGISTRY_HTTP_TLS_KEY
+            value: "/certs/ca.key"
+          - name: REGISTRY_HTTP_SECRET
+            value: "tekton"
+      volumes:
+        - name: sslcert
+          configMap:
+            defaultMode: 420
+            items:
+            - key: ca.crt
+              path: ca.crt
+            - key: ca.key
+              path: ca.key
+            name: sslcert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+spec:
+  ports:
+  - port: 5000
+  selector:
+    run: registry

--- a/task/buildah/0.4/tests/pre-apply-task-hook.sh
+++ b/task/buildah/0.4/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+add_sidecar_secure_registry
+
+# Add git-clone
+add_task git-clone latest

--- a/task/buildah/0.4/tests/run.yaml
+++ b/task/buildah/0.4/tests/run.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildah-test-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    - name: buildah
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: sslcertdir
+        workspace: sslcertdir
+      params:
+      - name: IMAGE
+        value: registry:5000/nocode
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: sslcertdir
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+      - key: ca.crt
+        path: ca.crt
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildah-test-skip-push-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    - name: buildah
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: sslcertdir
+        workspace: sslcertdir
+      params:
+      - name: IMAGE
+        value: registry:5000/nocode
+      - name: SKIP_PUSH
+        value: "true"
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: sslcertdir
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+      - key: ca.crt
+        path: ca.crt

--- a/task/buildah/0.4/tr.yaml
+++ b/task/buildah/0.4/tr.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: image-build
+  labels:
+    app.kubernetes.io/managed-by: tekton-pipelines
+    app.kubernetes.io/version: "0.3"
+    tekton.dev/task: buildah
+  name: buildah-run
+  namespace: test
+spec:
+  serviceAccountName: pipeline
+  taskRef:
+    kind: Task
+    name: buildah
+  workspaces:
+  - configMap:
+      name: dockerfile
+    name: source


### PR DESCRIPTION
Create a new version of the buildah task to run by default as user for building images which should be much  more secure.

We are not using upstream buildah since it has some issues when running on kind, the UBI based version from catalog.redhat.com works fine on OpenShift4.x and Kind.

We are merging the two steps together since the sharing of /var/lib/containers doesn't seem to work as non root but that's should not change anything from a user pov.