### PR TITLE
Fix upload-pypi task version 0.2

### DIFF
--- a/task/upload-pypi/0.2/upload-pypi.yaml
+++ b/task/upload-pypi/0.2/upload-pypi.yaml
@@ -56,7 +56,7 @@ spec:
 
       python setup.py sdist bdist_wheel
   - name: upload-package
-    image: quay.io/thoth-station/twine@sha256:643ab12bb05c91db1cec6c042160466a3f258e030f5acff2a39d5b0a00442f4b #tag: latest
+    image: quay.io/thoth-station/twine:v0.0.2 #tag: v0.0.2
     workingDir: $(workspaces.source.path)
     env:
     - name: TWINE_REPOSITORY_URL


### PR DESCRIPTION
# Changes

`upload-pypi` Task version 0.2 is failing during nightly tests and
reason for the failure was that the image digest was inaccessible.

Updated the image with the tag `v0.0.2`

Closes #921 

Signed-off-by: vinamra28 <vinjain@redhat.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
