### PR TITLE
added -n to IMAGE_URL result to avoid adding a line feed

### DIFF
--- a/task/kaniko/0.6/kaniko.yaml
+++ b/task/kaniko/0.6/kaniko.yaml
@@ -62,4 +62,4 @@ spec:
       script: |
         set -e
         image="$(params.IMAGE)"
-        echo "${image}" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${image}" | tee "$(results.IMAGE_URL.path)"


### PR DESCRIPTION
Added -n to the echo command used to export the IMAGE_URL result in order to avoid to add a new line after the image url that caused gke-deploy in a pipeline to fail with a "could not parse reference" when IMAGE_URL result is used as an argument to the --image parameter in gke-deploy
