### PR TITLE
v0.2 for orka tasks

### DIFF
--- a/task/orka-deploy/0.2/README.md
+++ b/task/orka-deploy/0.2/README.md
@@ -1,0 +1,113 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task`, along with `orka-init` and `orka-teardown`, allows you to utilize multiple macOS build agents in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-deploy`
+
+A `Task` that deploys a VM instance from a specified VM template. Usually, you would use the VM template created with `orka-init`.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.1/README.md#installation) for more information on setting up the Orka API configuration.
+
+```sh
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-deploy/0.1/orka-deploy.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+## Storing SSH credentials
+
+The `orka-deploy` task looks for a Kubernetes secret that stores the SSH access credentials for your macOS base image. This secret is called `orka-ssh-creds` by default and is expected to have the keys `username` and `password`.
+
+These defaults exist for convenience, and you can change them using the available [`Task` parameters](#Configuring-Secrets-and-Config-Maps).
+
+You can use the following example configuration. Make sure to provide the correct credentials for your base image.
+
+```yaml
+# orka-ssh-creds.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-ssh-creds.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+### Using an SSH key
+
+If using an SSH key to connect to the VM instead of an SSH username and password, complete the following:
+
+1. Copy the public key to the VM and commit the base image.
+2. Store the username and private key in a Kubernetes secret:
+
+```sh
+kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+```
+
+See also: [use-ssh-key.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-deploy/0.1/samples/use-ssh-key.yaml) example
+
+## Workspaces
+
+* **orka**: The contents of this workspace will be copied to the deployed VM. All files present in the workspace will be available to the build script run inside the VM. For example, you could clone a git repository containing Objective-C or Swift code in a previous pipeline step and run a build with Xcode command line tools in your build script. If the `copy-build` parameter is set to true, all build artifacts will be copied from the VM back to the workspace.
+
+## Parameters
+
+### Common parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `script` | The script to run inside of the VM. The script will be prepended with `#!/bin/sh` and `set -ex` if no shebang is present. You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby). | --- |
+| `copy-build` | Specifies whether to copy build artifacts from the Orka VM back to the workspace. Disable when there is no need to copy build artifacts (e.g., when running tests or linting code). | true |
+| `verbose` | Enables verbose logging for all connection activity to the VM. | false |
+| `ssh-key` | Specifies whether the SSH credentials secret contains an [SSH key](#using-an-ssh-key), as opposed to a password. | false |
+| `delete-vm` | Specifies whether to delete the VM after use when run in a pipeline. You can discard build agents that are no longer needed to free up resources. Set to false if you intend to clean up VMs after use manually. | true |
+| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |
+
+### Configuring secrets and config maps
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `ssh-secret` | The name of the secret holding your VM SSH credentials. | orka-ssh-creds |
+| `ssh-username-key` | The name of the key in the VM SSH credentials secret for the username associated with the macOS VM. | username |
+| `ssh-password-key` | The name of the key in the VM SSH credentials secret for the password associated with the macOS VM. If `ssh-key` is true, this parameter should specify the name of the key in the VM SSH credentials secret that holds the private SSH key. | password |
+| `orka-token-secret` | The name of the secret holding the authentication token used to access the Orka API. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-token |
+| `orka-token-secret-key` | The name of the key in the Orka token secret, which holds the authentication token. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | token |
+| `orka-vm-name-config` | The name of the config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-vm-name |
+| `orka-vm-name-config-key` | The name of the key in the VM name config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | vm-name |
+
+## Samples
+
+[parallel-deploy.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-deploy/0.1/samples/parallel-deploy.yaml) is a sample `Pipeline` that uses the `orka-init`, `orka-deploy`, and `orka-teardown` tasks and performs the following operations:
+1. Sets up an Orka job runner.
+2. Deploys 2 VMs in parallel and executes a different script on each VM.
+3. Cleans up the environment.

--- a/task/orka-deploy/0.2/README.md
+++ b/task/orka-deploy/0.2/README.md
@@ -17,7 +17,7 @@ The Task can be run on `linux/amd64` platform.
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
 * You need an Orka environment with the following components:
   * Orka 1.4.1 or later.
-  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.20`, `http://10.221.188.100` or `https://<custom-domain>`.
   * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
   * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
 * You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
@@ -26,12 +26,14 @@ See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-s
 
 See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
 
+> **NOTE:** Beginning with Orka 2.1.0, net new Orka clusters are configured with the Orka service endpoint as `http://10.221.188.20`. Existing clusters will continue to use the service endpoint as initially configured, typically `http://10.221.188.100`.
+
 ## Installation
 
-Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.1/README.md#installation) for more information on setting up the Orka API configuration.
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.2/README.md#installation) for more information on setting up the Orka API configuration.
 
 ```sh
-kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-deploy/0.1/orka-deploy.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-deploy/0.2/orka-deploy.yaml
 ```
 
 Omit `--namespace` if installing in the `default` namespace.
@@ -74,7 +76,7 @@ If using an SSH key to connect to the VM instead of an SSH username and password
 kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
 ```
 
-See also: [use-ssh-key.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-deploy/0.1/samples/use-ssh-key.yaml) example
+See also: [use-ssh-key.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-deploy/0.2/samples/use-ssh-key.yaml) example
 
 ## Workspaces
 
@@ -86,12 +88,15 @@ See also: [use-ssh-key.yaml](https://github.com/tektoncd/catalog/blob/main/task/
 
 | Parameter | Description | Default |
 | --- | --- | ---: |
+| `vm-metadata` | Inject custom metadata to the VM (on Intel nodes only). You need to provide the metadata in format:`[{ key: firstKey, value: firstValue }, { key: secondKey, value: secondValue }]`. Refer to [`inject-vm-metadata`](samples/inject-vm-metadata.yaml) example. | --- |
+| `system-serial` | Assign an owned macOS system serial number to the VM (on Intel nodes only). Refer to [`inject-system-serial`](samples/inject-system-serial.yaml) example. | --- |
+| `gpu-passthrough` | Enables or disables GPU passthrough for the VM (on Intel nodes only). Refer to [`gpu-passthrough`](samples/gpu-passthrough.yaml) example. | false |
 | `script` | The script to run inside of the VM. The script will be prepended with `#!/bin/sh` and `set -ex` if no shebang is present. You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby). | --- |
 | `copy-build` | Specifies whether to copy build artifacts from the Orka VM back to the workspace. Disable when there is no need to copy build artifacts (e.g., when running tests or linting code). | true |
 | `verbose` | Enables verbose logging for all connection activity to the VM. | false |
 | `ssh-key` | Specifies whether the SSH credentials secret contains an [SSH key](#using-an-ssh-key), as opposed to a password. | false |
 | `delete-vm` | Specifies whether to delete the VM after use when run in a pipeline. You can discard build agents that are no longer needed to free up resources. Set to false if you intend to clean up VMs after use manually. | true |
-| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |
+| `docker-image` | The docker image used to run the task steps. | ghcr.io/macstadium/orka-tekton-runner:0.2 |
 
 ### Configuring secrets and config maps
 
@@ -107,7 +112,7 @@ See also: [use-ssh-key.yaml](https://github.com/tektoncd/catalog/blob/main/task/
 
 ## Samples
 
-[parallel-deploy.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-deploy/0.1/samples/parallel-deploy.yaml) is a sample `Pipeline` that uses the `orka-init`, `orka-deploy`, and `orka-teardown` tasks and performs the following operations:
+[parallel-deploy.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-deploy/0.2/samples/parallel-deploy.yaml) is a sample `Pipeline` that uses the `orka-init`, `orka-deploy`, and `orka-teardown` tasks and performs the following operations:
 1. Sets up an Orka job runner.
 2. Deploys 2 VMs in parallel and executes a different script on each VM.
 3. Cleans up the environment.

--- a/task/orka-deploy/0.2/orka-deploy.yaml
+++ b/task/orka-deploy/0.2/orka-deploy.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-deploy
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Deployment
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -47,11 +47,11 @@ spec:
 
         Set to false if you intend to clean up VMs after use manually.
       default: "true"
-    - name: orka-image
+    - name: docker-image
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
     - name: ssh-key
       type: string
       description: |
@@ -75,6 +75,23 @@ spec:
         If ssh-key is true, this parameter should specify the name of the key in
         the VM SSH credentials secret that holds the private SSH key.
       default: password
+    - name: system-serial
+      type: string
+      description: "Assign an owned macOS system serial number to the VM (on Intel nodes only)."
+      default: ""
+    - name: vm-metadata
+      type: string
+      description: |
+        "Inject custom metadata to the VM (on Intel nodes only). You need to provide the metadata in format:
+        [
+          { key: firstKey, value: firstValue },
+          { key: secondKey, value: secondsValue }
+        ]"
+      default: ""
+    - name: gpu-passthrough
+      type: string
+      description: Enables or disables GPU passthrough for the VM (on Intel nodes only).
+      default: "false"
     - name: orka-token-secret
       type: string
       description: |
@@ -106,7 +123,7 @@ spec:
     workingDir: /workspace
   steps:
     - name: copy-script
-      image: $(params.orka-image)
+      image: $(params.docker-image)
       script: |
         #!/bin/sh
         SCRIPT=$(mktemp)
@@ -116,7 +133,7 @@ spec:
         EOF
         copy-script $SCRIPT
     - name: build
-      image: $(params.orka-image)
+      image: $(params.docker-image)
       env:
         - name: ORKA_API
           valueFrom:
@@ -138,6 +155,12 @@ spec:
           value: /etc/$(params.ssh-secret)/$(params.ssh-password-key)
         - name: SSH_KEY
           value: $(params.ssh-key)
+        - name: SYSTEM_SERIAL
+          value: $(params.system-serial)
+        - name: VM_METADATA
+          value: $(params.vm-metadata)
+        - name: GPU_PASSTHROUGH
+          value: $(params.gpu-passthrough)
         - name: TOKEN
           valueFrom:
             secretKeyRef:

--- a/task/orka-deploy/0.2/orka-deploy.yaml
+++ b/task/orka-deploy/0.2/orka-deploy.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-deploy
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Deployment
+    tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/tags: "orka, macstadium, deploy, build"
+    tekton.dev/displayName: "MacStadium Orka Deploy"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    With this set of Tasks, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task deploys a VM instance from a specified VM template.
+    Usually, you would use the VM template created with `orka-init`.
+  params:
+    - name: script
+      type: string
+      description: |
+        The script to run inside of the VM. The script will be prepended with the following
+        if no shebang is present:
+
+        #!/bin/sh
+        set -ex
+
+        You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby).
+    - name: copy-build
+      type: string
+      description: |
+        Specifies whether to copy build artifacts from the Orka VM back to the workspace.
+        Disable when there is no need to copy build artifacts (e.g., when running tests or linting code).
+      default: "true"
+    - name: verbose
+      type: string
+      description: Enables verbose logging for all connection activity to the VM.
+      default: "false"
+    - name: delete-vm
+      type: string
+      description: |
+        Specifies whether to delete the VM after use when run in a pipeline.
+        You can discard build agents that are no longer needed to free up resources.
+
+        Set to false if you intend to clean up VMs after use manually.
+      default: "true"
+    - name: orka-image
+      type: string
+      description: |
+        The name of the docker image which runs the task step.
+      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+    - name: ssh-key
+      type: string
+      description: |
+        Specifies whether the SSH credentials secret contains an SSH key, as opposed to a password.
+      default: "false"
+    - name: ssh-secret
+      type: string
+      description: The name of the secret holding your VM SSH credentials.
+      default: orka-ssh-creds
+    - name: ssh-username-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the username associated with the macOS VM.
+      default: username
+    - name: ssh-password-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the password
+        associated with the macOS VM.
+
+        If ssh-key is true, this parameter should specify the name of the key in
+        the VM SSH credentials secret that holds the private SSH key.
+      default: password
+    - name: orka-token-secret
+      type: string
+      description: |
+        The name of the secret holding the authentication token used to access the Orka API.
+      default: orka-token
+    - name: orka-token-secret-key
+      type: string
+      description: |
+        The name of the key in the Orka token secret, which holds the authentication token.
+      default: token
+    - name: orka-vm-name-config
+      type: string
+      description: |
+        The name of the config map, which stores the name of the generated VM configuration.
+      default: orka-vm-name
+    - name: orka-vm-name-config-key
+      type: string
+      description: |
+        The name of the key in the VM name config map, which stores the name of the generated VM configuration.
+      default: vm-name
+    - name: user-home
+      type: string
+      default: /tekton/home
+      description: Absolute path to the user's home directory.
+  stepTemplate:
+    env:
+      - name: HOME
+        value: $(params.user-home)
+    workingDir: /workspace
+  steps:
+    - name: copy-script
+      image: $(params.orka-image)
+      script: |
+        #!/bin/sh
+        SCRIPT=$(mktemp)
+        # Safeguard against having to escape quotes / vars in script
+        cat > $SCRIPT << 'EOF'
+        $(params.script)
+        EOF
+        copy-script $SCRIPT
+    - name: build
+      image: $(params.orka-image)
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: VERBOSE
+          value: $(params.verbose)
+        - name: DELETE_VM
+          value: $(params.delete-vm)
+        - name: COPY_BUILD
+          value: $(params.copy-build)
+        - name: SSH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.ssh-secret)
+              key: $(params.ssh-username-key)
+        - name: SSH_PASSFILE
+          value: /etc/$(params.ssh-secret)/$(params.ssh-password-key)
+        - name: SSH_KEY
+          value: $(params.ssh-key)
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-token-secret)
+              key: $(params.orka-token-secret-key)
+        - name: VM_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: $(params.orka-vm-name-config)
+              key: $(params.orka-vm-name-config-key)
+      volumeMounts:
+        - name: ssh-creds
+          readOnly: true
+          mountPath: /etc/$(params.ssh-secret)
+      script: |
+        #!/bin/sh
+        set -x
+        orka-deploy
+  volumes:
+    - name: ssh-creds
+      secret:
+        secretName: $(params.ssh-secret)
+        items:
+          - key: $(params.ssh-password-key)
+            path: $(params.ssh-password-key)
+            mode: 256
+  workspaces:
+    - name: orka

