### PR TITLE
Versioning Resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ The process for contributing looks like this:
 
 ## How to Contribute a new version of a Task or Pipeline
 
+To provide stability of resources, we require that resources have to be bumped
+to new versions when making changes instead of modifying existing versions. This
+ensures that the resource definition is independent of the time it was applied to
+the cluster. Changes to existing versions may be permitted only for non-functional
+parts of the resources, e.g. labels and annotations, but we try to keep that minimal.
+
 If you are planning to add a new version of a Task or Pipeline make sure to
 separate your changes from the copied task. This makes it easy for reviewers to
 review the changes and not the actual copy.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Today, we don't always bump versions of resources when updating them. The guideline has been to bump versions only when behavior changes, but it's hard to figure out when the behavior has changed (a change that could be trivial to one user could be meaningful to another).

Not bumping resource versions when changing them causes issues where the resource definition becomes dependent on the time when it was applied by the user - which causes unexpected failures as described in https://github.com/tektoncd/catalog/issues/784.

This issue also came up as an issue where users cannot depend on the Step indices because they can change: https://github.com/tektoncd/community/pull/572#pullrequestreview-836578705.

In TEP-0003, we already proposed that a policy for versioning of resources:
https://github.com/tektoncd/community/blob/main/teps/0003-tekton-catalog-organization.md#versioning-resources

In Catalog Working Group on 01/13/2022, we revisited that policy and:
- agreed to follow the versioning policy
- make it easier to bump resources (see https://github.com/tektoncd/plumbing/pull/994 - thanks @sbwsg 🎉)

This change documents the versioning policy in the contributions guide.

Fixes https://github.com/tektoncd/catalog/issues/784

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._