### PR TITLE
Fix pypiserver in tests of upload-pypi task

### DIFF
--- a/task/upload-pypi/0.2/tests/pre-apply-task-hook.sh
+++ b/task/upload-pypi/0.2/tests/pre-apply-task-hook.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Add pypiserver sidecar
-add_sidecars ${TMPF} '{"image":"pypiserver/pypiserver:latest", "name": "pypiserver", "args": ["-P .", "-a ."]}'
+add_sidecars ${TMPF} '{"image":"pypiserver/pypiserver:v1.4.2", "name": "pypiserver", "args": ["-P .", "-a ."]}'
 
 # Add git-clone
 add_task git-clone latest


### PR DESCRIPTION
# Changes

Currently in the tests of upload-pypi task, pypiserver was pointing to
latest and there are some recent changes made there which is breaking
the test here. Pinning the version to v1.4.2

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