--- a/task/orka-deploy/0.2/samples/parallel-deploy.yaml
+++ b/task/orka-deploy/0.2/samples/parallel-deploy.yaml
@@ -20,8 +20,10 @@ spec:
         name: orka-init
       params:
         - name: base-image
-          value: catalina-ssh-30G.img
+          value: 90GBigSurSSH.img
     - name: diskinfo
+      runAfter:
+        - setup
       retries: 1
       taskRef:
         name: orka-deploy
@@ -35,6 +37,8 @@ spec:
         - name: orka
           workspace: shared-data
     - name: ruby
+      runAfter:
+        - setup
       retries: 1
       taskRef:
         name: orka-deploy

--- a/task/orka-deploy/0.2/samples/parallel-deploy.yaml
+++ b/task/orka-deploy/0.2/samples/parallel-deploy.yaml
@@ -1,0 +1,66 @@
+# ###
+# This example shows how to deploy multiple Orka VMs in a Pipeline.
+# In this scenario, the VMs will be run in parallel and run two different jobs.
+#
+# The orka-init and orka-teardown Tasks require a Kubernetes service account with
+# permission to create / delete secrets and config maps. See the README for more
+# information.
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: parallel-deploy
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: setup
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: catalina-ssh-30G.img
+    - name: diskinfo
+      retries: 1
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: copy-build
+          value: "false"
+        - name: script
+          value: |
+            diskutil info /
+      workspaces:
+        - name: orka
+          workspace: shared-data
+    - name: ruby
+      retries: 1
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: copy-build
+          value: "false"
+        - name: script
+          value: |
+            #!/usr/bin/env ruby
+            puts "Hello macOS"
+      workspaces:
+        - name: orka
+          workspace: shared-data
+  finally:
+    - name: cleanup
+      taskRef:
+        name: orka-teardown
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-parallel-deploy
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: parallel-deploy
+  workspaces:
+    - name: shared-data
+      emptyDir: {}

--- a/task/orka-deploy/0.2/samples/use-ssh-key.yaml
+++ b/task/orka-deploy/0.2/samples/use-ssh-key.yaml
@@ -12,54 +12,29 @@
 # ###
 ---
 apiVersion: tekton.dev/v1beta1
-kind: Pipeline
+kind: TaskRun
 metadata:
   name: use-ssh-key
 spec:
+  taskRef:
+    name: orka-full
+  params:
+    - name: base-image
+      value: catalina-ssh-key-30G.img
+    - name: ssh-secret
+      value: orka-ssh-key
+    - name: ssh-password-key
+      value: id_rsa
+    - name: ssh-key
+      value: "true"
+    - name: verbose
+      value: "true"
+    - name: copy-build
+      value: "false"
+    - name: script
+      value: |
+        #!/usr/bin/env ruby
+        puts "Hello macOS"
   workspaces:
-    - name: shared-data
-  tasks:
-    - name: setup
-      taskRef:
-        name: orka-init
-      params:
-        - name: base-image
-          value: catalina-ssh-key-30G.img
-    - name: hello-macos
-      retries: 1
-      taskRef:
-        name: orka-deploy
-      params:
-        - name: ssh-secret
-          value: orka-ssh-key
-        - name: ssh-password-key
-          value: id_rsa
-        - name: ssh-key
-          value: "true"
-        - name: verbose
-          value: "true"
-        - name: copy-build
-          value: "false"
-        - name: script
-          value: |
-            #!/usr/bin/env ruby
-            puts "Hello macOS"
-      workspaces:
-        - name: orka
-          workspace: shared-data
-  finally:
-    - name: cleanup
-      taskRef:
-        name: orka-teardown
----
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: run-use-ssh-key
-spec:
-  serviceAccountName: orka-svc
-  pipelineRef:
-    name: use-ssh-key
-  workspaces:
-    - name: shared-data
+    - name: orka
       emptyDir: {}

--- a/task/orka-deploy/0.2/samples/use-ssh-key.yaml
+++ b/task/orka-deploy/0.2/samples/use-ssh-key.yaml
@@ -1,0 +1,65 @@
+# ###
+# This example demonstrates how to use an SSH key to connect to the Orka VM.
+# You will first need to copy the public key to the VM and commit or save an
+# image using `orka image commit` or `orka image save` and specify that base image.
+# in the TaskRun or Pipeline as a param.
+#
+# You must specify the Task param ssh-key="true" in order to use an SSH key.
+#
+# ###
+# You can create a Kubernetes secret with the SSH credentials as follows:
+# kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: use-ssh-key
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: setup
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: catalina-ssh-key-30G.img
+    - name: hello-macos
+      retries: 1
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: ssh-secret
+          value: orka-ssh-key
+        - name: ssh-password-key
+          value: id_rsa
+        - name: ssh-key
+          value: "true"
+        - name: verbose
+          value: "true"
+        - name: copy-build
+          value: "false"
+        - name: script
+          value: |
+            #!/usr/bin/env ruby
+            puts "Hello macOS"
+      workspaces:
+        - name: orka
+          workspace: shared-data
+  finally:
+    - name: cleanup
+      taskRef:
+        name: orka-teardown
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-use-ssh-key
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: use-ssh-key
+  workspaces:
+    - name: shared-data
+      emptyDir: {}

--- a/task/orka-deploy/0.2/tests/mocks/orka.yaml
+++ b/task/orka-deploy/0.2/tests/mocks/orka.yaml
@@ -1,0 +1,32 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/deploy
+response:
+  status: 200
+  output: '{"ip": "localhost", "ssh_port": "22", "vm_id": "wxyz"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/delete
+response:
+  status: 200
+  output: '{"message": "Successfully deleted VM"}'
+  content-type: text/json

--- a/task/orka-deploy/0.2/tests/mods/mod_task.py
+++ b/task/orka-deploy/0.2/tests/mods/mod_task.py
@@ -1,0 +1,45 @@
+import os, sys, yaml
+
+def str_presenter(dumper, data):
+  scalar_style = "|" if len(data.splitlines()) > 1 else None
+  return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=scalar_style)
+
+yaml.add_representer(str, str_presenter)
+
+if __name__ == "__main__":
+    # Load YAML files
+    with open(os.path.join(sys.path[0], "..", "mocks", "orka.yaml"), "r", encoding="utf-8") as f:
+        mocks = f.read()
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    go_rest_api = [
+        {
+            "name": "go-rest-api",
+            "image": "quay.io/chmouel/go-rest-api-test",
+            "env": [
+                {
+                    "name": "CONFIG",
+                    "value": mocks
+                }
+            ]
+        }
+    ]
+
+    # Modify Task YAML
+    if data["metadata"]["name"] == "orka-deploy":
+        # Load YAML files
+        with open(os.path.join(sys.path[0], "sidecars.yaml"), "r", encoding="utf-8") as f:
+            sidecars = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+        with open(os.path.join(sys.path[0], "volumes.yaml"), "r", encoding="utf-8") as f:
+            volumes = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+        data["spec"]["volumes"] += volumes
+        data["spec"]["sidecars"] = sidecars + go_rest_api
+    else:
+        data["spec"]["sidecars"] = go_rest_api
+
+    # Dump YAML
+    print(yaml.dump(data, default_flow_style=False))

--- a/task/orka-deploy/0.2/tests/mods/sidecars.yaml
+++ b/task/orka-deploy/0.2/tests/mods/sidecars.yaml
@@ -1,0 +1,12 @@
+---
+- name: ssh-server
+  image: panubo/sshd:1.3.0
+  env:
+    - name: "SSH_USERS"
+      value: "admin:1000:1000"
+    - name: "SSH_ENABLE_PASSWORD_AUTH"
+      value: "true"
+  volumeMounts:
+    - name: startup-script
+      mountPath: "/etc/entrypoint.d"
+      readOnly: true

--- a/task/orka-deploy/0.2/tests/mods/volumes.yaml
+++ b/task/orka-deploy/0.2/tests/mods/volumes.yaml
@@ -1,0 +1,8 @@
+---
+- name: startup-script
+  configMap:
+    name: ssh-scripts
+    items:
+      - key: "startup-script"
+        path: "startup.sh"
+        mode: 448

--- a/task/orka-deploy/0.2/tests/pre-apply-task-hook.sh
+++ b/task/orka-deploy/0.2/tests/pre-apply-task-hook.sh
@@ -3,7 +3,7 @@
 # Modify orka-init
 ORKA_INIT=$(mktemp /tmp/.mm.XXXXXX)
 MOD_SCRIPT=${taskdir}/tests/mods/mod_task.py
-cp task/orka-init/0.1/orka-init.yaml ${ORKA_INIT}
+cp task/orka-init/0.2/orka-init.yaml ${ORKA_INIT}
 python3 ${MOD_SCRIPT} ${ORKA_INIT} > ${ORKA_INIT}.mod
 
 # Add orka-init

