### PR TITLE
Use Multi-arch gradle image for ppc64le, s390x gradle tasks

### DIFF
--- a/test/linux-ppc64le.sh
+++ b/test/linux-ppc64le.sh
@@ -34,5 +34,8 @@ find task -name *registry*.yaml | xargs -I{} yq eval '(..|select(.kind?=="Deploy
 echo "Change GOARCH parameter value"
 find task/golang*/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "GOARCH","value": env(GOARCH)}' -i {}
 
+echo "Add extra GRADLE_IMAGE value"
+find task/gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "GRADLE_IMAGE","value": env(BUILDER_IMAGE)}' -i {}
+
 echo "Add extra BUILDER_IMAGE parameter"
 find task/jib-gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "BUILDER_IMAGE","value": env(BUILDER_IMAGE)}' -i {}

--- a/test/linux-s390x.sh
+++ b/test/linux-s390x.sh
@@ -34,5 +34,8 @@ find task -name *registry*.yaml | xargs -I{} yq eval '(..|select(.kind?=="Deploy
 echo "Change GOARCH parameter value"
 find task/golang*/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "GOARCH","value": env(GOARCH)}' -i {}
 
+echo "Add extra GRADLE_IMAGE value"
+find task/gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "GRADLE_IMAGE","value": env(BUILDER_IMAGE)}' -i {}
+
 echo "Add extra BUILDER_IMAGE parameter"
 find task/jib-gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "BUILDER_IMAGE","value": env(BUILDER_IMAGE)}' -i {}


### PR DESCRIPTION
This PR contains Multi-arch gradle image values for ppc64le, s390x platforms. 
This PR fixes https://github.com/tektoncd/catalog/issues/987
# Changes

Script contains

- Gradle image values required for ppc64le,s390x platform

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
