### PR TITLE
Update git-clone task to fix custom CAs for https and bump to 0.7 version

### DIFF
--- a/task/git-clone/0.7/README.md
+++ b/task/git-clone/0.7/README.md
@@ -1,0 +1,281 @@
+# `git-clone`
+
+**Please Note: this Task is only compatible with Tekton Pipelines versions 0.29.0 and greater!**
+
+This `Task` has two required inputs:
+
+1. The URL of a git repo to clone provided with the `url` param.
+2. A Workspace called `output`.
+
+The `git-clone` `Task` will clone a repo from the provided `url` into the
+`output` Workspace. By default the repo will be cloned into the root of
+your Workspace. You can clone into a subdirectory by setting this `Task`'s
+`subdirectory` param. If the directory where the repo will be cloned is
+already populated then by default the contents will be deleted before the
+clone takes place. This behaviour can be disabled by setting the
+`deleteExisting` param to `"false"`.
+
+## Workspaces
+
+* **output**: A workspace for this Task to fetch the git repository in to.
+* **ssh-directory**: An optional workspace to provide SSH credentials. At
+  minimum this should include a private key but can also include other common
+  files from `.ssh` including `config` and `known_hosts`. It is **strongly**
+  recommended that this workspace be bound to a Kubernetes `Secret`.
+
+* **ssl-ca-directory**: An optional workspace to provide custom CA certificates.
+  Like the /etc/ssl/certs path this directory can have any pem or cert files,
+  this uses libcurl ssl capath directive. See this SO answer here
+  https://stackoverflow.com/a/9880236 on how it works.
+
+* **basic-auth**: An optional workspace containing `.gitconfig` and
+  `.git-credentials` files. This allows username/password/access token to be
+  provided for basic auth.
+
+  It is **strongly** recommended that this workspace be bound to a Kubernetes
+  `Secret`. For details on the correct format of the files in this Workspace
+  see [Using basic-auth Credentials](#using-basic-auth-credentials) below.
+
+  **Note**: Settings provided as part of a `.gitconfig` file can affect the
+  execution of `git` in ways that conflict with the parameters of this Task.
+  For example, specifying proxy settings in `.gitconfig` could conflict with
+  the `httpProxy` and `httpsProxy` parameters this Task provides. Nothing
+  prevents you setting these parameters but it is not advised.
+
+## Parameters
+
+* **url**: Repository URL to clone from. (_required_)
+* **revision**: Revision to checkout. (branch, tag, sha, ref, etc...) (_default_: "")
+* **refspec**: Refspec to fetch before checking out revision. (_default_:"")
+* **submodules**: Initialize and fetch git submodules. (_default_: true)
+* **depth**: Perform a shallow clone, fetching only the most recent N commits. (_default_: 1)
+* **sslVerify**: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote. (_default_: true)
+* **crtFileName**: If `sslVerify` is **true** and `ssl-ca-directory` workspace is given then set `crtFileName` if mounted file name is different than `ca-bundle.crt`. (_default_: "ca-bundle.crt")
+* **subdirectory**: Subdirectory inside the `output` workspace to clone the repo into. (_default:_ "")
+* **deleteExisting**: Clean out the contents of the destination directory if it already exists before cloning. (_default_: true)
+* **httpProxy**: HTTP proxy server for non-SSL requests. (_default_: "")
+* **httpsProxy**: HTTPS proxy server for SSL requests. (_default_: "")
+* **noProxy**: Opt out of proxying HTTP/HTTPS requests. (_default_: "")
+* **verbose**: Log the commands that are executed during `git-clone`'s operation. (_default_: true)
+* **sparseCheckoutDirectories**: Which directories to match or exclude when performing a sparse checkout (_default_: "")
+* **gitInitImage**: The image providing the git-init binary that this Task runs. (_default_: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:TODO")
+* **userHome**: The user's home directory. Set this explicitly if you are running the image as a non-root user. (_default_: "/tekton/home")
+
+## Results
+
+* **commit**: The precise commit SHA that was fetched by this Task
+* **url**: The precise URL that was fetched by this Task
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64`, and `linux/ppc64le` platforms.
+
+## Usage
+
+If the `revision` is not provided in the param of the taskrun
+then it will auto-detect the branch as specified by the `default`
+in the respective git repository.
+
+The following pipelines demonstrate usage of the git-clone Task:
+
+- [Cloning a branch](./samples/git-clone-checking-out-a-branch.yaml)
+- [Checking out a specific git commit](./samples/git-clone-checking-out-a-commit.yaml)
+- [Checking out a git tag and using the "commit" Task Result](./samples/using-git-clone-result.yaml)
+
+## Cloning Private Repositories
+
+This Task supports fetching private repositories. There are three ways to
+authenticate:
+
+1. The simplest approach is to bind an `ssh-directory` workspace to this
+Task. The workspace should contain private keys (e.g. `id_rsa`), `config`
+and `known_hosts` files - anything you need to interact with your git remote
+via SSH. It's **strongly** recommended that you use Kubernetes `Secrets` to
+hold your credentials and bind to this workspace.
+
+    In a TaskRun that would look something like this:
+
+    ```yaml
+    kind: TaskRun
+    spec:
+      workspaces:
+      - name: ssh-directory
+        secret:
+          secretName: my-ssh-credentials
+    ```
+
+    And in a Pipeline and PipelineRun it would look like this:
+
+    ```yaml
+    kind: Pipeline
+    spec:
+      workspaces:
+      - name: ssh-creds
+      # ...
+      tasks:
+      - name: fetch-source
+        taskRef:
+          name: git-clone
+        workspaces:
+        - name: ssh-directory
+          workspace: ssh-creds
+      # ...
+    ---
+    kind: PipelineRun
+    spec:
+      workspaces:
+      - name: ssh-creds
+        secret:
+          secretName: my-ssh-credentials
+      # ...
+    ```
+
+    The `Secret` would appear the same in both cases - structured like a `.ssh`
+    directory:
+
+    ```yaml
+    kind: Secret
+    apiVersion: v1
+    metadata:
+      name: my-ssh-credentials
+    data:
+      id_rsa: # ... base64-encoded private key ...
+      known_hosts: # ... base64-encoded known_hosts file ...
+      config: # ... base64-encoded ssh config file ...
+    ```
+
+    Including `known_hosts` is optional but strongly recommended. Without it
+    the `git-clone` Task will blindly accept the remote server's identity.
+
+2. Use Tekton Pipelines' built-in credentials support as [documented in
+Pipelines' auth.md](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md).
+
+3. Another approach is to bind an `ssl-ca-directory` workspace to this
+Task. The workspace should contain crt keys (e.g. `ca-bundle.crt`)files - anything you need to interact with your git remote
+via custom CA . It's **strongly** recommended that you use Kubernetes `Secrets` to
+hold your credentials and bind to this workspace.
+
+    In a TaskRun that would look something like this:
+
+    ```yaml
+    kind: TaskRun
+    spec:
+      workspaces:
+      - name: ssl-ca-directory
+        secret:
+          secretName: my-ssl-credentials
+    ```
+
+    And in a Pipeline and PipelineRun it would look like this:
+
+    ```yaml
+    kind: Pipeline
+    spec:
+      workspaces:
+      - name: ssl-creds
+      # ...
+      tasks:
+      - name: fetch-source
+        taskRef:
+          name: git-clone
+        workspaces:
+        - name: ssl-ca-directory
+          workspace: ssl-creds
+      # ...
+    ---
+    kind: PipelineRun
+    spec:
+      workspaces:
+      - name: ssl-creds
+        secret:
+          secretName: my-ssl-credentials
+      # ...
+    ```
+
+    The `Secret` would appear like below:
+
+    ```yaml
+    kind: Secret
+    apiVersion: v1
+    metadata:
+      name: my-ssl-credentials
+    data:
+      ca-bundle.crt: # ... base64-encoded crt ...  # If key/filename is other than ca-bundle.crt then set crtFileName param as explained under Parameters section
+    ```
+
+## Running as a Non-Root User
+
+The `git-init` image that this Task utilizes offers a built in nonroot
+user. In combination with support from other Tasks this allows your
+Pipelines to run without needing root permissions. There are some extra
+steps you'll need to take for this to work:
+
+- In the security context for the Task make sure you're using UID 65532.
+
+    In a TaskRun that looks like this:
+
+    ```yaml
+    kind: TaskRun
+    spec:
+      podTemplate:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+    ```
+
+    And in a PipelineRun it looks like this:
+
+    ```yaml
+    kind: PipelineRun
+    spec:
+      taskRunSpecs:
+      - pipelineTaskName: footask # ...your git-clone PipelineTask name...
+        taskPodTemplate:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+    ```
+
+- Make sure to provide the `userHome` param and set it to nonroot's
+home directory:
+
+    ```yaml
+    params:
+    - name: userHome
+      value: /home/nonroot
+    ```
+
+Once these two modifications are in effect you should now see your
+`git-clone` Task run as nonroot. The files cloned on to the `output`
+workspace will end up owned by user 65532.
+
+## Using basic-auth Credentials
+
+**Note**: It is strongly advised that you use `ssh` credentials when the option
+is available to you before using basic auth. You can use generate a short
+lived token from WebVCS platforms (Github, Gitlab, Bitbucket etc..) to be use
+as password and generally be able to use `git` as the username.
+On bitbucket server the token may have a / into it so you would need
+to urlquote them before in the `Secret`, see this stackoverflow answer :
+
+https://stackoverflow.com/a/24719496 
+
+To support basic-auth this Task exposes an optional `basic-auth` Workspace.
+The bound Workspace must contain a `.gitconfig` and `.git-credentials` file.
+Any other files on this Workspace are ignored. A typical `Secret` containing
+these credentials looks as follows:
+
+```yaml
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-basic-auth-secret
+type: Opaque
+stringData:
+  .gitconfig: |
+    [credential "https://<hostname>"]
+      helper = store
+  .git-credentials: |
+    https://<user>:<pass>@<hostname>
+```
+

--- a/task/git-clone/0.7/git-clone.yaml
+++ b/task/git-clone/0.7/git-clone.yaml
@@ -1,0 +1,236 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+  labels:
+    app.kubernetes.io/version: "0.7"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.29.0"
+    tekton.dev/categories: Git
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    These Tasks are Git tasks to work with repositories used by other tasks
+    in your Pipeline.
+
+    The git-clone Task will clone a repo from the provided url into the
+    output Workspace. By default the repo will be cloned into the root of
+    your Workspace. You can clone into a subdirectory by setting this Task's
+    subdirectory param. This Task also supports sparse checkouts. To perform
+    a sparse checkout, pass a list of comma separated directory patterns to
+    this Task's sparseCheckoutDirectories param.
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this Workspace.
+    - name: ssh-directory
+      optional: true
+      description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+    - name: basic-auth
+      optional: true
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+    - name: ssl-ca-directory
+      optional: true
+      description: |
+        A workspace containing CA certificates, this will be used by Git to
+        verify the peer with when fetching or pushing over HTTPS.
+  params:
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: refspec
+      description: Refspec to fetch before checking out revision.
+      default: ""
+    - name: submodules
+      description: Initialize and fetch git submodules.
+      type: string
+      default: "true"
+    - name: depth
+      description: Perform a shallow clone, fetching only the most recent N commits.
+      type: string
+      default: "1"
+    - name: sslVerify
+      description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+      type: string
+      default: "true"
+    - name: crtFileName
+      description: file name of mounted crt using ssl-ca-directory workspace. default value is ca-bundle.crt.
+      type: string
+      default: "ca-bundle.crt"
+    - name: subdirectory
+      description: Subdirectory inside the `output` Workspace to clone the repo into.
+      type: string
+      default: ""
+    - name: sparseCheckoutDirectories
+      description: Define the directory patterns to match or exclude when performing a sparse checkout.
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: Clean out the contents of the destination directory if it already exists before cloning.
+      type: string
+      default: "true"
+    - name: httpProxy
+      description: HTTP proxy server for non-SSL requests.
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: HTTPS proxy server for SSL requests.
+      type: string
+      default: ""
+    - name: noProxy
+      description: Opt out of proxying HTTP/HTTPS requests.
+      type: string
+      default: ""
+    - name: verbose
+      description: Log the commands that are executed during `git-clone`'s operation.
+      type: string
+      default: "true"
+    - name: gitInitImage
+      description: The image providing the git-init binary that this Task runs.
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.29.0"
+    - name: userHome
+      description: |
+        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
+        the gitInitImage param with an image containing custom user configuration.
+      type: string
+      default: "/tekton/home"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: url
+      description: The precise URL that was fetched by this Task.
+  steps:
+    - name: clone
+      image: "$(params.gitInitImage)"
+      env:
+      - name: HOME
+        value: "$(params.userHome)"
+      - name: PARAM_URL
+        value: $(params.url)
+      - name: PARAM_REVISION
+        value: $(params.revision)
+      - name: PARAM_REFSPEC
+        value: $(params.refspec)
+      - name: PARAM_SUBMODULES
+        value: $(params.submodules)
+      - name: PARAM_DEPTH
+        value: $(params.depth)
+      - name: PARAM_SSL_VERIFY
+        value: $(params.sslVerify)
+      - name: PARAM_CRT_FILENAME
+        value: $(params.crtFileName)
+      - name: PARAM_SUBDIRECTORY
+        value: $(params.subdirectory)
+      - name: PARAM_DELETE_EXISTING
+        value: $(params.deleteExisting)
+      - name: PARAM_HTTP_PROXY
+        value: $(params.httpProxy)
+      - name: PARAM_HTTPS_PROXY
+        value: $(params.httpsProxy)
+      - name: PARAM_NO_PROXY
+        value: $(params.noProxy)
+      - name: PARAM_VERBOSE
+        value: $(params.verbose)
+      - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+        value: $(params.sparseCheckoutDirectories)
+      - name: PARAM_USER_HOME
+        value: $(params.userHome)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
+      - name: WORKSPACE_SSH_DIRECTORY_BOUND
+        value: $(workspaces.ssh-directory.bound)
+      - name: WORKSPACE_SSH_DIRECTORY_PATH
+        value: $(workspaces.ssh-directory.path)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+        value: $(workspaces.basic-auth.bound)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+        value: $(workspaces.basic-auth.path)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_BOUND
+        value: $(workspaces.ssl-ca-directory.bound)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
+        value: $(workspaces.ssl-ca-directory.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ] ; then
+          set -x
+        fi
+
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        if [ "${WORKSPACE_SSL_CA_DIRECTORY_BOUND}" = "true" ] ; then
+           export GIT_SSL_CAPATH="${WORKSPACE_SSL_CA_DIRECTORY_PATH}"
+           if [ "${PARAM_CRT_FILENAME}" != "" ] ; then
+              export GIT_SSL_CAINFO="${WORKSPACE_SSL_CA_DIRECTORY_PATH}/${PARAM_CRT_FILENAME}"
+           fi
+        fi
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+          # or the root of a mounted volume.
+          if [ -d "${CHECKOUT_DIR}" ] ; then
+            # Delete non-hidden files and directories
+            rm -rf "${CHECKOUT_DIR:?}"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "${CHECKOUT_DIR}"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "${CHECKOUT_DIR}"/..?*
+          fi
+        }
+
+        if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+          cleandir
+        fi
+
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+        /ko-app/git-init \
+          -url="${PARAM_URL}" \
+          -revision="${PARAM_REVISION}" \
+          -refspec="${PARAM_REFSPEC}" \
+          -path="${CHECKOUT_DIR}" \
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth="${PARAM_DEPTH}" \
+          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "${PARAM_URL}" > "$(results.url.path)"

--- a/task/git-clone/0.7/samples/git-clone-checking-out-a-branch.yaml
+++ b/task/git-clone/0.7/samples/git-clone-checking-out-a-branch.yaml
@@ -1,0 +1,75 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cat-branch-readme
+spec:
+  description: |
+    cat-branch-readme takes a git repository and a branch name and
+    prints the README.md file from that branch. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a branch
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: branch-name
+    type: string
+    description: The git branch to clone.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the repo's README.md file to be read.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.branch-name)
+  - name: cat-readme
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          cat $(workspaces.source.path)/README.md
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-checking-out-a-branch
+spec:
+  pipelineRef:
+    name: cat-branch-readme
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: branch-name
+    value: release-v0.12.x

--- a/task/git-clone/0.7/samples/git-clone-checking-out-a-commit.yaml
+++ b/task/git-clone/0.7/samples/git-clone-checking-out-a-commit.yaml
@@ -1,0 +1,121 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: checking-out-a-revision
+spec:
+  description: |
+    checking-out-a-revision takes a git repository and a commit SHA
+    and validates that cloning the revision succeeds. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a specific commit
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: commit
+    type: string
+    description: The git commit to fetch.
+  - name: user-home
+    type: string
+    description: The home directory of the user performing the git clone.
+    default: "/tekton/home"
+  - name: user-uid
+    type: string
+    description: The UID of the user performing the git clone.
+    default: "0"
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the commit to be checked.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.commit)
+    - name: gitInitImage
+      value: localhost:5000/git-init-4874978a9786b6625dd8b6ef2a21aa70:latest
+    - name: userHome
+      value: $(params.user-home)
+  - name: check-expectations
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    params:
+    - name: expected-commit
+      value: $(params.commit)
+    - name: expected-readme-uid
+      value: $(params.user-uid)
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      params:
+      - name: expected-commit
+      - name: expected-readme-uid
+      workspaces:
+      - name: source
+      steps:
+      - image: alpine/git:v2.24.3
+        script: |
+          #!/usr/bin/env sh
+          cd "$(workspaces.source.path)"
+
+          receivedCommit="$(git rev-parse HEAD)"
+          if [ "$receivedCommit" != "$(params.expected-commit)" ]; then
+            echo "Expected commit $(params.expected-commit) but received $receivedCommit."
+            exit 1
+          else
+            echo "Received commit $receivedCommit as expected."
+          fi
+
+          detectedUID="$(ls -l ./README.md | awk '{ print $3 }')"
+          if [ "$detectedUID" != "$(params.expected-readme-uid)" ]; then
+            echo "Expected README UID of $(params.expected-readme-uid) but received $detectedUID."
+            exit 2
+          else
+            echo "Saw README with owner of $detectedUID as expected."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-clone-checking-out-a-commit-
+spec:
+  pipelineRef:
+    name: checking-out-a-revision
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi
+  taskRunSpecs:
+  - pipelineTaskName: fetch-repo
+    taskPodTemplate:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532 # nonroot user in git-init container
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: commit
+    value: 301b41380e95382a18b391c2165fa3a6a3de93b0  # Tekton Pipeline's first ever commit!
+  - name: user-home
+    value: "/home/nonroot"
+  - name: user-uid
+    value: "65532"

--- a/task/git-clone/0.7/samples/git-clone-sparse-checkout.yaml
+++ b/task/git-clone/0.7/samples/git-clone-sparse-checkout.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: sparse-checkout-list-dir
+spec:
+  description: |
+    sparse-checkout-list-dir takes a git repository and a list of
+    directory patterns to match and lists all cloned files and directories.
+    This is an example pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a specific set of
+        files based on directory patterns.
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: sparseCheckoutDirectories
+    type: string
+    description: directory patterns to clone
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task to list all cloned files and directories.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: sparseCheckoutDirectories
+      value: $(params.sparseCheckoutDirectories)
+  - name: list-dirs
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before listing all files and directories cloned
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          ls -R $(workspaces.source.path)/
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-sparse-checkout
+spec:
+  pipelineRef:
+    name: sparse-checkout-list-dir
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: sparseCheckoutDirectories
+    value: /*,!/*/,/docs/,/cmd/

--- a/task/git-clone/0.7/samples/using-git-clone-result.yaml
+++ b/task/git-clone/0.7/samples/using-git-clone-result.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: validate-tag-sha
+spec:
+  description: |
+    validate-tag-sha takes a git repository, tag name, and a commit SHA and
+    checks whether the given tag resolves to that commit. This example
+    Pipeline demonstrates the following:
+      - How to use the git-clone catalog Task
+      - How to use the git-clone Task's "commit" Task Result from another Task.
+      - How to discard the contents of the git repo when it isn't needed by
+        passing an `emptyDir` Volume as its "output" workspace.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: tag-name
+    type: string
+    description: The git tag to clone.
+  - name: expected-sha
+    type: string
+    description: The expected SHA to be received for the supplied revision.
+  workspaces:
+  - name: output
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: output
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.tag-name)
+  - name: validate-revision-sha
+    params:
+    - name: revision-name
+      value: $(params.tag-name)
+    - name: expected-sha
+      value: $(params.expected-sha)
+    - name: received-sha
+      value: $(tasks.fetch-repository.results.commit)
+    taskSpec:
+      params:
+      - name: revision-name
+      - name: expected-sha
+      - name: received-sha
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          if [ "$(params.expected-sha)" != "$(params.received-sha)" ]; then
+            echo "Expected revision $(params.revision-name) to have SHA $(params.expected-sha)."
+            exit 1
+          else
+            echo "Revision $(params.revision-name) has expected SHA $(params.expected-sha)."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: using-git-clone-result-
+spec:
+  pipelineRef:
+    name: validate-tag-sha
+  workspaces:
+  - name: output
+    emptyDir: {}  # We don't care about the repo contents in this example, just the "commit" result
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: tag-name
+    value: v0.12.1
+  - name: expected-sha
+    value: a54dd3984affab47f3018852e61a1a6f9946ecfa

--- a/task/git-clone/0.7/tests/run.yaml
+++ b/task/git-clone/0.7/tests/run.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-noargs
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-tag
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: revision
+      value: 1.0.0
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-submodules
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/githubtraining/example-dependency
+    - name: submodules
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-depth-2
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: depth
+      value: "2"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-sslverify-none
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: sslVerify
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-ssl-cadirectory-empty
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+    - name: ssl-ca-directory
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: crtFileName
+      value: ""
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-subdirectory
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: subdirectory
+      value: "hellomoto"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-delete-existing
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: deleteExisting
+      value: "true"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-without-verbose
+spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: verbose
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-sparse
+spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: sparseCheckoutDirectories
+      value: "CONTRIBUTING.md,STYLE.md"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Issue:** tried cloning secured repository by creating secret for `crt` and mounted using `ssl-ca-directory` but still faced below issue
```
[clone] {"level":"error","ts":1655989849.1085541,"caller":"git/git.go:55","msg":"Error running git [fetch --recurse-submodules=yes --depth=1 origin --update-head-ok --force master]: exit status 128\nfatal: unable to access 'https://gitlab.cee.redhat.com/tekton/plumbing.git/': SSL certificate problem: unable to get local issuer certificate\n","stacktrace":"github.com/tektoncd/pipeline/pkg/git.run\n\tgithub.com/tektoncd/pipeline/pkg/git/git.go:55\ngithub.com/tektoncd/pipeline/pkg/git.Fetch\n\tgithub.com/tektoncd/pipeline/pkg/git/git.go:150\nmain.main\n\tgithub.com/tektoncd/pipeline/cmd/git-init/main.go:53\nruntime.main\n\truntime/proc.go:225"}
```
# Changes
* Added `GIT_SSL_CAINFO`
* Bumped new version `0.7`

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
