### PR TITLE
Update buildah to v1.23.3

### DIFF
--- a/task/buildah/0.3/README.md
+++ b/task/buildah/0.3/README.md
@@ -17,7 +17,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/bu
 
 * **IMAGE**: The name (reference) of the image to build.
 * **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
-  note below.  (_default:_ quay.io/buildah/stable:v1.18.0)
+  note below.  (_default:_ quay.io/buildah/stable:v1.23.3)
 * **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
   `./Dockerfile`)
 * **CONTEXT**: Path to the directory to use as context (_default:_

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -26,7 +26,7 @@ spec:
     description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
-    default: quay.io/buildah/stable:v1.18.0
+    default: quay.io/buildah/stable:v1.23.3
   - name: STORAGE_DRIVER
     description: Set buildah storage driver
     default: overlay


### PR DESCRIPTION
buildah v1.18.0 is pretty old - update to the latest v1.23.3. This fixes a few security advisories in buildah and also from its dependencies (I'm not sure if they affect buildah when used in Tekton).