### PR TITLE
Add V1 of gitea set status task

### DIFF
--- a/task/gitea-set-status/0.1/README.md
+++ b/task/gitea-set-status/0.1/README.md
@@ -1,0 +1,91 @@
+# Gitea Set Status
+
+Gitea Set Status is for updating the status of a commit. See the Gitea API documentation
+for more information about it's usage at [Gitea API](https://try.gitea.io/api/swagger).
+
+## Gitea token
+
+This task expects a secret set in the kubernetes secret `gitea`
+with a Gitea access token in the key `token`; you can easily create it on the
+command line with `kubectl` like this :
+
+```
+kubectl create secret generic gitea --from-literal token="MY_ACCESS_TOKEN"
+```
+
+## Set Status on a Commit/PR
+
+The `gitea-set-status` task uses the [commit status api](https://try.gitea.io/api/swagger)
+to mark Gitea commits with an `error`, `failure`, `pending`, `warning` or `success`
+state, which is then reflected in pull requests and commit history involving those commits.
+
+Statuses include as well a `description` and a `target_url`, to give the user
+informations about the CI statuses or a direct link to the full log.
+
+### Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitea-set-status/0.1/gitea-set-status.yaml
+```
+
+### Parameters
+
+* **REPO_FULL_NAME**: The Gitea repository full name, _e.g:_ `tektoncd/catalog`
+* **GITEA_HOST_URL**: The Gitea host, _e.g:_ `git.yourcompany.com`
+* **GITEA_HTTPS_OR_HTTP**: If we should connect with HTTP or HTTPS. Use `http` or `https` here. _default:_ `https`
+* **API_PATH_PREFIX**: The API path prefix of Gitea, _default:_ `/api/v1`
+* **SHA**: The commit SHA to set the status for _e.g_: `tektoncd/catalog`
+* **TARGET_URL**: The target URL to associate with this status. This URL will
+  be linked from the Gitea UI to allow users to easily see the source of the
+  status. For example you can link to a
+  [dashboard](https://github.com/tektoncd/dashboard) URL so users can follow a
+  Pipeline/Task run.
+* **DESCRIPTION**: A short description of the status. _e.g:_ `Building your PR`
+* **CONTEXT**: The Gitea context, A string label to differentiate this status
+  from the status of other systems. _e.g:_ `continuous-integration/tekton`
+* **STATE**: The state of the status. Can be one of the following `error`,
+  `failure`, `pending`, `warning` or `success`.
+* **GITEA_TOKEN_SECRET_NAME** \[optional\]: The name of the kubernetes secret that
+  contains the Gitea token. Default value: `gitea`.
+* **GITEA_TOKEN_SECRET_KEY** \[optional\]: The key within the kubernetes secret that
+  contains the Gitea token. Default value: `token`.
+* **IMAGE** \[optional\]: Image providing the python binary which this task uses. Default
+  value: `3.10.1-alpine3.15`, the smallest python image.
+* **SHEBANG** \[optional\]: The shebang relevant for the image. Default value: `/usrb/bin/env python`.
+
+
+### Platforms
+
+The Task can be run on any platform supporting a python image. The default image runs on `linux/386`
+`linux/amd64`, `linux/arm/v6`, `linux/arm/v7`, `linux/arm64/v8`, `linux/ppc64le`, `linux/s390x`.
+
+## Example usage
+
+This TaskRun sets a commit on Gitea to `pending` getting tested by the CI.
+
+```yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  labels:
+    tekton.dev/task: gitea-set-status
+  name: gitea-set-status-run-on-commit-bd93
+spec:
+  taskRef:
+    kind: Task
+    name: gitea-set-status
+  params:
+    - name: REPO_FULL_NAME
+      value: tektoncd/catalog
+    - name: GITEA_HOST_URL
+      value: gitea.com
+    - name: SHA
+      value: bd93869b489258cef567ccf85e7ef6bc0d6949ea
+    - name: DESCRIPTION
+      value: "Build has started"
+    - name: STATE
+      value: pending
+    - name: TARGET_URL
+      value: https://tekton/dashboard/taskrun/log
+```

--- a/task/gitea-set-status/0.1/gitea-set-status.yaml
+++ b/task/gitea-set-status/0.1/gitea-set-status.yaml
@@ -1,0 +1,162 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gitea-set-status
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: gitea
+    tekton.dev/displayName: "set gitea status"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This task will set the status of the CI job to the specified value along
+    with a link to the specified target URL where developers can follow the
+    progress of the CI job.
+
+    The `gitea-set-status` task allows external services to mark Gitea commits
+    with an `error`, `failure`, `pending`, or `success` state, which is then
+    reflected in pull requests involving those commits. Statuses include as well a
+    `description` and a `target_url`, to give the user informations about the CI
+    statuses or a direct link to the full log.
+
+  params:
+  - name: GITEA_HOST_URL
+    description: |
+      The Gitea host, e.g: git.yourcompany.com. Can include port.
+    type: string
+
+  - name: GITEA_HTTPS_OR_HTTP
+    description: |
+      If we should connect with HTTP or HTTPS. Use "http" or "https" here.
+    type: string
+    default: https
+
+  - name: API_PATH_PREFIX
+    description: |
+      The API path prefix of Gitea, default: /api/v1
+    default: "/api/v1"
+    type: string
+
+  - name: REPO_FULL_NAME
+    description: |
+      The Gitea repository full name, e.g.: tektoncd/catalog
+    type: string
+
+  - name: GITEA_TOKEN_SECRET_NAME
+    description: |
+      The name of the kubernetes secret that contains the Gitea token, default: gitea
+    type: string
+    default: gitea
+
+  - name: GITEA_TOKEN_SECRET_KEY
+    description: |
+      The key within the kubernetes secret that contains the Gitea token, default: token
+    type: string
+    default: token
+
+  - name: SHA
+    description: |
+      Commit SHA to set the status for.
+    type: string
+
+  - name: TARGET_URL
+    description: |
+      The target URL to associate with this status. This URL will be linked
+      from the Gitea UI to allow users to easily see the source of the
+      status.
+    type: string
+
+  - name: DESCRIPTION
+    description: |
+      A short description of the status.
+    type: string
+
+  - name: CONTEXT
+    description: |
+      The Gitea context, A string label to differentiate this status from
+      the status of other systems. ie: "continuous-integration/tekton"
+    default: "continuous-integration/tekton"
+    type: string
+
+  - name: STATE
+    description: |
+      The state of the status. Can be one of the following `error`,
+      `failure`, `pending`, `warning` or `success`.
+    type: string
+
+  - name: IMAGE
+    description: |
+      Image providing the python binary which this task uses.
+    type: string
+    default: python:3.10.1-alpine3.15@sha256:affe0faa14e7553fc570beec3864e74b5e36f8c19b2bb49ae8ba79c0e9e7236e
+
+  - name: SHEBANG
+    description: |
+      Python path. Depends on the image.
+    type: string
+    default: /usr/bin/env python
+
+  volumes:
+    - name: giteatoken
+      secret:
+        secretName: $(params.GITEA_TOKEN_SECRET_NAME)
+
+  steps:
+    - name: set-status
+      volumeMounts:
+        - name: giteatoken
+          mountPath: /etc/gitea-set-status
+
+      image: $(params.IMAGE)
+      script: |
+        #!$(params.SHEBANG)
+
+        """This script will set the CI status on a Gitea commit"""
+
+        import json
+        import sys
+        import http.client
+
+        gitea_token = open("/etc/gitea-set-status/$(params.GITEA_TOKEN_SECRET_KEY)", "r").read()
+
+        status_url = "$(params.API_PATH_PREFIX)" + "/repos/$(params.REPO_FULL_NAME)/" + \
+            "statuses/$(params.SHA)"
+
+        data = {
+            "state": "$(params.STATE)",
+            "target_url": "$(params.TARGET_URL)",
+            "description": "$(params.DESCRIPTION)",
+            "context": "$(params.CONTEXT)"
+        }
+        print("Sending this data to Gitea: ")
+        print(data)
+
+        authHeader = "token " + gitea_token
+
+        if "$(params.GITEA_HTTPS_OR_HTTP)" == "https":
+          conn = http.client.HTTPSConnection("$(params.GITEA_HOST_URL)")
+        else:
+          conn = http.client.HTTPConnection("$(params.GITEA_HOST_URL)")
+
+        conn.request(
+            "POST",
+            status_url,
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": authHeader,
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            })
+        resp = conn.getresponse()
+        if not str(resp.status).startswith("2"):
+            print("Error: %d" % (resp.status))
+            print(resp.read())
+            sys.exit(1)
+        else:
+            print("Gitea status '$(params.STATE)' has been set on "
+                "$(params.REPO_FULL_NAME)#$(params.SHA) ")

--- a/task/gitea-set-status/0.1/tests/fixtures/gitea-post.yaml
+++ b/task/gitea-set-status/0.1/tests/fixtures/gitea-post.yaml
@@ -1,0 +1,8 @@
+---
+headers:
+  method: POST
+  path: /api/v1/repos/tektoncd/catalog/statuses/d87daf015916c89cc65817cc9d2ccd90d3406746
+response:
+  status: 201
+  output: '{"status": 201}'
+  content-type: application/json

--- a/task/gitea-set-status/0.1/tests/pre-apply-task-hook.sh
+++ b/task/gitea-set-status/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+kubectl -n ${tns} create secret generic gitea --from-literal token="secret"

--- a/task/gitea-set-status/0.1/tests/run.yaml
+++ b/task/gitea-set-status/0.1/tests/run.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gitea-set-status
+spec:
+  tasks:
+    - name: set-status
+      taskRef:
+        name: gitea-set-status
+      params:
+        - name: GITEA_HOST_URL
+          value: "127.0.0.1:8080"
+        - name: GITEA_HTTPS_OR_HTTP
+          value: http
+        - name: REPO_FULL_NAME
+          value: tektoncd/catalog
+        - name: SHA
+          value: d87daf015916c89cc65817cc9d2ccd90d3406746
+        - name: TARGET_URL
+          value: "https://tekton.dev/"
+        - name: DESCRIPTION
+          value: "Gitea set status"
+        - name: STATE
+          value: success


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a set commit status task for Gitea.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention