### PR TITLE
added credentials authentication with aws ecr

### DIFF
--- a/task/kaniko/0.7/README.md
+++ b/task/kaniko/0.7/README.md
@@ -1,0 +1,79 @@
+# Kaniko
+
+This Task builds source into a container image using Google's
+[`kaniko`](https://github.com/GoogleCloudPlatform/kaniko) tool.
+
+>kaniko doesn't depend on a Docker daemon and executes each command within a
+>Dockerfile completely in userspace.  This enables building container images in
+>environments that can't easily or securely run a Docker daemon, such as a
+>standard Kubernetes cluster.
+> - [Kaniko website](https://github.com/GoogleCloudPlatform/kaniko)
+
+kaniko is meant to be run as an image, `gcr.io/kaniko-project/executor:v1.5.1`. This
+makes it a perfect tool to be part of Tekton. This task can also be used with Tekton Chains to
+attest and sign the image.
+
+## Changelog
+
+- Added `IMAGE_DIGEST` to the `Results` which get populated with the digest of a built image
+- Added `IMAGE_URL` to the `Results` which get populated with the URL of a built image
+
+Both these results are needed in order for Chains to sign the image. See Chains documentation for more information: https://github.com/tektoncd/chains/blob/main/docs/config.md#chains-type-hinting
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.6/kaniko.yaml
+```
+
+## Parameters
+
+* **IMAGE**: The name (reference) of the image to build.
+* **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_ `./Dockerfile`)
+* **CONTEXT**: The build context used by Kaniko (_default:_ `./`)
+* **EXTRA_ARGS**: Additional args to pass to the Kaniko executor.
+* **BUILDER_IMAGE**: The Kaniko executor image to use (_default:_ `gcr.io/kaniko-project/executor:v1.5.1`)
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing the source to build.
+* **dockerconfig**: An optional [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing a Docker `config.json`
+
+## Results
+
+* **IMAGE_DIGEST**: The digest of the image just built.
+* **IMAGE_URL**: URL of the image just built.
+
+These results are needed by chains to sign the created image. See Chains documentation for more information: https://github.com/tektoncd/chains/blob/main/docs/config.md#chains-type-hinting
+
+## Authentication to a Container Registry
+
+kaniko builds an image and pushes it to the destination defined as a parameter.
+In order to properly authenticate to the remote container registry, it needs to
+have the proper credentials. This can achieved by using a workspace that contains
+the docker `config.json`.
+
+When using a workspace, the workspace shall be bound to a secret that embeds the
+configuration file in a key called `config.json`.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Kaniko
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-run
+spec:
+  taskRef:
+    name: kaniko
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+  - name: dockerconfig
+    secret:
+      secretName: my-secret
+```

--- a/task/kaniko/0.7/README.md
+++ b/task/kaniko/0.7/README.md
@@ -38,6 +38,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ka
 
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing the source to build.
 * **dockerconfig**: An optional [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing a Docker `config.json`
+* **aws_credentials**: An optional [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing aws credentials file to authenticate ecr (when not using instance role)
 
 ## Results
 
@@ -55,6 +56,10 @@ the docker `config.json`.
 
 When using a workspace, the workspace shall be bound to a secret that embeds the
 configuration file in a key called `config.json`.
+
+When using kaniko to push to ecr and you are not authenticating using instance role, the workspace shall be bound to a secret that embeds the credentials files.
+
+see how to create the secret [here](https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr) 
 
 ## Usage
 

--- a/task/kaniko/0.7/kaniko.yaml
+++ b/task/kaniko/0.7/kaniko.yaml
@@ -1,0 +1,65 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kaniko
+  labels:
+    app.kubernetes.io/version: "0.6"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: Image Build
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "Build and upload container image using Kaniko"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This Task builds a simple Dockerfile with kaniko and pushes to a registry.
+    This Task stores the image name and digest as results, allowing Tekton Chains to pick up
+    that an image was built & sign it.
+  params:
+    - name: IMAGE
+      description: Name (reference) of the image to build.
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      default: ./Dockerfile
+    - name: CONTEXT
+      description: The build context used by Kaniko.
+      default: ./
+    - name: EXTRA_ARGS
+      type: array
+      default: []
+    - name: BUILDER_IMAGE
+      description: The image on which builds will run (default is v1.5.1)
+      default: gcr.io/kaniko-project/executor:v1.5.1@sha256:c6166717f7fe0b7da44908c986137ecfeab21f31ec3992f6e128fff8a94be8a5
+  workspaces:
+    - name: source
+      description: Holds the context and Dockerfile
+    - name: dockerconfig
+      description: Includes a docker `config.json`
+      optional: true
+      mountPath: /kaniko/.docker
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built.
+    - name: IMAGE_URL
+      description: URL of the image just built.
+  steps:
+    - name: build-and-push
+      workingDir: $(workspaces.source.path)
+      image: $(params.BUILDER_IMAGE)
+      args:
+        - $(params.EXTRA_ARGS)
+        - --dockerfile=$(params.DOCKERFILE)
+        - --context=$(workspaces.source.path)/$(params.CONTEXT) # The user does not need to care the workspace and the source.
+        - --destination=$(params.IMAGE)
+        - --digest-file=$(results.IMAGE_DIGEST.path)
+      # kaniko assumes it is running as root, which means this example fails on platforms
+      # that default to run containers as random uid (like OpenShift). Adding this securityContext
+      # makes it explicit that it needs to run as root.
+      securityContext:
+        runAsUser: 0
+    - name: write-url
+      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      script: |
+        set -e
+        image="$(params.IMAGE)"
+        echo "${image}" | tee "$(results.IMAGE_URL.path)"

--- a/task/kaniko/0.7/kaniko.yaml
+++ b/task/kaniko/0.7/kaniko.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: kaniko
   labels:
-    app.kubernetes.io/version: "0.6"
+    app.kubernetes.io/version: "0.7"
   annotations:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/categories: Image Build
@@ -37,6 +37,10 @@ spec:
       description: Includes a docker `config.json`
       optional: true
       mountPath: /kaniko/.docker
+    - name: aws_credentials
+      description: Includes aws credentials file, when using credentials to authenticate ecr
+      optional: true
+      mountPath: /root/.aws/
   results:
     - name: IMAGE_DIGEST
       description: Digest of the image just built.

--- a/task/kaniko/0.7/tests/pre-apply-task-hook.sh
+++ b/task/kaniko/0.7/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests withouth having to go to an external registry.
+add_sidecar_registry ${TMPF}
+
+# Add git-clone
+add_task git-clone latest

--- a/task/kaniko/0.7/tests/resources.yaml
+++ b/task/kaniko/0.7/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kaniko-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/kaniko/0.7/tests/run.yaml
+++ b/task/kaniko/0.7/tests/run.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kaniko-test-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  params:
+  - name: image
+    description: reference of the image to build
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: kaniko
+    taskRef:
+      name: kaniko
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: IMAGE
+      value: $(params.image)
+    - name: EXTRA_ARGS
+      value:
+        - --skip-tls-verify
+  - name: verify-digest
+    runAfter:
+    - kaniko
+    params:
+    - name: digest
+      value: $(tasks.kaniko.results.IMAGE_DIGEST)
+    taskSpec:
+      params:
+      - name: digest
+      steps:
+      - name: bash
+        image: ubuntu
+        script: |
+          echo $(params.digest)
+          case .$(params.digest) in
+            ".sha"*) exit 0 ;;
+            *)       echo "Digest value is not correct" && exit 1 ;;
+          esac
+  - name: verify-url
+    runAfter:
+    - kaniko
+    params:
+    - name: url
+      value: $(tasks.kaniko.results.IMAGE_URL)
+    taskSpec:
+      params:
+      - name: url
+      steps:
+      - name: bash
+        image: ubuntu
+        script: |
+          echo $(params.url)
+          case .$(params.url) in
+            *"/kaniko-nocode") exit 0 ;;
+            *)       echo "URL value is not correct" && exit 1 ;;
+          esac
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: kaniko-test-pipeline-run
+spec:
+  pipelineRef:
+    name: kaniko-test-pipeline
+  params:
+  - name: image
+    value: localhost:5000/kaniko-nocode
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: kaniko-source-pvc


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Added option to use aws credentials when pushing to ecr 
as described here:
https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr

The Current task didn't support in the additional secret that includes the aws credentials 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
