### PR TITLE
Add fully flexible script to yq task

### DIFF
--- a/task/yq/0.4/README.md
+++ b/task/yq/0.4/README.md
@@ -1,0 +1,28 @@
+# YQ Task
+
+The following task is used to interface with the yq tool on any file in your workspace.
+
+## Installing the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/yq/0.4/yq.yaml
+```
+
+## Parameters
+
+- **SCRIPT**: The yq script to execute. Can be multiple lines for complex tasks.
+- **image**: The `yq` image to use. (_default:_ docker.io/mikefarah/yq:4.16.2@sha256:0d4f6e27bdcac7316f635acd524ab0eecc4ad50834b54d10322268650c7712cb)
+- **files**: (deprecated, use SCRIPT instead) A list of files to execute the expression on. Needs to be relative to the source workspace. (_default:_ [])
+- **expression**: (deprecated, use SCRIPT instead) The yq expression to apply. Can be used to replace yaml fields. (_default:_ "")
+
+## Workspaces
+
+- **source** : The workspace containing files on which we want to run yq commands.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+For a real usage example checkout the [tests directory](https://github.com/tektoncd/catalog/tree/main/task/yq/0.4/tests) of this task for an example on how this task can be used on a Github repository. This can be used together with other git actions to commit such changes towards a GitOps repository for example which is automatically reconciled towards your infrastructure.

--- a/task/yq/0.4/tests/pre-apply-task-hook.sh
+++ b/task/yq/0.4/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+add_task git-clone 0.7

--- a/task/yq/0.4/tests/resources.yaml
+++ b/task/yq/0.4/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: yq-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/task/yq/0.4/tests/run.yaml
+++ b/task/yq/0.4/tests/run.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: yq-pipeline
+spec:
+  params:
+    - name: new-image-sha
+      description: example of a value to use
+      default: "123"
+  workspaces:
+    - name: source
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: source
+      params:
+        - name: url
+          value: https://github.com/GijsvanDulmen/yq-task-test
+        - name: revision
+          value: "main"
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: yq-replace
+      taskRef:
+        name: yq
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: SCRIPT
+          value: |
+            for var in "./helm/values.yaml" "./helm/values-development.yaml"
+              do
+                  /usr/bin/yq eval -i '.image="012345my-new-image-sha"' "$var"
+              done
+  finally:
+    - name: display-results
+      workspaces:
+        - name: source
+          workspace: source
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: print
+            image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+            script: |
+              #!/usr/bin/env bash
+              set -e
+              cat $(workspaces.source.path)/helm/values.yaml
+              cat $(workspaces.source.path)/helm/values-development.yaml
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: yq-pipeline-run
+spec:
+  pipelineRef:
+    name: yq-pipeline
+  workspaces:
+    - name: source
+      persistentvolumeclaim:
+        claimName: yq-pvc
+  taskRunSpecs:
+    - pipelineTaskName: yq-replace
+      taskPodTemplate:
+        securityContext:
+          runAsUser: 0

--- a/task/yq/0.4/yq.yaml
+++ b/task/yq/0.4/yq.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: yq
+  labels:
+    app.kubernetes.io/version: "0.4"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Developer Tools
+    tekton.dev/tags: yq
+    tekton.dev/displayName: "YQ"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task can be used to replace fields in YAML files. For example for altering helm charts on GitOps repos.
+  workspaces:
+    - name: source
+      description: A workspace that contains the file which needs to be altered.
+  params:
+    - name: SCRIPT
+      type: string
+      description: The yq script to execute. Can be multiple lines for complex tasks.
+      default: ""
+    - name: image
+      type: string
+      description: The yq image to use.
+      default: docker.io/mikefarah/yq:4.27.5@sha256:2be3626ed633fbe1fc33ee9343a1256a6be53334412b2251b9a859f8c145bb53
+    - name: files
+      type: array
+      description: (deprecated, use SCRIPT instead) A list of files to execute the expression on. Needs to be relative to the source workspace.
+      default: []
+    - name: expression
+      type: string
+      description: (deprecated, use SCRIPT instead) The yq expression to apply. Can be used to replace yaml fields.
+      default: ""
+  results:
+    - name: yq
+      description: The result from your yq command. You can write to it using `$(results.yq.path)`
+  steps:
+    - name: yq-script
+      image: $(params.image)
+      workingDir: $(workspaces.source.path)
+      args: ["$(params.files[*])"]
+      script: |
+        /usr/bin/env sh
+        set -e
+
+        # For backwards compatibility with previous versions
+        if [ "$(params.SCRIPT)" = "" ]; then
+          for var in "$@"
+          do
+              /usr/bin/yq eval -i "$(params.expression)" "$var"
+          done
+          exit $?
+        fi
+
+        $(params.SCRIPT)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The yq task was missing a -P (pretty print) option, as well as a --no-color option. Instead of making new task versions (and params) for each of the myriad of options yq offers, I figured that what I want in a `yq` task is to be able to use yq, however I want it. A script is more suitable for that.

The only problem I have with this change is that it's quite different from the previous versions. I was thinking about splitting it up into a new task, but then the new task's name would not have been `yq`, or the old task would have to be renamed to `yq-replace`, and then we would still be stuck with a big change for every user.

In theory, if you update your task you would take into account you might have to update your pipelines to make them work with the new task version.
Let me know if you think this will be problematic.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
