### PR TITLE
gcs-upload v0.2 do not delete missing files by default

### DIFF
--- a/task/gcs-upload/0.2/README.md
+++ b/task/gcs-upload/0.2/README.md
@@ -8,7 +8,6 @@ are intended as its replacement. This is part of our plan to [offer replacement
 as well as
 [document those replacements](https://github.com/tektoncd/pipeline/issues/1369).
 
-
 ## `gcs-upload`
 
 A `Task` that uploads files or directories from a Workspace to a GCS bucket.
@@ -23,6 +22,9 @@ A `Task` that uploads files or directories from a Workspace to a GCS bucket.
 
 * **path**: The path to files or directories relative to the source workspace that you'd like to upload. (_required_)
 * **location**: The address (including "gs://") where you'd like to upload files to. (_required_)
+* **deleteExtraFiles**: When "true", delete extra files under location not found under path.
+  NOTE: this option can delete data quickly if you specify the wrong source/destination combination.
+  "BE CAREFUL WHEN USING THIS OPTION!". (_default_: "false")
 * **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
 
 ## Platforms
@@ -30,7 +32,6 @@ A `Task` that uploads files or directories from a Workspace to a GCS bucket.
 The Task can be run on `linux/amd64` platform.
 
 ## Usage
-
 
 ### `gcs-upload`
 

--- a/task/gcs-upload/0.2/README.md
+++ b/task/gcs-upload/0.2/README.md
@@ -1,0 +1,62 @@
+# Google Cloud Storage Tasks
+
+These `Tasks` are for copying to and from GCS buckets from Pipelines.
+
+These `Tasks` do a similar job to the `GCS` `PipelineResource` and
+are intended as its replacement. This is part of our plan to [offer replacement
+`Tasks` for Pipeline Resources](https://github.com/tektoncd/catalog/issues/95)
+as well as
+[document those replacements](https://github.com/tektoncd/pipeline/issues/1369).
+
+
+## `gcs-upload`
+
+A `Task` that uploads files or directories from a Workspace to a GCS bucket.
+
+### Workspaces
+
+* **credentials**: A workspace that contains a service account key as a JSON file.
+    This workspace should be populated from a Secret in your TaskRuns and PipelineRuns.
+* **source**: A workspace where files will be uploaded from.
+
+### Parameters
+
+* **path**: The path to files or directories relative to the source workspace that you'd like to upload. (_required_)
+* **location**: The address (including "gs://") where you'd like to upload files to. (_required_)
+* **serviceAccountPath**: The path to the service account credential file in your credentials workspace. (_default_: "service\_account.json")
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+
+### `gcs-upload`
+
+This TaskRun uses the gcs-upload Task to upload a file from a ConfigMap.
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test-input-data
+data:
+  test_file.txt: "Hello, world!"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: upload-configmap-file-to-gcs
+spec:
+  taskRef:
+    name: gcs-upload
+  workspaces:
+  - name: credentials
+    secret:
+      secretName: my-gcs-credentials
+      defaultMode: 0400
+  - name: source
+    configMap:
+      name: test-input-data
+```

--- a/task/gcs-upload/0.2/gcs-upload.yaml
+++ b/task/gcs-upload/0.2/gcs-upload.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: gcs-upload
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Cloud, Storage
@@ -28,19 +28,34 @@ spec:
   - name: location
     description: The address (including "gs://") where you'd like to upload files to.
     type: string
+  - name: deleteExtraFiles
+    description: |
+      When "true", delete extra files under location not found under path.
+      By default extra files are not deleted.
+
+      NOTE: this option can delete data quickly if you specify the wrong
+      source/destination combination. "BE CAREFUL WHEN USING THIS OPTION!".
+    default: "false"
+    type: string
   - name: serviceAccountPath
     description: The path inside the credentials workspace to the GOOGLE_APPLICATION_CREDENTIALS key file.
     type: string
     default: service_account.json
   steps:
   - name: upload
-    image: gcr.io/google.com/cloudsdktool/cloud-sdk:310.0.0@sha256:cb03669fcdb9191d55a6200f2911fff3baec0b8c39b156d95b68aabe975ac506 #tag: 310.0.0
+    env:
+      - name: CRED_PATH
+        value: "$(workspaces.credentials.path)/$(params.serviceAccountPath)"
+      - name: SOURCE
+        value: "$(workspaces.source.path)/$(params.path)"
+      - name: LOCATION
+        value: "$(params.location)"
+      - name: DELETE_EXTRA_FILES
+        value: $(params.deleteExtraFiles)
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:379.0.0-slim@sha256:d844877c7aaa06a0072979230c68417ddb0f27087277f29747c7169d6ed0d2b9 #tag: 379.0.0-slim
     script: |
       #!/usr/bin/env bash
       set -xe
-
-      CRED_PATH="$(workspaces.credentials.path)/$(params.serviceAccountPath)"
-      SOURCE="$(workspaces.source.path)/$(params.path)"
 
       if [[ -f "$CRED_PATH" ]]; then
         GOOGLE_APPLICATION_CREDENTIALS="$CRED_PATH"
@@ -48,11 +63,15 @@ spec:
 
       if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
         echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
-        gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+        gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
       fi
 
+      RSYNC_PARAMS=""
       if [[ -d "$SOURCE" ]]; then
-        gsutil -m rsync -d -r "$SOURCE" "$(params.location)"
+        if [[ "$DELETE_EXTRA_FILES" == "true" ]]; then
+          RSYNC_PARAMS="-d"
+        fi
+        gsutil -m rsync ${RSYNC_PARAMS} -r "${SOURCE}" "${LOCATION}"
       else
-        gsutil cp "$SOURCE" "$(params.location)"
+        gsutil cp "${SOURCE}" "${LOCATION}"
       fi

--- a/task/gcs-upload/0.2/gcs-upload.yaml
+++ b/task/gcs-upload/0.2/gcs-upload.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gcs-upload
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Cloud, Storage
+    tekton.dev/tags: cloud, gcs
+    tekton.dev/displayName: "Upload to GCS"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    A Task that uploads a GCS bucket.
+
+    This task uploads files or directories from a Workspace to a GCS bucket.
+
+  workspaces:
+  - name: credentials
+    description: A secret with a service account key to use as GOOGLE_APPLICATION_CREDENTIALS.
+  - name: source
+    description: A workspace where files will be uploaded from.
+  params:
+  - name: path
+    description: The path to files or directories relative to the source workspace that you'd like to upload.
+    type: string
+  - name: location
+    description: The address (including "gs://") where you'd like to upload files to.
+    type: string
+  - name: serviceAccountPath
+    description: The path inside the credentials workspace to the GOOGLE_APPLICATION_CREDENTIALS key file.
+    type: string
+    default: service_account.json
+  steps:
+  - name: upload
+    image: gcr.io/google.com/cloudsdktool/cloud-sdk:310.0.0@sha256:cb03669fcdb9191d55a6200f2911fff3baec0b8c39b156d95b68aabe975ac506 #tag: 310.0.0
+    script: |
+      #!/usr/bin/env bash
+      set -xe
+
+      CRED_PATH="$(workspaces.credentials.path)/$(params.serviceAccountPath)"
+      SOURCE="$(workspaces.source.path)/$(params.path)"
+
+      if [[ -f "$CRED_PATH" ]]; then
+        GOOGLE_APPLICATION_CREDENTIALS="$CRED_PATH"
+      fi
+
+      if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+        echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+        gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+      fi
+
+      if [[ -d "$SOURCE" ]]; then
+        gsutil -m rsync -d -r "$SOURCE" "$(params.location)"
+      else
+        gsutil cp "$SOURCE" "$(params.location)"
+      fi

--- a/task/gcs-upload/0.2/samples/gcs-sample.yaml
+++ b/task/gcs-upload/0.2/samples/gcs-sample.yaml
@@ -1,0 +1,124 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: gcs-triggertemplate
+spec:
+  params:
+    - name: pvc-name
+    - name: project-name
+    - name: secret-name
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        name: gcs-pr-$(uid)
+      spec:
+        workspaces:
+        - name: data
+          persistentVolumeClaim:
+            claimName: $(params.pvc-name)
+        - name: credentials
+          secret:
+            secretName: $(params.secret-name)
+        pipelineSpec:
+          workspaces:
+          - name: data
+          - name: credentials
+          tasks:
+          - name: gcs-create-bucket
+            taskRef:
+              name: gcs-create-bucket
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            params:
+            - name: bucketName
+              value: gs://tekton-test-bucket-$(uid)
+            - name: project
+              value: $(params.project-name)
+          - name: create-data
+            runAfter: [gcs-create-bucket]
+            taskSpec:
+              workspaces:
+              - name: data
+              steps:
+              - name: write-data
+                image: ubuntu
+                script: |
+                  #!/usr/bin/env bash
+                  set -xe
+                  mkdir -p $(workspaces.data.path)/$(uid)/test_data/
+                  echo "Test data $(uid)" > $(workspaces.data.path)/$(uid)/test_data/test.txt
+            workspaces:
+            - name: data
+              workspace: data
+          - name: gcs-upload
+            taskRef:
+              name: gcs-upload
+            runAfter: [create-data]
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            - name: source
+              workspace: data
+            params:
+            - name: path
+              value: $(uid)
+            - name: location
+              value: gs://tekton-test-bucket-$(uid)
+            - name: serviceAccountPath
+              value: service_account.json
+          - name: gcs-download
+            taskRef:
+              name: gcs-download
+            runAfter: [gcs-upload]
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            - name: output
+              workspace: data
+            params:
+            - name: path
+              value: download-$(uid)
+            - name: location
+              value: gs://tekton-test-bucket-$(uid)
+            - name: typeDir
+              value: "true"
+            - name: serviceAccountPath
+              value: service_account.json
+          - name: verify-data
+            runAfter: [gcs-download]
+            workspaces:
+            - name: data
+              workspace: data
+            taskSpec:
+              workspaces:
+              - name: data
+              steps:
+              - image: ubuntu
+                script: |
+                  #!/usr/bin/env bash
+                  set -xe
+                  cat $(workspaces.data.path)/download-$(uid)/test_data/test.txt | grep "Test data $(uid)"
+          - name: delete-bucket
+            taskRef:
+              name: gcs-delete-bucket
+            runAfter: [gcs-download]
+            workspaces:
+            - name: credentials
+              workspace: credentials
+            params:
+            - name: bucketName
+              value: gs://tekton-test-bucket-$(uid)
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gcs-test-storage
+spec:
+  resources:
+    requests:
+      storage: 16Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The gcs-upload task v0.1, when dealing with folders, uses the "-d"
option by default, which deletes remote files by default. This is
a relatively dangerous choice of default, and it's safer to make
that as an opt-in, as it may result in deletion of a lot of remote
files by accident.

V0.2 has a new parameter "deleteExtraFiles" which corresponds to
gsutil "-d" flag. deleteExtraFiles defaults to false, making the
default behaviour of the task different from v0.1.

V0.2 replaces parameters in the script with environment variables
for security as recommended in the catalog best practices.

The cloud-sdk image version has been updated to 390.0.0-slim which
is newer, ~60% smaller than the current image and includes gsutil.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
