### PR TITLE
Add Task for Gradle builds

### DIFF
--- a/task/gradle/0.1/README.md
+++ b/task/gradle/0.1/README.md
@@ -1,0 +1,55 @@
+# Gradle
+
+This Task can be used to run a Gradle build on a gradle project.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gradle/0.1/gradle.yaml
+```
+
+## Parameters
+
+- **GRADLE_IMAGE**: The base image for gradle (_default_: `gradle:6.9.0-jdk8`)
+- **PROJECT_DIR**: The project directory containing `build.gradle` (_default_: `.`)
+- **TASKS**: The gradle tasks to run (_default_: `build`)
+
+## Workspaces
+
+- **source**: `PersistentVolumeClaim`-type so that the volume can be shared among `git-clone` and `gradle` task
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gradle-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+```
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: run-gradle-build
+spec:
+  taskRef:
+    name: gradle
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: PROJECT_DIR
+      value: my-workspace
+```

--- a/task/gradle/0.1/gradle.yaml
+++ b/task/gradle/0.1/gradle.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gradle
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/displayName: Gradle
+    tekton.dev/categories: Build Tools
+    tekton.dev/tags: build-tool
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This Task can be used to run a Gradle build.
+
+  workspaces:
+    - name: source
+      description: The workspace consisting of the gradle project.
+  params:
+    - name: GRADLE_IMAGE
+      description: Gradle base image.
+      type: string
+      default: docker.io/library/gradle:6.9-jdk8@sha256:571312a1555f5a43305e3a73505c1786c335e8acc441495a396f054194327885
+    - name: PROJECT_DIR
+      description: The directory containing build.gradle
+      type: string
+      default: "."
+    - name: TASKS
+      description: 'The gradle tasks to run (default: build)'
+      type: string
+      default: build
+  steps:
+    - name: gradle-tasks
+      image: $(params.GRADLE_IMAGE)
+      workingDir: $(workspaces.source.path)/$(params.PROJECT_DIR)
+      command:
+        - gradle
+      args:
+        - $(params.TASKS)

--- a/task/gradle/0.1/tests/pre-apply-task-hook.sh
+++ b/task/gradle/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+add_task git-clone latest

--- a/task/gradle/0.1/tests/resources.yaml
+++ b/task/gradle/0.1/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gradle-source-pvc
+spec:
+  resources:
+    requests:
+      storage: 500Mi
+  accessModes:
+    - ReadWriteOnce

--- a/task/gradle/0.1/tests/run.yaml
+++ b/task/gradle/0.1/tests/run.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gradle-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-code
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/crshnburn/simple-gradle
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: gradle-run
+      taskRef:
+        name: gradle
+      runAfter:
+        - fetch-code
+      params:
+        - name: TASKS
+          value: build
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: gradle-test-pipeline-rune
+spec:
+  pipelineRef:
+    name: gradle-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: gradle-source-pvc

--- a/task/gradle/OWNERS
+++ b/task/gradle/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- crshnburn
+reviewers:
+- crshnburn


### PR DESCRIPTION
- Create Gradle Task
- Add tests for gradle task
- Move first version into 0.1 directory

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Add a new task which runs a Gradle build which can then feed into other tasks.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
