### PR TITLE
Use RBAC v1 instead of v1beta1 in tasks' tests

### DIFF
--- a/task/ansible-runner/0.1/tests/resources.yaml
+++ b/task/ansible-runner/0.1/tests/resources.yaml
@@ -34,7 +34,7 @@ rules:
     resources: ['services', 'revisions', 'routes']
     verbs: ['get', 'list', 'create', 'update', 'delete', 'patch', 'watch']
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ansible-deployer-binding

--- a/task/blue-green-deploy/0.1/tests/resources.yaml
+++ b/task/blue-green-deploy/0.1/tests/resources.yaml
@@ -23,7 +23,7 @@ rules:
     resources: ["*"]
     verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: blue-green-binding

--- a/task/kubernetes-actions/0.2/tests/resources.yaml
+++ b/task/kubernetes-actions/0.2/tests/resources.yaml
@@ -23,7 +23,7 @@ rules:
     resources: ["*"]
     verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-actions-binding

--- a/task/tkn/0.2/tests/resources.yaml
+++ b/task/tkn/0.2/tests/resources.yaml
@@ -15,7 +15,7 @@ rules:
     resources: ["*"]
     verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tkn-binding

--- a/task/tkn/0.3/tests/resources.yaml
+++ b/task/tkn/0.3/tests/resources.yaml
@@ -15,7 +15,7 @@ rules:
     resources: ["*"]
     verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tkn-binding


### PR DESCRIPTION
# Changes

RBAC v1beta1 was deprecated in kubernetes and was removed in recent
versions.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