--- a/task/orka-deploy/0.2/tests/pre-apply-task-hook.sh
+++ b/task/orka-deploy/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Modify orka-init
+ORKA_INIT=$(mktemp /tmp/.mm.XXXXXX)
+MOD_SCRIPT=${taskdir}/tests/mods/mod_task.py
+cp task/orka-init/0.1/orka-init.yaml ${ORKA_INIT}
+python3 ${MOD_SCRIPT} ${ORKA_INIT} > ${ORKA_INIT}.mod
+
+# Add orka-init
+${KUBECTL_CMD} -n "${tns}" apply -f ${ORKA_INIT}.mod
+rm -f ${ORKA_INIT} ${ORKA_INIT}.mod
+
+# Modify task
+cp ${TMPF} ${TMPF}.read
+python3 ${MOD_SCRIPT} ${TMPF}.read > ${TMPF}
+rm -f ${TMPF}.read

--- a/task/orka-deploy/0.2/tests/resources.yaml
+++ b/task/orka-deploy/0.2/tests/resources.yaml
@@ -1,0 +1,68 @@
+# Secrets set and used for local test instance.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssh-scripts
+data:
+  startup-script: |
+    #!/usr/bin/env bash
+    set -e
+    echo "admin:admin" | chpasswd
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: orka-deploy-0-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner-deploy
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner-deploy
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: orka-deploy-0-1
+roleRef:
+  kind: ClusterRole
+  name: orka-runner-deploy
+  apiGroup: rbac.authorization.k8s.io

--- a/task/orka-deploy/0.2/tests/resources.yaml
+++ b/task/orka-deploy/0.2/tests/resources.yaml
@@ -39,7 +39,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: orka-svc
-  namespace: orka-deploy-0-1
+  namespace: orka-deploy-0-2
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -61,7 +61,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: orka-svc
-  namespace: orka-deploy-0-1
+  namespace: orka-deploy-0-2
 roleRef:
   kind: ClusterRole
   name: orka-runner-deploy

--- a/task/orka-deploy/0.2/tests/run.yaml
+++ b/task/orka-deploy/0.2/tests/run.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: orka-deploy-test
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: init
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: base-image.img
+    - name: deploy
+      runAfter:
+        - init
+      taskRef:
+        name: orka-deploy
+      params:
+        - name: copy-build
+          value: "false"
+        - name: verbose
+          value: "true"
+        - name: script
+          value: |
+            echo "Hello from TektonCD test"
+      workspaces:
+        - name: orka
+          workspace: shared-data
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: orka-deploy-test-run
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: orka-deploy-test
+  workspaces:
+    - name: shared-data
+      emptyDir: {}

--- a/task/orka-full/0.2/README.md
+++ b/task/orka-full/0.2/README.md
@@ -1,0 +1,149 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task` is for utilizing a single macOS build agent in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-full`
+
+A `Task` that creates a VM template with the specified configuration, deploys a VM instance from it, and then cleans up the environment. All operations in this `Task` are performed against an Orka environment.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster.
+
+You can use the following sample `orka-configuration.yaml`. Make sure to provide the correct Orka API endpoint for your Orka environment.
+
+```yaml
+# orka-configuration.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://10.221.188.100
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-configuration.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-full/0.1/orka-full.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+> **TIP:** Did you know you could use a script for easier install?
+> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/SCRIPTS.md#install-the-task)
+
+## Storing your credentials
+
+The provided `Task` looks for two Kubernetes secrets that store your credentials: `orka-creds` for the Orka user and `orka-ssh-creds` for the SSH credentials.
+  * `orka-creds` has the following keys: `email` and `password`
+  * `orka-ssh-creds` has the following keys: `username` and `password`
+
+These defaults exist for convenience, and you can change them using the available [`Task` parameters](#Configuring-Secrets).
+
+You can use the following sample `credentials.yaml`. Make sure to provide the correct credentials for your Orka environment and the correct SSH credentials for the base image you intend to use.
+
+```yaml
+# credentials.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f credentials.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+> **TIP:** Did you know you could use a script for easier setup?
+>
+> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/SCRIPTS.md#store-the-orka-environment-credentials)
+
+### Using an SSH key
+
+If using an SSH key to connect to the VM instead of an SSH username and password, complete the following:
+
+1. Copy the public key to the VM and commit the base image.
+2. Store the username and private key in a Kubernetes secret:
+
+```sh
+kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+```
+
+See also: [`use-ssh-key`](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/samples/use-ssh-key.yaml) example
+
+## Workspaces
+
+* **orka**: An Orka environment against which to perform all operations. The environment parameters are configured with the `Task` parameters.
+
+## Parameters
+
+### Common parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `base-image` | The Orka base image to use for the VM config. | --- |
+| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |
+| `cpu-count` | The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24. | 3 |
+| `vcpu-count` | The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3. Otherwise, must equal half of or exactly the number of CPUs specified. | 3 |
+| `vnc-console` | Enables or disables VNC for the VM. | false |
+| `script` | The script to run inside of the VM. The script will be prepended with `#!/bin/sh` and `set -ex` if no shebang is present. You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby). | --- |
+| `copy-build` | Specifies whether to copy build artifacts from the Orka VM back to the workspace. Disable when there is no need to copy build artifacts (e.g., when running tests or linting code). | true |
+| `verbose` | Enables verbose logging for all connection activity to the VM. | false |
+| `ssh-key` | Specifies whether the SSH credentials secret contains an [SSH key](#using-an-ssh-key), as opposed to a password. | false |
+
+### Configuring secrets
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `orka-creds-secret` | The name of the secret holding your Orka credentials. | orka-creds |
+| `orka-creds-email-key` | The name of the key in the Orka user credentials secret for the email address associated with the Orka user. | email |
+| `orka-creds-password-key` | The name of the key in the Orka credentials secret for the password associated with the Orka user. | password |
+| `ssh-secret` | The name of the secret holding your VM SSH credentials. | orka-ssh-creds |
+| `ssh-username-key` | The name of the key in the VM SSH credentials secret for the username associated with the macOS VM. | username |
+| `ssh-password-key` | The name of the key in the VM SSH credentials secret for the password associated with the macOS VM. If `ssh-key` is true, this parameter should specify the name of the key in the VM SSH credentials secret that holds the private SSH key. | password |
+
+## Samples
+
+[dump-disk-info.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/samples/dump-disk-info.yaml) is a sample `TaskRun` that uses the `orka-full` `Task` to create a VM, run a script on it, and then clean up the environment.
+
+[build-audiokit-pipeline.yaml](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/samples/build-audiokit-pipeline.yaml) is a  sample `Pipeline` that uses the `orka-full` `Task` and performs the following operations:
+1. Clones a git repository.
+2. Passes it to the Orka build agent.
+3. Stores build artifacts on a persistent volume.
+4. Cleans up the Orka environment.

--- a/task/orka-full/0.2/README.md
+++ b/task/orka-full/0.2/README.md
@@ -17,7 +17,7 @@ The Task can be run on `linux/amd64` platform.
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
 * You need an Orka environment with the following components:
   * Orka 1.4.1 or later.
-  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.20`, `http://10.221.188.100` or `https://<custom-domain>`.
   * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
   * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
 * You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
@@ -25,6 +25,8 @@ The Task can be run on `linux/amd64` platform.
 See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
 
 See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+> **NOTE:** Beginning with Orka 2.1.0, net new Orka clusters are configured with the Orka service endpoint as `http://10.221.188.20`. Existing clusters will continue to use the service endpoint as initially configured, typically `http://10.221.188.100`.
 
 ## Installation
 
@@ -39,18 +41,18 @@ kind: ConfigMap
 metadata:
   name: orka-tekton-config
 data:
-  ORKA_API: http://10.221.188.100
+  ORKA_API: http://10.221.188.20
 ```
 
 ```sh
 kubectl apply --namespace=<namespace> -f orka-configuration.yaml
-kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-full/0.1/orka-full.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-full/0.2/orka-full.yaml
 ```
 
 Omit `--namespace` if installing in the `default` namespace.
 
 > **TIP:** Did you know you could use a script for easier install?
-> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/SCRIPTS.md#install-the-task)
+> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.2/SCRIPTS.md#install-the-task)
 
 ## Storing your credentials
 
@@ -92,7 +94,7 @@ Omit `--namespace` if installing in the `default` namespace.
 
 > **TIP:** Did you know you could use a script for easier setup?
 >
-> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/SCRIPTS.md#store-the-orka-environment-credentials)
+> See [SCRIPTS.md](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.2/SCRIPTS.md#store-the-orka-environment-credentials)
 
 ### Using an SSH key
 
@@ -105,7 +107,7 @@ If using an SSH key to connect to the VM instead of an SSH username and password
 kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
 ```
 
-See also: [`use-ssh-key`](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.1/samples/use-ssh-key.yaml) example
+See also: [`use-ssh-key`](https://github.com/tektoncd/catalog/blob/main/task/orka-full/0.2/samples/use-ssh-key.yaml) example
 
 ## Workspaces
 
@@ -118,10 +120,16 @@ See also: [`use-ssh-key`](https://github.com/tektoncd/catalog/blob/main/task/ork
 | Parameter | Description | Default |
 | --- | --- | ---: |
 | `base-image` | The Orka base image to use for the VM config. | --- |
-| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |
+| `docker-image` | The docker image used to run the task steps. | ghcr.io/macstadium/orka-tekton-runner:0.2 |
 | `cpu-count` | The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24. | 3 |
 | `vcpu-count` | The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3. Otherwise, must equal half of or exactly the number of CPUs specified. | 3 |
 | `vnc-console` | Enables or disables VNC for the VM. | false |
+| `vm-metadata` | Inject custom metadata to the VM (on Intel nodes only). You need to provide the metadata in format:`[{ key: firstKey, value: firstValue }, { key: secondKey, value: secondValue }]`. Refer to [`inject-vm-metadata`](samples/inject-vm-metadata.yaml) example. | --- |
+| `system-serial` | Assign an owned macOS system serial number to the VM (on Intel nodes only). Refer to [`inject-system-serial`](samples/inject-system-serial.yaml) example. | --- |
+| `gpu-passthrough` | Enables or disables GPU passthrough for the VM (on Intel nodes only). Refer to [`gpu-passthrough`](samples/gpu-passthrough.yaml) example. | false |
+| `tag` | When specified, the VM is preferred to be deployed to a node marked with this tag. | --- |
+| `tag-required` | VM is required to be deployed to a node marked with tag specified above. | false |
+| `scheduler` | When set to 'most-allocated', the deployed VM will be scheduled to nodes having most of their resources allocated. | default |
 | `script` | The script to run inside of the VM. The script will be prepended with `#!/bin/sh` and `set -ex` if no shebang is present. You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby). | --- |
 | `copy-build` | Specifies whether to copy build artifacts from the Orka VM back to the workspace. Disable when there is no need to copy build artifacts (e.g., when running tests or linting code). | true |
 | `verbose` | Enables verbose logging for all connection activity to the VM. | false |

--- a/task/orka-full/0.2/SCRIPTS.md
+++ b/task/orka-full/0.2/SCRIPTS.md
@@ -1,0 +1,121 @@
+# Install & Configure with Scripts
+
+For easier install and configuration of the Orka Tekton `Tasks`, you can use the provided scripts.
+
+* [TL;DR](#tldr)
+* [How to install the task](#how-to-install-the-task)
+* [How to store your credentials](#how-to-store-your-credentials)
+
+## TL;DR
+
+Omit `NAMESPACE` if installing in the `default` Kubernetes namespace.
+
+#### Install the task
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/install.sh && chmod 755 install.sh
+
+NAMESPACE=<namespace> ORKA_API=<endpoint> ./install.sh --apply
+```
+
+#### Store the Orka environment credentials
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-orka-creds.sh && chmod 755 add-orka-creds.sh
+
+NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --apply
+```
+
+#### Store the SSH credentials for the base image
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
+
+NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh --apply
+```
+
+## How to install the task
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster.
+
+### Get install.sh
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/install.sh && chmod 755 install.sh
+```
+
+### Default namespace installation
+
+To install in your Kubernetes cluster's `default` namespace, run the following command against your actual Orka API endpoint.
+
+```sh
+ORKA_API=http://10.221.188.100 ./install.sh --apply
+```
+
+To uninstall from the `default` namespace, run the script with the `-d` or `--delete` flag:
+
+```sh
+./install.sh --delete
+```
+
+### Custom namespace installation
+
+To install in a custom namespace, run the following command against your preferred namespace and your actual Orka API endpoint:
+
+```sh
+NAMESPACE=<namespace> ORKA_API=<endpoint> ./install.sh --apply
+```
+
+To uninstall from a selected namespace, run the script with the `-d` or `--delete` flag against the namespace:
+
+```sh
+NAMESPACE=<namespace> ./install.sh --delete
+```
+
+## How to store your credentials
+
+The provided `Task` looks for two Kubernetes secrets that store your credentials: `orka-creds` for the Orka user and `orka-ssh-creds` for the SSH credentials.
+  * `orka-creds` has the following keys: `email` and `password`
+  * `orka-ssh-creds` has the following keys: `username` and `password`
+
+You need to create Kubernetes secrets to store the Orka user credentials and the base image's SSH credentials.
+
+### Get the credentials scripts
+
+```sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-orka-creds.sh && chmod 755 add-orka-creds.sh
+
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
+```
+
+### Store in the default namespace
+
+To create a Kubernetes secret in the `default` namespace of your cluster, run the following commands:
+
+```sh
+EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --apply
+SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh --apply
+```
+
+To remove the secrets from the `default` namespace, run:
+
+```sh
+./add-orka-creds.sh --delete
+./add-ssh-creds.sh --delete
+```
+
+### Store in a custom namespace
+
+To create a Kubernetes secret in a custom namespace, run the following commands against your preferred namespace:
+
+```sh
+NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --apply
+NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh --apply
+```
+
+To remove the secrets from the custom specify, run the following commands against the namespace:
+
+```sh
+NAMESPACE=<namespace> ./add-orka-creds.sh --delete
+NAMESPACE=<namespace> ./add-ssh-creds.sh --delete
+```

--- a/task/orka-full/0.2/SCRIPTS.md
+++ b/task/orka-full/0.2/SCRIPTS.md
@@ -13,7 +13,7 @@ Omit `NAMESPACE` if installing in the `default` Kubernetes namespace.
 #### Install the task
 
 ```sh
-curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/install.sh && chmod 755 install.sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2/install.sh && chmod 755 install.sh
 
 NAMESPACE=<namespace> ORKA_API=<endpoint> ./install.sh --apply
 ```
@@ -21,7 +21,7 @@ NAMESPACE=<namespace> ORKA_API=<endpoint> ./install.sh --apply
 #### Store the Orka environment credentials
 
 ```sh
-curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-orka-creds.sh && chmod 755 add-orka-creds.sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2/add-orka-creds.sh && chmod 755 add-orka-creds.sh
 
 NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --apply
 ```
@@ -29,7 +29,7 @@ NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh --ap
 #### Store the SSH credentials for the base image
 
 ```sh
-curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
 
 NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh --apply
 ```
@@ -41,7 +41,7 @@ Before you can use this `Task` in Tekton pipelines, you need to install it and t
 ### Get install.sh
 
 ```sh
-curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/install.sh && chmod 755 install.sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2/install.sh && chmod 755 install.sh
 ```
 
 ### Default namespace installation
@@ -49,7 +49,7 @@ curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/
 To install in your Kubernetes cluster's `default` namespace, run the following command against your actual Orka API endpoint.
 
 ```sh
-ORKA_API=http://10.221.188.100 ./install.sh --apply
+ORKA_API=http://10.221.188.20 ./install.sh --apply
 ```
 
 To uninstall from the `default` namespace, run the script with the `-d` or `--delete` flag:
@@ -83,9 +83,9 @@ You need to create Kubernetes secrets to store the Orka user credentials and the
 ### Get the credentials scripts
 
 ```sh
-curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-orka-creds.sh && chmod 755 add-orka-creds.sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2/add-orka-creds.sh && chmod 755 add-orka-creds.sh
 
-curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
+curl -LO https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2/add-ssh-creds.sh && chmod 755 add-ssh-creds.sh
 ```
 
 ### Store in the default namespace

--- a/task/orka-full/0.2/add-orka-creds.sh
+++ b/task/orka-full/0.2/add-orka-creds.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+: ${NAMESPACE:="default"}
+
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1"
+USAGE=$(cat <<EOF
+Usage:
+  NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh [-a|-d|--apply|--delete]
+Options:
+  -a, --apply : Install secret with Orka credentials.
+  -d, --delete : Uninstall secret with Orka credentials.
+  --help : Display this message
+Environment:
+  NAMESPACE : Kubernetes namespace. Defaults to "default"
+  EMAIL (required) : Username for Orka service account, e.g. tekton-svc@macstadium.com
+  PASSWORD (required) : Password for Orka service account
+EOF
+)
+
+if [ -n "$1" ]; then
+  if [[ "$1" == "-a" || "$1" == "--apply" ]]; then
+    ACTION="apply"
+  elif [[ "$1" == "-d" || "$1" = "--delete" ]]; then
+    ACTION="delete"
+    kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/resources/orka-creds.yaml.tmpl
+    exit 0
+  elif [[ "$1" == "--help" ]]; then
+    echo "$USAGE"
+    exit 0
+  else
+    echo -e "Unkown argument: $1\n"
+    echo "$USAGE"
+    exit 1
+  fi
+else
+  ACTION="apply"
+fi
+
+if [[ ! $EMAIL || ! $PASSWORD ]]; then
+  echo -e "Email and password required!\n"
+  echo "$USAGE"
+  exit 1
+fi
+
+YAML_TEMPLATE=$(mktemp)
+trap "rm -f $YAML_TEMPLATE" EXIT
+
+curl --fail --location ${BASE_URL}/resources/orka-creds.yaml.tmpl --output $YAML_TEMPLATE
+sed -e 's|$(email)|'"$EMAIL"'|' \
+  -e 's|$(password)|'"$PASSWORD"'|' $YAML_TEMPLATE \
+  > ${YAML_TEMPLATE}.new
+mv ${YAML_TEMPLATE}.new $YAML_TEMPLATE
+kubectl $ACTION --namespace=$NAMESPACE -f $YAML_TEMPLATE

--- a/task/orka-full/0.2/add-orka-creds.sh
+++ b/task/orka-full/0.2/add-orka-creds.sh
@@ -4,7 +4,7 @@ set -e
 
 : ${NAMESPACE:="default"}
 
-BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1"
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2"
 USAGE=$(cat <<EOF
 Usage:
   NAMESPACE=<namespace> EMAIL=<email> PASSWORD=<password> ./add-orka-creds.sh [-a|-d|--apply|--delete]

--- a/task/orka-full/0.2/add-ssh-creds.sh
+++ b/task/orka-full/0.2/add-ssh-creds.sh
@@ -4,7 +4,7 @@ set -e
 
 : ${NAMESPACE:="default"}
 
-BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1"
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2"
 USAGE=$(cat <<EOF
 Usage:
   NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh [-a|-d|--apply|--delete]

--- a/task/orka-full/0.2/add-ssh-creds.sh
+++ b/task/orka-full/0.2/add-ssh-creds.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+: ${NAMESPACE:="default"}
+
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1"
+USAGE=$(cat <<EOF
+Usage:
+  NAMESPACE=<namespace> SSH_USERNAME=<username> SSH_PASSWORD=<password> ./add-ssh-creds.sh [-a|-d|--apply|--delete]
+Options:
+  -a, --apply : Install secret with VM SSH credentials.
+  -d, --delete : Uninstall secret with VM SSH credentials.
+  --help : Display this message
+Environment:
+  NAMESPACE : Kubernetes namespace. Defaults to "default"
+  SSH_USERNAME (required) : Username for SSH access to VM
+  SSH_PASSWORD (required) : Password for SSH access to VM
+EOF
+)
+
+if [ -n "$1" ]; then
+  if [[ "$1" == "-a" || "$1" == "--apply" ]]; then
+    ACTION="apply"
+  elif [[ "$1" == "-d" || "$1" = "--delete" ]]; then
+    ACTION="delete"
+    kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/resources/orka-ssh-creds.yaml.tmpl
+    exit 0
+  elif [[ "$1" == "--help" ]]; then
+    echo "$USAGE"
+    exit 0
+  else
+    echo -e "Unkown argument: $1\n"
+    echo "$USAGE"
+    exit 1
+  fi
+else
+  ACTION="apply"
+fi
+
+if [[ ! $SSH_USERNAME || ! $SSH_PASSWORD ]]; then
+  echo -e "Username and password required!\n"
+  echo "$USAGE"
+  exit 1
+fi
+
+YAML_TEMPLATE=$(mktemp)
+trap "rm -f $YAML_TEMPLATE" EXIT
+
+curl --fail --location ${BASE_URL}/resources/orka-ssh-creds.yaml.tmpl --output $YAML_TEMPLATE
+sed -e 's|$(username)|'"$SSH_USERNAME"'|' \
+  -e 's|$(password)|'"$SSH_PASSWORD"'|' $YAML_TEMPLATE \
+  > ${YAML_TEMPLATE}.new
+mv ${YAML_TEMPLATE}.new $YAML_TEMPLATE
+kubectl $ACTION --namespace=$NAMESPACE -f $YAML_TEMPLATE

--- a/task/orka-full/0.2/install.sh
+++ b/task/orka-full/0.2/install.sh
@@ -5,7 +5,7 @@ set -e
 : ${NAMESPACE:="default"}
 : ${ORKA_API:="http://10.221.188.100"}
 
-BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1"
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.2"
 USAGE=$(cat <<EOF
 Usage:
   NAMESPACE=<namespace> ORKA_API=<url> ./install.sh [-a|-d|--apply|--delete]

--- a/task/orka-full/0.2/install.sh
+++ b/task/orka-full/0.2/install.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+: ${NAMESPACE:="default"}
+: ${ORKA_API:="http://10.221.188.100"}
+
+BASE_URL="https://raw.githubusercontent.com/tektoncd/catalog/main/task/orka-full/0.1"
+USAGE=$(cat <<EOF
+Usage:
+  NAMESPACE=<namespace> ORKA_API=<url> ./install.sh [-a|-d|--apply|--delete]
+Options:
+  -a, --apply : Install orka-full task and config map
+  -d, --delete : Uninstall orka-full task and config map
+  --help : Display this message
+Environment:
+  NAMESPACE : Kubernetes namespace. Defaults to "default"
+  ORKA_API : Orka API endpoint. Defaults to "http://10.221.188.100"
+EOF
+)
+
+if [ -n "$1" ]; then
+  if [[ "$1" == "-a" || "$1" == "--apply" ]]; then
+    ACTION="apply"
+  elif [[ "$1" == "-d" || "$1" = "--delete" ]]; then
+    ACTION="delete"
+    kubectl $ACTION --namespace=$NAMESPACE \
+      -f ${BASE_URL}/resources/orka-tekton-config.yaml.tmpl \
+      --ignore-not-found
+    kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/orka-full.yaml
+    exit 0
+  elif [[ "$1" == "--help" ]]; then
+    echo "$USAGE"
+    exit 0
+  else
+    echo -e "Unkown argument: $1\n"
+    echo "$USAGE"
+    exit 1
+  fi
+else
+  ACTION="apply"
+fi
+
+# Install config map
+YAML_TEMPLATE=$(mktemp)
+trap "rm -f $YAML_TEMPLATE" EXIT
+
+curl --fail --location ${BASE_URL}/resources/orka-tekton-config.yaml.tmpl --output $YAML_TEMPLATE
+sed -e 's|$(url)|'"$ORKA_API"'|' $YAML_TEMPLATE \
+  > ${YAML_TEMPLATE}.new
+mv ${YAML_TEMPLATE}.new $YAML_TEMPLATE
+kubectl $ACTION --namespace=$NAMESPACE -f $YAML_TEMPLATE
+
+# Install tasks
+kubectl $ACTION --namespace=$NAMESPACE -f ${BASE_URL}/orka-full.yaml

--- a/task/orka-full/0.2/orka-full.yaml
+++ b/task/orka-full/0.2/orka-full.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-full
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -21,11 +21,11 @@ spec:
     - name: base-image
       type: string
       description: The Orka base image to use for the VM config.
-    - name: orka-image
+    - name: docker-image
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
     - name: cpu-count
       type: string
       description: |
@@ -41,6 +41,35 @@ spec:
       type: string
       description: Enables or disables VNC for the VM.
       default: "false"
+    - name: vm-metadata
+      type: string
+      description: |
+        "Inject custom metadata to the VM (on Intel nodes only). You need to provide the metadata in format:
+        [
+          { key: firstKey, value: firstValue },
+          { key: secondKey, value: secondsValue }
+        ]"
+      default: ""
+    - name: system-serial
+      type: string
+      description: "Assign an owned macOS system serial number to the VM (on Intel nodes only)."
+      default: ""
+    - name: gpu-passthrough
+      type: string
+      description: Enables or disables GPU passthrough for the VM (on Intel nodes only).
+      default: "false"
+    - name: tag
+      type: string
+      description: When specified, the VM is preferred to be deployed to a node marked with this tag.
+      default: ""
+    - name: tag-required
+      type: string
+      description: VM is required to be deployed to a node marked with tag specified above.
+      default: "false"
+    - name: scheduler
+      type: string
+      description: "When set to 'most-allocated', the deployed VM will be scheduled to nodes having most of their resources allocated."
+      default: "default"
     - name: script
       type: string
       description: |
@@ -109,7 +138,7 @@ spec:
     workingDir: /workspace
   steps:
     - name: copy-script
-      image: $(params.orka-image)
+      image: $(params.docker-image)
       script: |
         #!/bin/sh
         SCRIPT=$(mktemp)
@@ -119,7 +148,7 @@ spec:
         EOF
         copy-script $SCRIPT
     - name: build
-      image: $(params.orka-image)
+      image: $(params.docker-image)
       securityContext:
         privileged: true
       env:
@@ -136,6 +165,18 @@ spec:
           value: $(params.vcpu-count)
         - name: VNC_CONSOLE
           value: $(params.vnc-console)
+        - name: VM_METADATA
+          value: $(params.vm-metadata)
+        - name: SYSTEM_SERIAL
+          value: $(params.system-serial)
+        - name: GPU_PASSTHROUGH
+          value: $(params.gpu-passthrough)
+        - name: TAG
+          value: $(params.tag)
+        - name: TAG_REQUIRED
+          value: $(params.tag-required)
+        - name: SCHEDULER
+          value: $(params.scheduler)
         - name: VERBOSE
           value: $(params.verbose)
         - name: COPY_BUILD

--- a/task/orka-full/0.2/orka-full.yaml
+++ b/task/orka-full/0.2/orka-full.yaml
@@ -1,0 +1,177 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-full
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Cloud, Kubernetes
+    tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    With this Task, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task creates a VM template with the specified configuration,
+    deploys a VM instance from it, and then cleans up the environment.
+    All operations in this `Task` are performed against an Orka environment.
+  params:
+    - name: base-image
+      type: string
+      description: The Orka base image to use for the VM config.
+    - name: orka-image
+      type: string
+      description: |
+        The name of the docker image which runs the task step.
+      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+    - name: cpu-count
+      type: string
+      description: |
+        The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24.
+      default: "3"
+    - name: vcpu-count
+      type: string
+      description: |
+        The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3.
+        Otherwise, must equal half of or exactly the number of CPUs specified.
+      default: "3"
+    - name: vnc-console
+      type: string
+      description: Enables or disables VNC for the VM.
+      default: "false"
+    - name: script
+      type: string
+      description: |
+        The script to run inside of the VM. The script will be prepended with the following
+        if no shebang is present:
+
+        #!/bin/sh
+        set -ex
+
+        You can set your shebang instead (e.g., to run a script with your preferred shell or a scripting language like Python or Ruby).
+    - name: copy-build
+      type: string
+      description: |
+        Specifies whether to copy build artifacts from the Orka VM back to the workspace.
+        Disable when there is no need to copy build artifacts (e.g., when running tests or linting code).
+      default: "true"
+    - name: verbose
+      type: string
+      description: Enables verbose logging for all connection activity to the VM.
+      default: "false"
+    - name: orka-creds-secret
+      type: string
+      description: The name of the secret holding your Orka credentials.
+      default: orka-creds
+    - name: orka-creds-email-key
+      type: string
+      description: |
+        The name of the key in the Orka user credentials secret for the email address associated with the Orka user.
+      default: email
+    - name: orka-creds-password-key
+      type: string
+      description: |
+        The name of the key in the Orka credentials secret for the password associated with the Orka user.
+      default: password
+    - name: ssh-key
+      type: string
+      description: |
+        Specifies whether the SSH credentials secret contains an SSH key, as opposed to a password.
+      default: "false"
+    - name: ssh-secret
+      type: string
+      description: The name of the secret holding your VM SSH credentials.
+      default: orka-ssh-creds
+    - name: ssh-username-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the username associated with the macOS VM.
+      default: username
+    - name: ssh-password-key
+      type: string
+      description: |
+        The name of the key in the VM SSH credentials secret for the password
+        associated with the macOS VM.
+
+        If ssh-key is true, this parameter should specify the name of the key in
+        the VM SSH credentials secret that holds the private SSH key.
+      default: password
+    - name: user-home
+      type: string
+      default: /tekton/home
+      description: Absolute path to the user's home directory.
+  stepTemplate:
+    env:
+      - name: HOME
+        value: $(params.user-home)
+    workingDir: /workspace
+  steps:
+    - name: copy-script
+      image: $(params.orka-image)
+      script: |
+        #!/bin/sh
+        SCRIPT=$(mktemp)
+        # Safeguard against having to escape quotes / vars in script
+        cat > $SCRIPT << 'EOF'
+        $(params.script)
+        EOF
+        copy-script $SCRIPT
+    - name: build
+      image: $(params.orka-image)
+      securityContext:
+        privileged: true
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: BASE_IMAGE
+          value: $(params.base-image)
+        - name: CPU_COUNT
+          value: $(params.cpu-count)
+        - name: VCPU_COUNT
+          value: $(params.vcpu-count)
+        - name: VNC_CONSOLE
+          value: $(params.vnc-console)
+        - name: VERBOSE
+          value: $(params.verbose)
+        - name: COPY_BUILD
+          value: $(params.copy-build)
+        - name: SSH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: $(params.ssh-secret)
+              key: $(params.ssh-username-key)
+        - name: SSH_PASSFILE
+          value: /etc/$(params.ssh-secret)/$(params.ssh-password-key)
+        - name: SSH_KEY
+          value: $(params.ssh-key)
+        - name: SVC_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-email-key)
+        - name: SVC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-password-key)
+      volumeMounts:
+        - name: ssh-creds
+          readOnly: true
+          mountPath: /etc/$(params.ssh-secret)
+      command:
+        - orka-full
+  volumes:
+    - name: ssh-creds
+      secret:
+        secretName: $(params.ssh-secret)
+        items:
+          - key: $(params.ssh-password-key)
+            path: $(params.ssh-password-key)
+            mode: 256
+  workspaces:
+    - name: orka

--- a/task/orka-full/0.2/resources/orka-creds.yaml.tmpl
+++ b/task/orka-full/0.2/resources/orka-creds.yaml.tmpl
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: $(email)
+  password: $(password)

--- a/task/orka-full/0.2/resources/orka-ssh-creds.yaml.tmpl
+++ b/task/orka-full/0.2/resources/orka-ssh-creds.yaml.tmpl
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: $(username)
+  password: $(password)

--- a/task/orka-full/0.2/resources/orka-tekton-config.yaml.tmpl
+++ b/task/orka-full/0.2/resources/orka-tekton-config.yaml.tmpl
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: $(url)

--- a/task/orka-full/0.2/samples/build-audiokit-pipeline.yaml
+++ b/task/orka-full/0.2/samples/build-audiokit-pipeline.yaml
@@ -1,6 +1,6 @@
 # ###
 # This example relies on the git-clone Task:
-# https://github.com/tektoncd/catalog/tree/main/task/git-clone/0.2
+# https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.2
 #
 # ###
 #
@@ -11,15 +11,18 @@
 # which can be consumed by a later Task in the Pipeline, or simply
 # saved to a cloud storage bucket.
 #
+# You will first need to install Xcode on the VM and commit or save an
+# image using `orka image commit` or `orka image save` and specify that base image.
+#
 # ###
 # Install the git-clone task:
-# kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.2/git-clone.yaml
+# kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-clone/0.2/git-clone.yaml
 # ###
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: build-audiokit-pipeline
+  name: build-calcupad-pipeline
 spec:
   workspaces:
     - name: shared-data
@@ -32,8 +35,10 @@ spec:
           workspace: shared-data
       params:
         - name: url
-          value: https://github.com/audiokit/AudioKit.git
-    - name: build-audiokit
+          value: https://github.com/kwonye/calcupad.git
+        - name: revision
+          value: f59faf96b1d45120bc6a3b4ea9e94d4fd67fb9a3
+    - name: build-calcupad
       runAfter:
         - fetch-repo
       taskRef:
@@ -49,14 +54,13 @@ spec:
           value: "true"
         - name: script
           value: |
-            cd AudioKit/iOS
-            time xcodebuild
+            time xcodebuild CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
       workspaces:
         - name: orka
           workspace: shared-data
     - name: show-build
       runAfter:
-        - build-audiokit
+        - build-calcupad
       workspaces:
         - name: source
           workspace: shared-data
@@ -65,20 +69,21 @@ spec:
           - name: source
         steps:
           - name: list
-            image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+            image: docker.io/macstadium/orka-tekton-runner:master
             script: |
               #!/bin/sh
               set -ex
-              ls -al $(workspaces.source.path)/AudioKit/iOS
-              ls -al $(workspaces.source.path)/AudioKit/iOS/build
+              ls -al $(workspaces.source.path)
+              ls -al $(workspaces.source.path)/build
+              ls -al $(workspaces.source.path)/build/Release-iphoneos
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: run-build-audiokit-pipeline
+  name: run-build-calcupad-pipeline
 spec:
   pipelineRef:
-    name: build-audiokit-pipeline
+    name: build-calcupad-pipeline
   workspaces:
     - name: shared-data
       volumeClaimTemplate:

--- a/task/orka-full/0.2/samples/build-audiokit-pipeline.yaml
+++ b/task/orka-full/0.2/samples/build-audiokit-pipeline.yaml
@@ -1,0 +1,91 @@
+# ###
+# This example relies on the git-clone Task:
+# https://github.com/tektoncd/catalog/tree/main/task/git-clone/0.2
+#
+# ###
+#
+# This Pipeline will first clone a git repository into a shared workspace.
+# The workspace will then be copied to the Orka VM, and the supplied build
+# script will be executed inside the VM.
+# Build artifacts will then be transferred back to the Tekton workspace,
+# which can be consumed by a later Task in the Pipeline, or simply
+# saved to a cloud storage bucket.
+#
+# ###
+# Install the git-clone task:
+# kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.2/git-clone.yaml
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-audiokit-pipeline
+spec:
+  workspaces:
+    - name: shared-data
+  tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-data
+      params:
+        - name: url
+          value: https://github.com/audiokit/AudioKit.git
+    - name: build-audiokit
+      runAfter:
+        - fetch-repo
+      taskRef:
+        name: orka-full
+      params:
+        - name: base-image
+          value: catalina-buildtools-90G.img
+        - name: cpu-count
+          value: "6"
+        - name: vcpu-count
+          value: "6"
+        - name: verbose
+          value: "true"
+        - name: script
+          value: |
+            cd AudioKit/iOS
+            time xcodebuild
+      workspaces:
+        - name: orka
+          workspace: shared-data
+    - name: show-build
+      runAfter:
+        - build-audiokit
+      workspaces:
+        - name: source
+          workspace: shared-data
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: list
+            image: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+            script: |
+              #!/bin/sh
+              set -ex
+              ls -al $(workspaces.source.path)/AudioKit/iOS
+              ls -al $(workspaces.source.path)/AudioKit/iOS/build
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-build-audiokit-pipeline
+spec:
+  pipelineRef:
+    name: build-audiokit-pipeline
+  workspaces:
+    - name: shared-data
+      volumeClaimTemplate:
+        spec:
+          storageClassName: manual
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/task/orka-full/0.2/samples/dump-disk-info.yaml
+++ b/task/orka-full/0.2/samples/dump-disk-info.yaml
@@ -15,7 +15,7 @@ spec:
     name: orka-full
   params:
     - name: base-image
-      value: catalina-ssh-30G.img
+      value: 90GBMontereySSH.orkasi
     - name: copy-build
       value: "false"
     - name: script

--- a/task/orka-full/0.2/samples/dump-disk-info.yaml
+++ b/task/orka-full/0.2/samples/dump-disk-info.yaml
@@ -1,0 +1,28 @@
+# ###
+# This example shows how to use the orka-full Task to create a single macOS VM.
+# The script provided in the params will be executed inside the VM.
+#
+# You will need to have a secret containing the Orka credentials as well as a
+# secret containing the VM SSH credentials as described in the README.
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: dump-disk-info
+spec:
+  taskRef:
+    name: orka-full
+  params:
+    - name: base-image
+      value: catalina-ssh-30G.img
+    - name: copy-build
+      value: "false"
+    - name: script
+      value: |
+        DISK_INFO=$(mktemp)
+        diskutil info / > $DISK_INFO
+        cat $DISK_INFO
+  workspaces:
+    - name: orka
+      emptyDir: {}

--- a/task/orka-full/0.2/samples/use-ssh-key.yaml
+++ b/task/orka-full/0.2/samples/use-ssh-key.yaml
@@ -1,0 +1,40 @@
+# ###
+# This example demonstrates how to use an SSH key to connect to the Orka VM.
+# You will first need to copy the public key to the VM and commit or save an
+# image using `orka image commit` or `orka image save` and specify that base image.
+# in the TaskRun or Pipeline as a param.
+#
+# You must specify the Task param ssh-key="true" in order to use an SSH key.
+#
+# ###
+# You can create a Kubernetes secret with the SSH credentials as follows:
+# kubectl create secret generic orka-ssh-key --from-file=id_rsa=/path/to/id_rsa --from-literal=username=<username>
+# ###
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: use-ssh-key
+spec:
+  taskRef:
+    name: orka-full
+  params:
+    - name: base-image
+      value: catalina-ssh-key-30G.img
+    - name: ssh-secret
+      value: orka-ssh-key
+    - name: ssh-password-key
+      value: id_rsa
+    - name: ssh-key
+      value: "true"
+    - name: verbose
+      value: "true"
+    - name: copy-build
+      value: "false"
+    - name: script
+      value: |
+        #!/usr/bin/env ruby
+        puts "Hello macOS"
+  workspaces:
+    - name: orka
+      emptyDir: {}

--- a/task/orka-full/0.2/tests/mocks/orka.yaml
+++ b/task/orka-full/0.2/tests/mocks/orka.yaml
@@ -1,0 +1,40 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/deploy
+response:
+  status: 200
+  output: '{"ip": "localhost", "ssh_port": "22"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/purge
+response:
+  status: 200
+  output: '{"message": "Successfully purged VM"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /token
+response:
+  status: 200
+  output: '{"tokensRevoked": 1}'
+  content-type: text/json

--- a/task/orka-full/0.2/tests/mods/mod_task.py
+++ b/task/orka-full/0.2/tests/mods/mod_task.py
@@ -1,0 +1,38 @@
+import os, sys, yaml
+
+def str_presenter(dumper, data):
+  scalar_style = "|" if len(data.splitlines()) > 1 else None
+  return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=scalar_style)
+
+yaml.add_representer(str, str_presenter)
+
+if __name__ == "__main__":
+    # Load YAML files
+    with open(os.path.join(sys.path[0], "..", "mocks", "orka.yaml"), "r", encoding="utf-8") as f:
+        mocks = f.read()
+
+    with open(os.path.join(sys.path[0], "sidecars.yaml"), "r", encoding="utf-8") as f:
+        sidecars = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    with open(os.path.join(sys.path[0], "volumes.yaml"), "r", encoding="utf-8") as f:
+        volumes = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    # Modify Task YAML
+    sidecars.append({
+        "name": "go-rest-api",
+        "image": "gcr.io/tekton-releases/dogfooding/go-rest-api-test:latest",
+        "env": [
+            {
+                "name": "CONFIG",
+                "value": mocks
+            }
+        ]
+    })
+    data["spec"]["sidecars"] = sidecars
+    data["spec"]["volumes"] += volumes
+
+    # Dump YAML
+    print(yaml.dump(data, default_flow_style=False))

--- a/task/orka-full/0.2/tests/mods/sidecars.yaml
+++ b/task/orka-full/0.2/tests/mods/sidecars.yaml
@@ -1,0 +1,12 @@
+---
+- name: ssh-server
+  image: panubo/sshd:1.3.0
+  env:
+    - name: "SSH_USERS"
+      value: "admin:1000:1000"
+    - name: "SSH_ENABLE_PASSWORD_AUTH"
+      value: "true"
+  volumeMounts:
+    - name: startup-script
+      mountPath: "/etc/entrypoint.d"
+      readOnly: true

--- a/task/orka-full/0.2/tests/mods/volumes.yaml
+++ b/task/orka-full/0.2/tests/mods/volumes.yaml
@@ -1,0 +1,8 @@
+---
+- name: startup-script
+  configMap:
+    name: ssh-scripts
+    items:
+      - key: "startup-script"
+        path: "startup.sh"
+        mode: 448

--- a/task/orka-full/0.2/tests/pre-apply-task-hook.sh
+++ b/task/orka-full/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp ${TMPF} ${TMPF}.mod
+python3 ${taskdir}/tests/mods/mod_task.py ${TMPF}.mod > ${TMPF}
+rm -f ${TMPF}.mod

--- a/task/orka-full/0.2/tests/resources.yaml
+++ b/task/orka-full/0.2/tests/resources.yaml
@@ -1,0 +1,36 @@
+# Secrets set and used for local test instance.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssh-scripts
+data:
+  startup-script: |
+    #!/usr/bin/env bash
+    set -e
+    echo "admin:admin" | chpasswd
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-ssh-creds
+type: Opaque
+stringData:
+  username: admin
+  password: admin

--- a/task/orka-full/0.2/tests/run.yaml
+++ b/task/orka-full/0.2/tests/run.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: orka-full-test-run
+spec:
+  taskRef:
+    name: orka-full
+  params:
+    - name: base-image
+      value: base-image.img
+    - name: copy-build
+      value: "false"
+    - name: verbose
+      value: "true"
+    - name: script
+      value: |
+        echo "Hello from TektonCD test"
+  workspaces:
+    - name: orka
+      emptyDir: {}

--- a/task/orka-init/0.2/README.md
+++ b/task/orka-init/0.2/README.md
@@ -17,7 +17,7 @@ The Task can be run on `linux/amd64` platform.
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
 * You need an Orka environment with the following components:
   * Orka 1.4.1 or later.
-  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.20`, `http://10.221.188.100` or `https://<custom-domain>`.
   * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
   * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
 * You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
@@ -26,6 +26,8 @@ The Task can be run on `linux/amd64` platform.
 See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
 
 See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+> **NOTE:** Beginning with Orka 2.1.0, net new Orka clusters are configured with the Orka service endpoint as `http://10.221.188.20`. Existing clusters will continue to use the service endpoint as initially configured, typically `http://10.221.188.100`.
 
 ## Installation
 
@@ -41,12 +43,12 @@ kind: ConfigMap
 metadata:
   name: orka-tekton-config
 data:
-  ORKA_API: http://10.221.188.100
+  ORKA_API: http://10.221.188.20
 ```
 
 ```sh
 kubectl apply --namespace=<namespace> -f orka-configuration.yaml
-kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-init/0.1/orka-init.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-init/0.2/orka-init.yaml
 ```
 
 Omit `--namespace` if installing in the `default` namespace.
@@ -135,10 +137,13 @@ Omit `--namespace` if installing in the `default` namespace.
 | Parameter | Description | Default |
 | --- | --- | ---: |
 | `base-image` | The Orka base image to use for the VM config. | --- |
-| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |
+| `docker-image` | The docker image used to run the task steps. | ghcr.io/macstadium/orka-tekton-runner:0.2 |
 | `cpu-count` | The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24. | 3 |
 | `vcpu-count` | The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3. Otherwise, must equal half of or exactly the number of CPUs specified. | 3 |
 | `vnc-console` | Enables or disables VNC for the VM. | false |
+| `tag` | When specified, the VM is preferred to be deployed to a node marked with this tag. | --- |
+| `tag-required` | VM is required to be deployed to a node marked with tag specified above. | false |
+| `scheduler` | When set to 'most-allocated', the deployed VM will be scheduled to nodes having most of their resources allocated. | default |
 
 ### Configuring secrets and config maps
 

--- a/task/orka-init/0.2/README.md
+++ b/task/orka-init/0.2/README.md
@@ -1,0 +1,153 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task`, along with `orka-deploy` and `orka-teardown`, allows you to utilize multiple macOS build agents in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-init`
+
+A `Task` that creates a VM template with the specified configuration. All operations in this `Task` are performed against an Orka environment.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+* For the `orka-init` and `orka-teardown` tasks, you need a Kubernetes service account, a cluster role, and a cluster role binding. See [Kubernetes service account setup](#kubernetes-service-account-setup).
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster.
+
+You can use the following sample `orka-configuration.yaml`. Make sure to provide the correct Orka API endpoint for your Orka environment.
+
+```yaml
+# orka-configuration.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://10.221.188.100
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-configuration.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-init/0.1/orka-init.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+## Kubernetes service account setup
+
+To use the `orka-init` and `orka-teardown` tasks, you need to configure a Kubernetes service account, a cluster role, and a cluster role binding.
+
+You can use the following sample:
+
+```yaml
+# orka-runner.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: orka-runner
+  apiGroup: rbac.authorization.k8s.io
+```
+
+```sh
+kubectl apply -f orka-runner.yaml
+```
+
+Make sure to specify the namespace in which the `orka-init` and `orka-teardown` tasks are installed when declaring the `ServiceAccount` and `ClusterRoleBinding`.
+
+## Storing your credentials
+
+The `orka-init` task looks for a Kubernetes secret that stores your Orka user credentials. This secret is called `orka-creds` by default and is expected to have the keys `email` and `password`.
+
+These defaults exist for convenience, and you can change them using the available [`Task` parameters](#Configuring-Secrets-and-Config-Maps).
+
+You can use the following example configuration. Make sure to provide the correct credentials for your Orka environment.
+
+```yaml
+# orka-creds.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+```
+
+```sh
+kubectl apply --namespace=<namespace> -f orka-creds.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+> **NOTE:** These credentials are used by the `orka-init` task to generate an authentication token to access the Orka API. This authentication token is then used by the `orka-deploy` and `orka-teardown` tasks for all API calls.
+
+## Parameters
+
+### Common parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `base-image` | The Orka base image to use for the VM config. | --- |
+| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |
+| `cpu-count` | The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24. | 3 |
+| `vcpu-count` | The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3. Otherwise, must equal half of or exactly the number of CPUs specified. | 3 |
+| `vnc-console` | Enables or disables VNC for the VM. | false |
+
+### Configuring secrets and config maps
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `orka-creds-secret` | The name of the secret holding your Orka credentials. | orka-creds |
+| `orka-creds-email-key` | The name of the key in the Orka user credentials secret for the email address associated with the Orka user. | email |
+| `orka-creds-password-key` | The name of the key in the Orka credentials secret for the password associated with the Orka user. | password |
+| `orka-token-secret` | The name of the secret holding the authentication token used to access the Orka API. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-token |
+| `orka-token-secret-key` | The name of the key in the Orka token secret, which holds the authentication token. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | token |
+| `orka-vm-name-config` | The name of the config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-vm-name |
+| `orka-vm-name-config-key` | The name of the key in the VM name config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | vm-name |

--- a/task/orka-init/0.2/orka-init.yaml
+++ b/task/orka-init/0.2/orka-init.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-init
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -22,11 +22,11 @@ spec:
     - name: base-image
       type: string
       description: The Orka base image to use for the VM config.
-    - name: orka-image
+    - name: docker-image
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
     - name: cpu-count
       type: string
       description: |
@@ -42,6 +42,22 @@ spec:
       type: string
       description: Enables or disables VNC for the VM.
       default: "true"
+    - name: io-boost
+      type: string
+      description: Enables or disables IO performance improvements for the VM.
+      default: "false"
+    - name: tag
+      type: string
+      description: When specified, the VM is preferred to be deployed to a node marked with this tag.
+      default: ""
+    - name: tag-required
+      type: string
+      description: VM is required to be deployed to a node marked with tag specified above.
+      default: "false"
+    - name: scheduler
+      type: string
+      description: "When set to 'most-allocated', the deployed VM will be scheduled to nodes having most of their resources allocated."
+      default: "default"
     - name: orka-creds-secret
       type: string
       description: The name of the secret holding your Orka credentials.
@@ -78,7 +94,7 @@ spec:
       default: vm-name
   steps:
     - name: orka-init
-      image: "$(params.orka-image)"
+      image: "$(params.docker-image)"
       securityContext:
         privileged: true
       env:
@@ -95,6 +111,12 @@ spec:
           value: $(params.vcpu-count)
         - name: VNC_CONSOLE
           value: $(params.vnc-console)
+        - name: TAG
+          value: $(params.tag)
+        - name: TAG_REQUIRED
+          value: $(params.tag-required)
+        - name: SCHEDULER
+          value: $(params.scheduler)
         - name: SVC_EMAIL
           valueFrom:
             secretKeyRef:

--- a/task/orka-init/0.2/orka-init.yaml
+++ b/task/orka-init/0.2/orka-init.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-init
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Cloud, Kubernetes
+    tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/tags: "orka, macstadium, init, setup"
+    tekton.dev/displayName: "MacStadium Orka Init"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    With this set of Tasks, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task creates a VM template with the specified configuration.
+    All operations in this Task are performed against an Orka environment.
+  params:
+    - name: base-image
+      type: string
+      description: The Orka base image to use for the VM config.
+    - name: orka-image
+      type: string
+      description: |
+        The name of the docker image which runs the task step.
+      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+    - name: cpu-count
+      type: string
+      description: |
+        The number of CPU cores to dedicate for the VM. Must be 3, 4, 6, 8, 12, or 24.
+      default: "3"
+    - name: vcpu-count
+      type: string
+      description: |
+        The number of vCPUs for the VM. Must equal the number of CPUs, when CPU is less than or equal to 3.
+        Otherwise, must equal half of or exactly the number of CPUs specified.
+      default: "3"
+    - name: vnc-console
+      type: string
+      description: Enables or disables VNC for the VM.
+      default: "true"
+    - name: orka-creds-secret
+      type: string
+      description: The name of the secret holding your Orka credentials.
+      default: orka-creds
+    - name: orka-creds-email-key
+      type: string
+      description: |
+        The name of the key in the Orka user credentials secret for the email address associated with the Orka user.
+      default: email
+    - name: orka-creds-password-key
+      type: string
+      description: |
+        The name of the key in the Orka credentials secret for the password associated with the Orka user.
+      default: password
+    - name: orka-token-secret
+      type: string
+      description: |
+        The name of the secret holding the authentication token used to access the Orka API.
+      default: orka-token
+    - name: orka-token-secret-key
+      type: string
+      description: |
+        The name of the key in the Orka token secret, which holds the authentication token.
+      default: token
+    - name: orka-vm-name-config
+      type: string
+      description: |
+        The name of the config map, which stores the name of the generated VM configuration.
+      default: orka-vm-name
+    - name: orka-vm-name-config-key
+      type: string
+      description: |
+        The name of the key in the VM name config map, which stores the name of the generated VM configuration.
+      default: vm-name
+  steps:
+    - name: orka-init
+      image: "$(params.orka-image)"
+      securityContext:
+        privileged: true
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: BASE_IMAGE
+          value: $(params.base-image)
+        - name: CPU_COUNT
+          value: $(params.cpu-count)
+        - name: VCPU_COUNT
+          value: $(params.vcpu-count)
+        - name: VNC_CONSOLE
+          value: $(params.vnc-console)
+        - name: SVC_EMAIL
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-email-key)
+        - name: SVC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-creds-secret)
+              key: $(params.orka-creds-password-key)
+      script: |
+        #!/bin/sh
+        set -x
+        orka-init
+        if [ $? -ne 0 ]; then
+          orka-cleanup
+          exit 1
+        fi
+        TOKEN=/etc/orka-token
+        VM_NAME=/etc/orka-vm-name
+        if [ -f "$TOKEN" ] && [ -f "$VM_NAME" ]; then
+          kubectl delete secret $(params.orka-token-secret) --ignore-not-found
+          kubectl create secret generic $(params.orka-token-secret) \
+            --from-file=$(params.orka-token-secret-key)=$TOKEN
+          kubectl delete configmap $(params.orka-vm-name-config) --ignore-not-found
+          kubectl create configmap $(params.orka-vm-name-config) \
+            --from-file=$(params.orka-vm-name-config-key)=$VM_NAME
+        else
+          echo "fatal: could not create resources!"
+          orka-cleanup
+          exit 1
+        fi

--- a/task/orka-init/0.2/tests/fixtures/orka.yaml
+++ b/task/orka-init/0.2/tests/fixtures/orka.yaml
@@ -1,0 +1,16 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json

--- a/task/orka-init/0.2/tests/resources.yaml
+++ b/task/orka-init/0.2/tests/resources.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: orka-svc
-  namespace: orka-init-0-1
+  namespace: orka-init-0-2
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -42,7 +42,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: orka-svc
-  namespace: orka-init-0-1
+  namespace: orka-init-0-2
 roleRef:
   kind: ClusterRole
   name: orka-runner-init

--- a/task/orka-init/0.2/tests/resources.yaml
+++ b/task/orka-init/0.2/tests/resources.yaml
@@ -1,0 +1,49 @@
+# Secrets set and used for local test instance.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: orka-init-0-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner-init
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner-init
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: orka-init-0-1
+roleRef:
+  kind: ClusterRole
+  name: orka-runner-init
+  apiGroup: rbac.authorization.k8s.io

--- a/task/orka-init/0.2/tests/run.yaml
+++ b/task/orka-init/0.2/tests/run.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: orka-init-test-run
+spec:
+  serviceAccountName: orka-svc
+  taskRef:
+    name: orka-init
+  params:
+    - name: base-image
+      value: base-image.img

--- a/task/orka-teardown/0.2/README.md
+++ b/task/orka-teardown/0.2/README.md
@@ -17,7 +17,7 @@ The Task can be run on `linux/amd64` platform.
 * You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
 * You need an Orka environment with the following components:
   * Orka 1.4.1 or later.
-  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.20`, `http://10.221.188.100` or `https://<custom-domain>`.
   * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
   * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
 * You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
@@ -27,12 +27,14 @@ See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-s
 
 See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
 
+> **NOTE:** Beginning with Orka 2.1.0, net new Orka clusters are configured with the Orka service endpoint as `http://10.221.188.20`. Existing clusters will continue to use the service endpoint as initially configured, typically `http://10.221.188.100`.
+
 ## Installation
 
-Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.1/README.md#installation) for more information on setting up the Orka API configuration.
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.2/README.md#installation) for more information on setting up the Orka API configuration.
 
 ```sh
-kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-teardown/0.1/orka-teardown.yaml
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-teardown/0.2/orka-teardown.yaml
 ```
 
 Omit `--namespace` if installing in the `default` namespace.
@@ -41,7 +43,7 @@ Omit `--namespace` if installing in the `default` namespace.
 
 To use the `orka-init` and `orka-teardown` tasks, you need to configure a Kubernetes service account, a cluster role, and a cluster role binding.
 
-See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.1/README.md#kubernetes-service-account-setup) for more information on setting up a service account.
+See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.2/README.md#kubernetes-service-account-setup) for more information on setting up a service account.
 
 ## Parameters
 
@@ -51,4 +53,4 @@ See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blo
 | `orka-token-secret-key` | The name of the key in the Orka token secret, which holds the authentication token. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | token |
 | `orka-vm-name-config` | The name of the config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-vm-name |
 | `orka-vm-name-config-key` | The name of the key in the VM name config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | vm-name |
-| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |
+| `docker-image` | The docker image used to run the task steps. | ghcr.io/macstadium/orka-tekton-runner:0.2 |

--- a/task/orka-teardown/0.2/README.md
+++ b/task/orka-teardown/0.2/README.md
@@ -1,0 +1,54 @@
+# Run macOS Builds with Tekton and Orka by MacStadium
+
+> **IMPORTANT:** This `Task` requires **Tekton Pipelines v0.16.0 or later** and an Orka environment running on **Orka 1.4.1 or later**.
+
+This `Task`, along with `orka-init` and `orka-deploy`, allows you to utilize multiple macOS build agents in your [Orka environment](https://orkadocs.macstadium.com).
+
+## `orka-teardown`
+
+A `Task` that cleans up the Orka environment after your workload completes. This `Task` deletes the VM instances deployed with `orka-deploy` and their related template.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Prerequisites
+
+* You need a Kubernetes cluster with Tekton Pipelines v0.16.0 or later configured.
+* You need an Orka environment with the following components:
+  * Orka 1.4.1 or later.
+  * [An Orka service endpoint](https://orkadocs.macstadium.com/docs/endpoint-faqs#whats-the-orka-service-endpoint) (IP or custom domain). Usually, `http://10.221.188.100`, `http://10.10.10.100` or `https://<custom-domain>`.
+  * A dedicated Orka user with valid credentials (email & password). Create a new user or request one from your Orka administrator.
+  * An SSH-enabled base image and the respective SSH credentials (email & password OR SSH key). Use an [existing base image](https://orkadocs.macstadium.com/docs/existing-images-upload-management) or [create your own](https://orkadocs.macstadium.com/docs/creating-an-ssh-enabled-image).
+* You need an active VPN connection between your Kubernetes cluster and Orka. Use a [VPN client](https://orkadocs.macstadium.com/docs/vpn-connect) for temporary access or create a [site-to-site VPN tunnel](https://orkadocs.macstadium.com/docs/aws-orka-connections) for permanent access.
+* For the `orka-init` and `orka-teardown` tasks, you need a Kubernetes service account, a cluster role, and a cluster role binding. See [Kubernetes service account setup](#kubernetes-service-account-setup).
+
+See also: [Using Orka, At a Glance](https://orkadocs.macstadium.com/docs/quick-start-introduction)
+
+See also: [GCP-MacStadium Site-to-Site VPN](https://docs.macstadium.com/docs/google-cloud-setup)
+
+## Installation
+
+Before you can use this `Task` in Tekton pipelines, you need to install it and the Orka configuration in your Kubernetes cluster. See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.1/README.md#installation) for more information on setting up the Orka API configuration.
+
+```sh
+kubectl apply --namespace=<namespace> -f https://raw.githubusercontent.com/tektoncd/catalog/task/orka-teardown/0.1/orka-teardown.yaml
+```
+
+Omit `--namespace` if installing in the `default` namespace.
+
+## Kubernetes service account setup
+
+To use the `orka-init` and `orka-teardown` tasks, you need to configure a Kubernetes service account, a cluster role, and a cluster role binding.
+
+See the `orka-init` documentation [here](https://github.com/tektoncd/catalog/blob/main/task/orka-init/0.1/README.md#kubernetes-service-account-setup) for more information on setting up a service account.
+
+## Parameters
+
+| Parameter | Description | Default |
+| --- | --- | ---: |
+| `orka-token-secret` | The name of the secret holding the authentication token used to access the Orka API. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-token |
+| `orka-token-secret-key` | The name of the key in the Orka token secret, which holds the authentication token. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | token |
+| `orka-vm-name-config` | The name of the config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | orka-vm-name |
+| `orka-vm-name-config-key` | The name of the key in the VM name config map, which stores the name of the generated VM configuration. Applicable to `orka-init` / `orka-deploy` / `orka-teardown`. | vm-name |
+| `orka-image` | The docker image used to run the task steps. | docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339 |

--- a/task/orka-teardown/0.2/orka-teardown.yaml
+++ b/task/orka-teardown/0.2/orka-teardown.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: orka-teardown
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Cloud, Kubernetes
+    tekton.dev/pipelines.minVersion: "0.16.0"
+    tekton.dev/tags: "orka, macstadium, teardown, cleanup"
+    tekton.dev/displayName: "MacStadium Orka Teardown"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    With this set of Tasks, you can use your Orka environment
+    to run macOS builds and macOS-related testing from your Tekton pipelines.
+
+    This Task cleans up the Orka environment after your workload completes.
+    This Task deletes the VM instances deployed with `orka-deploy` and their related templates.
+  params:
+    - name: orka-token-secret
+      type: string
+      description: |
+        The name of the secret holding the authentication token used to access the Orka API.
+      default: orka-token
+    - name: orka-token-secret-key
+      type: string
+      description: |
+        The name of the key in the Orka token secret, which holds the authentication token.
+      default: token
+    - name: orka-vm-name-config
+      type: string
+      description: |
+        The name of the config map, which stores the name of the generated VM configuration.
+      default: orka-vm-name
+    - name: orka-vm-name-config-key
+      type: string
+      description: |
+        The name of the key in the VM name config map, which stores the name of the generated VM configuration.
+      default: vm-name
+    - name: orka-image
+      type: string
+      description: |
+        The name of the docker image which runs the task step.
+      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+  steps:
+    - name: teardown
+      image: $(params.orka-image)
+      securityContext:
+        privileged: true
+      env:
+        - name: ORKA_API
+          valueFrom:
+            configMapKeyRef:
+              name: orka-tekton-config
+              key: ORKA_API
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.orka-token-secret)
+              key: $(params.orka-token-secret-key)
+        - name: VM_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: $(params.orka-vm-name-config)
+              key: $(params.orka-vm-name-config-key)
+      script: |
+        #!/bin/sh
+        set -x
+        orka-cleanup
+        kubectl delete secret $(params.orka-token-secret) --ignore-not-found
+        kubectl delete configmap $(params.orka-vm-name-config) --ignore-not-found

--- a/task/orka-teardown/0.2/orka-teardown.yaml
+++ b/task/orka-teardown/0.2/orka-teardown.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: orka-teardown
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/categories: Cloud, Kubernetes
     tekton.dev/pipelines.minVersion: "0.16.0"
@@ -39,14 +39,14 @@ spec:
       description: |
         The name of the key in the VM name config map, which stores the name of the generated VM configuration.
       default: vm-name
-    - name: orka-image
+    - name: docker-image
       type: string
       description: |
         The name of the docker image which runs the task step.
-      default: docker.io/macstadium/orka-tekton-runner:2020-10-23-a93757dc-0.1@sha256:e8ed3370dcb91cdb8bcd4e9a7e9f6652879d80acdab9644cda69a98cd8c93339
+      default: ghcr.io/macstadium/orka-tekton-runner:0.2
   steps:
     - name: teardown
-      image: $(params.orka-image)
+      image: $(params.docker-image)
       securityContext:
         privileged: true
       env:

--- a/task/orka-teardown/0.2/tests/mocks/orka.yaml
+++ b/task/orka-teardown/0.2/tests/mocks/orka.yaml
@@ -1,0 +1,40 @@
+---
+headers:
+  method: POST
+  path: /token
+response:
+  status: 200
+  output: '{"token": "abcd"}'
+  content-type: text/json
+---
+headers:
+  method: POST
+  path: /resources/vm/create
+response:
+  status: 200
+  output: '{"status": 200}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/delete
+response:
+  status: 200
+  output: '{"message": "Successfully deleted VM"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /resources/vm/purge
+response:
+  status: 200
+  output: '{"message": "Successfully purged VM"}'
+  content-type: text/json
+---
+headers:
+  method: DELETE
+  path: /token
+response:
+  status: 200
+  output: '{"tokensRevoked": 1}'
+  content-type: text/json

--- a/task/orka-teardown/0.2/tests/mods/mod_task.py
+++ b/task/orka-teardown/0.2/tests/mods/mod_task.py
@@ -1,0 +1,34 @@
+import os, sys, yaml
+
+def str_presenter(dumper, data):
+  scalar_style = "|" if len(data.splitlines()) > 1 else None
+  return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=scalar_style)
+
+yaml.add_representer(str, str_presenter)
+
+if __name__ == "__main__":
+    # Load YAML files
+    with open(os.path.join(sys.path[0], "..", "mocks", "orka.yaml"), "r", encoding="utf-8") as f:
+        mocks = f.read()
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        data = yaml.load(f.read(), Loader=yaml.FullLoader)
+
+    go_rest_api = [
+        {
+            "name": "go-rest-api",
+            "image": "quay.io/chmouel/go-rest-api-test",
+            "env": [
+                {
+                    "name": "CONFIG",
+                    "value": mocks
+                }
+            ]
+        }
+    ]
+
+    # Modify Task YAML
+    data["spec"]["sidecars"] = go_rest_api
+
+    # Dump YAML
+    print(yaml.dump(data, default_flow_style=False))

--- a/task/orka-teardown/0.2/tests/pre-apply-task-hook.sh
+++ b/task/orka-teardown/0.2/tests/pre-apply-task-hook.sh
@@ -3,7 +3,7 @@
 # Modify orka-init
 ORKA_INIT=$(mktemp /tmp/.mm.XXXXXX)
 MOD_SCRIPT=${taskdir}/tests/mods/mod_task.py
-cp task/orka-init/0.1/orka-init.yaml ${ORKA_INIT}
+cp task/orka-init/0.2/orka-init.yaml ${ORKA_INIT}
 python3 ${MOD_SCRIPT} ${ORKA_INIT} > ${ORKA_INIT}.mod
 
 # Add orka-init

--- a/task/orka-teardown/0.2/tests/pre-apply-task-hook.sh
+++ b/task/orka-teardown/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Modify orka-init
+ORKA_INIT=$(mktemp /tmp/.mm.XXXXXX)
+MOD_SCRIPT=${taskdir}/tests/mods/mod_task.py
+cp task/orka-init/0.1/orka-init.yaml ${ORKA_INIT}
+python3 ${MOD_SCRIPT} ${ORKA_INIT} > ${ORKA_INIT}.mod
+
+# Add orka-init
+${KUBECTL_CMD} -n "${tns}" apply -f ${ORKA_INIT}.mod
+rm -f ${ORKA_INIT} ${ORKA_INIT}.mod
+
+# Modify task
+cp ${TMPF} ${TMPF}.read
+python3 ${MOD_SCRIPT} ${TMPF}.read > ${TMPF}
+rm -f ${TMPF}.read

--- a/task/orka-teardown/0.2/tests/resources.yaml
+++ b/task/orka-teardown/0.2/tests/resources.yaml
@@ -1,0 +1,49 @@
+# Secrets set and used for local test instance.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orka-tekton-config
+data:
+  ORKA_API: http://localhost:8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: orka-creds
+type: Opaque
+stringData:
+  email: tekton-svc@macstadium.com
+  password: p@ssw0rd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: orka-svc
+  namespace: orka-teardown-0-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orka-runner-teardown
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orka-runner-teardown
+subjects:
+- kind: ServiceAccount
+  name: orka-svc
+  namespace: orka-teardown-0-1
+roleRef:
+  kind: ClusterRole
+  name: orka-runner-teardown
+  apiGroup: rbac.authorization.k8s.io

--- a/task/orka-teardown/0.2/tests/resources.yaml
+++ b/task/orka-teardown/0.2/tests/resources.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: orka-svc
-  namespace: orka-teardown-0-1
+  namespace: orka-teardown-0-2
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -42,7 +42,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: orka-svc
-  namespace: orka-teardown-0-1
+  namespace: orka-teardown-0-2
 roleRef:
   kind: ClusterRole
   name: orka-runner-teardown

--- a/task/orka-teardown/0.2/tests/run.yaml
+++ b/task/orka-teardown/0.2/tests/run.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: orka-teardown-test
+spec:
+  tasks:
+    - name: init
+      taskRef:
+        name: orka-init
+      params:
+        - name: base-image
+          value: base-image.img
+    - name: teardown
+      runAfter:
+        - init
+      taskRef:
+        name: orka-teardown
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: orka-teardown-test-run
+spec:
+  serviceAccountName: orka-svc
+  pipelineRef:
+    name: orka-teardown-test


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Added version `0.2` for tasks `orka-deploy`, `orka-full`, `orka-init` and `orka-teardown`

* Compatibility changes to make the pipelines also work properly when using Tekton v0.34.1
* Added additional task parameters for feature parity with Orka v2.1.0:
  * `system-serial`: Assign an owned macOS system serial number to the VM (on Intel nodes only).
  * `gpu-passthrough`: Enables or disables GPU passthrough for the VM (on Intel nodes only).
  * `tag`: When specified, the VM is preferred to be deployed to a node marked with this tag.
  * `tag-required`: VM is required to be deployed to a node marked with tag specified above.
  * `scheduler`: When set to 'most-allocated', the deployed VM will be scheduled to nodes having most of their resources allocated.
* Modified build-audiokit-pipeline example to use a different open-source iOS project (Calcupad) for compatibility reasons
* Changes in scripts to dynamically add additional parameters to VM config/deploy request when they are passed in pipelines

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
