### PR TITLE
Don't run tasks as root unless required

### DIFF
--- a/task/git-clone/0.8/README.md
+++ b/task/git-clone/0.8/README.md
@@ -1,0 +1,281 @@
+# `git-clone`
+
+**Please Note: this Task is only compatible with Tekton Pipelines versions 0.29.0 and greater!**
+
+This `Task` has two required inputs:
+
+1. The URL of a git repo to clone provided with the `url` param.
+2. A Workspace called `output`.
+
+The `git-clone` `Task` will clone a repo from the provided `url` into the
+`output` Workspace. By default the repo will be cloned into the root of
+your Workspace. You can clone into a subdirectory by setting this `Task`'s
+`subdirectory` param. If the directory where the repo will be cloned is
+already populated then by default the contents will be deleted before the
+clone takes place. This behaviour can be disabled by setting the
+`deleteExisting` param to `"false"`.
+
+## Workspaces
+
+* **output**: A workspace for this Task to fetch the git repository in to.
+* **ssh-directory**: An optional workspace to provide SSH credentials. At
+  minimum this should include a private key but can also include other common
+  files from `.ssh` including `config` and `known_hosts`. It is **strongly**
+  recommended that this workspace be bound to a Kubernetes `Secret`.
+
+* **ssl-ca-directory**: An optional workspace to provide custom CA certificates.
+  Like the /etc/ssl/certs path this directory can have any pem or cert files,
+  this uses libcurl ssl capath directive. See this SO answer here
+  https://stackoverflow.com/a/9880236 on how it works.
+
+* **basic-auth**: An optional workspace containing `.gitconfig` and
+  `.git-credentials` files. This allows username/password/access token to be
+  provided for basic auth.
+
+  It is **strongly** recommended that this workspace be bound to a Kubernetes
+  `Secret`. For details on the correct format of the files in this Workspace
+  see [Using basic-auth Credentials](#using-basic-auth-credentials) below.
+
+  **Note**: Settings provided as part of a `.gitconfig` file can affect the
+  execution of `git` in ways that conflict with the parameters of this Task.
+  For example, specifying proxy settings in `.gitconfig` could conflict with
+  the `httpProxy` and `httpsProxy` parameters this Task provides. Nothing
+  prevents you setting these parameters but it is not advised.
+
+## Parameters
+
+* **url**: Repository URL to clone from. (_required_)
+* **revision**: Revision to checkout. (branch, tag, sha, ref, etc...) (_default_: "")
+* **refspec**: Refspec to fetch before checking out revision. (_default_:"")
+* **submodules**: Initialize and fetch git submodules. (_default_: true)
+* **depth**: Perform a shallow clone, fetching only the most recent N commits. (_default_: 1)
+* **sslVerify**: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote. (_default_: true)
+* **crtFileName**: If `sslVerify` is **true** and `ssl-ca-directory` workspace is given then set `crtFileName` if mounted file name is different than `ca-bundle.crt`. (_default_: "ca-bundle.crt")
+* **subdirectory**: Subdirectory inside the `output` workspace to clone the repo into. (_default:_ "")
+* **deleteExisting**: Clean out the contents of the destination directory if it already exists before cloning. (_default_: true)
+* **httpProxy**: HTTP proxy server for non-SSL requests. (_default_: "")
+* **httpsProxy**: HTTPS proxy server for SSL requests. (_default_: "")
+* **noProxy**: Opt out of proxying HTTP/HTTPS requests. (_default_: "")
+* **verbose**: Log the commands that are executed during `git-clone`'s operation. (_default_: true)
+* **sparseCheckoutDirectories**: Which directories to match or exclude when performing a sparse checkout (_default_: "")
+* **gitInitImage**: The image providing the git-init binary that this Task runs. (_default_: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:TODO")
+* **userHome**: The user's home directory. Set this explicitly if you are running the image as a non-root user. (_default_: "/tekton/home")
+
+## Results
+
+* **commit**: The precise commit SHA that was fetched by this Task
+* **url**: The precise URL that was fetched by this Task
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64`, and `linux/ppc64le` platforms.
+
+## Usage
+
+If the `revision` is not provided in the param of the taskrun
+then it will auto-detect the branch as specified by the `default`
+in the respective git repository.
+
+The following pipelines demonstrate usage of the git-clone Task:
+
+- [Cloning a branch](./samples/git-clone-checking-out-a-branch.yaml)
+- [Checking out a specific git commit](./samples/git-clone-checking-out-a-commit.yaml)
+- [Checking out a git tag and using the "commit" Task Result](./samples/using-git-clone-result.yaml)
+
+## Cloning Private Repositories
+
+This Task supports fetching private repositories. There are three ways to
+authenticate:
+
+1. The simplest approach is to bind an `ssh-directory` workspace to this
+Task. The workspace should contain private keys (e.g. `id_rsa`), `config`
+and `known_hosts` files - anything you need to interact with your git remote
+via SSH. It's **strongly** recommended that you use Kubernetes `Secrets` to
+hold your credentials and bind to this workspace.
+
+    In a TaskRun that would look something like this:
+
+    ```yaml
+    kind: TaskRun
+    spec:
+      workspaces:
+      - name: ssh-directory
+        secret:
+          secretName: my-ssh-credentials
+    ```
+
+    And in a Pipeline and PipelineRun it would look like this:
+
+    ```yaml
+    kind: Pipeline
+    spec:
+      workspaces:
+      - name: ssh-creds
+      # ...
+      tasks:
+      - name: fetch-source
+        taskRef:
+          name: git-clone
+        workspaces:
+        - name: ssh-directory
+          workspace: ssh-creds
+      # ...
+    ---
+    kind: PipelineRun
+    spec:
+      workspaces:
+      - name: ssh-creds
+        secret:
+          secretName: my-ssh-credentials
+      # ...
+    ```
+
+    The `Secret` would appear the same in both cases - structured like a `.ssh`
+    directory:
+
+    ```yaml
+    kind: Secret
+    apiVersion: v1
+    metadata:
+      name: my-ssh-credentials
+    data:
+      id_rsa: # ... base64-encoded private key ...
+      known_hosts: # ... base64-encoded known_hosts file ...
+      config: # ... base64-encoded ssh config file ...
+    ```
+
+    Including `known_hosts` is optional but strongly recommended. Without it
+    the `git-clone` Task will blindly accept the remote server's identity.
+
+2. Use Tekton Pipelines' built-in credentials support as [documented in
+Pipelines' auth.md](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md).
+
+3. Another approach is to bind an `ssl-ca-directory` workspace to this
+Task. The workspace should contain crt keys (e.g. `ca-bundle.crt`)files - anything you need to interact with your git remote
+via custom CA . It's **strongly** recommended that you use Kubernetes `Secrets` to
+hold your credentials and bind to this workspace.
+
+    In a TaskRun that would look something like this:
+
+    ```yaml
+    kind: TaskRun
+    spec:
+      workspaces:
+      - name: ssl-ca-directory
+        secret:
+          secretName: my-ssl-credentials
+    ```
+
+    And in a Pipeline and PipelineRun it would look like this:
+
+    ```yaml
+    kind: Pipeline
+    spec:
+      workspaces:
+      - name: ssl-creds
+      # ...
+      tasks:
+      - name: fetch-source
+        taskRef:
+          name: git-clone
+        workspaces:
+        - name: ssl-ca-directory
+          workspace: ssl-creds
+      # ...
+    ---
+    kind: PipelineRun
+    spec:
+      workspaces:
+      - name: ssl-creds
+        secret:
+          secretName: my-ssl-credentials
+      # ...
+    ```
+
+    The `Secret` would appear like below:
+
+    ```yaml
+    kind: Secret
+    apiVersion: v1
+    metadata:
+      name: my-ssl-credentials
+    data:
+      ca-bundle.crt: # ... base64-encoded crt ...  # If key/filename is other than ca-bundle.crt then set crtFileName param as explained under Parameters section
+    ```
+
+## Running as a Non-Root User
+
+The `git-init` image that this Task utilizes offers a built in nonroot
+user. In combination with support from other Tasks this allows your
+Pipelines to run without needing root permissions. There are some extra
+steps you'll need to take for this to work:
+
+- In the security context for the Task make sure you're using UID 65532.
+
+    In a TaskRun that looks like this:
+
+    ```yaml
+    kind: TaskRun
+    spec:
+      podTemplate:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65532
+    ```
+
+    And in a PipelineRun it looks like this:
+
+    ```yaml
+    kind: PipelineRun
+    spec:
+      taskRunSpecs:
+      - pipelineTaskName: footask # ...your git-clone PipelineTask name...
+        taskPodTemplate:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+    ```
+
+- Make sure to provide the `userHome` param and set it to nonroot's
+home directory:
+
+    ```yaml
+    params:
+    - name: userHome
+      value: /home/nonroot
+    ```
+
+Once these two modifications are in effect you should now see your
+`git-clone` Task run as nonroot. The files cloned on to the `output`
+workspace will end up owned by user 65532.
+
+## Using basic-auth Credentials
+
+**Note**: It is strongly advised that you use `ssh` credentials when the option
+is available to you before using basic auth. You can use generate a short
+lived token from WebVCS platforms (Github, Gitlab, Bitbucket etc..) to be use
+as password and generally be able to use `git` as the username.
+On bitbucket server the token may have a / into it so you would need
+to urlquote them before in the `Secret`, see this stackoverflow answer :
+
+https://stackoverflow.com/a/24719496 
+
+To support basic-auth this Task exposes an optional `basic-auth` Workspace.
+The bound Workspace must contain a `.gitconfig` and `.git-credentials` file.
+Any other files on this Workspace are ignored. A typical `Secret` containing
+these credentials looks as follows:
+
+```yaml
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-basic-auth-secret
+type: Opaque
+stringData:
+  .gitconfig: |
+    [credential "https://<hostname>"]
+      helper = store
+  .git-credentials: |
+    https://<user>:<pass>@<hostname>
+```
+

--- a/task/git-clone/0.8/git-clone.yaml
+++ b/task/git-clone/0.8/git-clone.yaml
@@ -1,0 +1,236 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+  labels:
+    app.kubernetes.io/version: "0.7"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.29.0"
+    tekton.dev/categories: Git
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    These Tasks are Git tasks to work with repositories used by other tasks
+    in your Pipeline.
+
+    The git-clone Task will clone a repo from the provided url into the
+    output Workspace. By default the repo will be cloned into the root of
+    your Workspace. You can clone into a subdirectory by setting this Task's
+    subdirectory param. This Task also supports sparse checkouts. To perform
+    a sparse checkout, pass a list of comma separated directory patterns to
+    this Task's sparseCheckoutDirectories param.
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this Workspace.
+    - name: ssh-directory
+      optional: true
+      description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+    - name: basic-auth
+      optional: true
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+    - name: ssl-ca-directory
+      optional: true
+      description: |
+        A workspace containing CA certificates, this will be used by Git to
+        verify the peer with when fetching or pushing over HTTPS.
+  params:
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: refspec
+      description: Refspec to fetch before checking out revision.
+      default: ""
+    - name: submodules
+      description: Initialize and fetch git submodules.
+      type: string
+      default: "true"
+    - name: depth
+      description: Perform a shallow clone, fetching only the most recent N commits.
+      type: string
+      default: "1"
+    - name: sslVerify
+      description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+      type: string
+      default: "true"
+    - name: crtFileName
+      description: file name of mounted crt using ssl-ca-directory workspace. default value is ca-bundle.crt.
+      type: string
+      default: "ca-bundle.crt"
+    - name: subdirectory
+      description: Subdirectory inside the `output` Workspace to clone the repo into.
+      type: string
+      default: ""
+    - name: sparseCheckoutDirectories
+      description: Define the directory patterns to match or exclude when performing a sparse checkout.
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: Clean out the contents of the destination directory if it already exists before cloning.
+      type: string
+      default: "true"
+    - name: httpProxy
+      description: HTTP proxy server for non-SSL requests.
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: HTTPS proxy server for SSL requests.
+      type: string
+      default: ""
+    - name: noProxy
+      description: Opt out of proxying HTTP/HTTPS requests.
+      type: string
+      default: ""
+    - name: verbose
+      description: Log the commands that are executed during `git-clone`'s operation.
+      type: string
+      default: "true"
+    - name: gitInitImage
+      description: The image providing the git-init binary that this Task runs.
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.29.0"
+    - name: userHome
+      description: |
+        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
+        the gitInitImage param with an image containing custom user configuration.
+      type: string
+      default: "/tekton/home"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: url
+      description: The precise URL that was fetched by this Task.
+  steps:
+    - name: clone
+      image: "$(params.gitInitImage)"
+      env:
+      - name: HOME
+        value: "$(params.userHome)"
+      - name: PARAM_URL
+        value: $(params.url)
+      - name: PARAM_REVISION
+        value: $(params.revision)
+      - name: PARAM_REFSPEC
+        value: $(params.refspec)
+      - name: PARAM_SUBMODULES
+        value: $(params.submodules)
+      - name: PARAM_DEPTH
+        value: $(params.depth)
+      - name: PARAM_SSL_VERIFY
+        value: $(params.sslVerify)
+      - name: PARAM_CRT_FILENAME
+        value: $(params.crtFileName)
+      - name: PARAM_SUBDIRECTORY
+        value: $(params.subdirectory)
+      - name: PARAM_DELETE_EXISTING
+        value: $(params.deleteExisting)
+      - name: PARAM_HTTP_PROXY
+        value: $(params.httpProxy)
+      - name: PARAM_HTTPS_PROXY
+        value: $(params.httpsProxy)
+      - name: PARAM_NO_PROXY
+        value: $(params.noProxy)
+      - name: PARAM_VERBOSE
+        value: $(params.verbose)
+      - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+        value: $(params.sparseCheckoutDirectories)
+      - name: PARAM_USER_HOME
+        value: $(params.userHome)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
+      - name: WORKSPACE_SSH_DIRECTORY_BOUND
+        value: $(workspaces.ssh-directory.bound)
+      - name: WORKSPACE_SSH_DIRECTORY_PATH
+        value: $(workspaces.ssh-directory.path)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+        value: $(workspaces.basic-auth.bound)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+        value: $(workspaces.basic-auth.path)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_BOUND
+        value: $(workspaces.ssl-ca-directory.bound)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
+        value: $(workspaces.ssl-ca-directory.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ] ; then
+          set -x
+        fi
+
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        if [ "${WORKSPACE_SSL_CA_DIRECTORY_BOUND}" = "true" ] ; then
+           export GIT_SSL_CAPATH="${WORKSPACE_SSL_CA_DIRECTORY_PATH}"
+           if [ "${PARAM_CRT_FILENAME}" != "" ] ; then
+              export GIT_SSL_CAINFO="${WORKSPACE_SSL_CA_DIRECTORY_PATH}/${PARAM_CRT_FILENAME}"
+           fi
+        fi
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+          # or the root of a mounted volume.
+          if [ -d "${CHECKOUT_DIR}" ] ; then
+            # Delete non-hidden files and directories
+            rm -rf "${CHECKOUT_DIR:?}"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "${CHECKOUT_DIR}"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "${CHECKOUT_DIR}"/..?*
+          fi
+        }
+
+        if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+          cleandir
+        fi
+
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+        /ko-app/git-init \
+          -url="${PARAM_URL}" \
+          -revision="${PARAM_REVISION}" \
+          -refspec="${PARAM_REFSPEC}" \
+          -path="${CHECKOUT_DIR}" \
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth="${PARAM_DEPTH}" \
+          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "${PARAM_URL}" > "$(results.url.path)"

--- a/task/git-clone/0.8/git-clone.yaml
+++ b/task/git-clone/0.8/git-clone.yaml
@@ -105,10 +105,9 @@ spec:
       default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.29.0"
     - name: userHome
       description: |
-        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
-        the gitInitImage param with an image containing custom user configuration.
+        Absolute path to the user's home directory.
       type: string
-      default: "/tekton/home"
+      default: "/home/nonroot"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task.
@@ -164,6 +163,9 @@ spec:
         value: $(workspaces.ssl-ca-directory.bound)
       - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
         value: $(workspaces.ssl-ca-directory.path)
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
       script: |
         #!/usr/bin/env sh
         set -eu

--- a/task/git-clone/0.8/git-clone.yaml
+++ b/task/git-clone/0.8/git-clone.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: git-clone
   labels:
-    app.kubernetes.io/version: "0.7"
+    app.kubernetes.io/version: "0.8"
   annotations:
     tekton.dev/pipelines.minVersion: "0.29.0"
     tekton.dev/categories: Git

--- a/task/git-clone/0.8/samples/git-clone-checking-out-a-branch.yaml
+++ b/task/git-clone/0.8/samples/git-clone-checking-out-a-branch.yaml
@@ -1,0 +1,75 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cat-branch-readme
+spec:
+  description: |
+    cat-branch-readme takes a git repository and a branch name and
+    prints the README.md file from that branch. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a branch
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: branch-name
+    type: string
+    description: The git branch to clone.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the repo's README.md file to be read.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.branch-name)
+  - name: cat-readme
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          cat $(workspaces.source.path)/README.md
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-checking-out-a-branch
+spec:
+  pipelineRef:
+    name: cat-branch-readme
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: branch-name
+    value: release-v0.12.x

--- a/task/git-clone/0.8/samples/git-clone-checking-out-a-commit.yaml
+++ b/task/git-clone/0.8/samples/git-clone-checking-out-a-commit.yaml
@@ -1,0 +1,121 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: checking-out-a-revision
+spec:
+  description: |
+    checking-out-a-revision takes a git repository and a commit SHA
+    and validates that cloning the revision succeeds. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a specific commit
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: commit
+    type: string
+    description: The git commit to fetch.
+  - name: user-home
+    type: string
+    description: The home directory of the user performing the git clone.
+    default: "/tekton/home"
+  - name: user-uid
+    type: string
+    description: The UID of the user performing the git clone.
+    default: "0"
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the commit to be checked.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.commit)
+    - name: gitInitImage
+      value: localhost:5000/git-init-4874978a9786b6625dd8b6ef2a21aa70:latest
+    - name: userHome
+      value: $(params.user-home)
+  - name: check-expectations
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    params:
+    - name: expected-commit
+      value: $(params.commit)
+    - name: expected-readme-uid
+      value: $(params.user-uid)
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      params:
+      - name: expected-commit
+      - name: expected-readme-uid
+      workspaces:
+      - name: source
+      steps:
+      - image: alpine/git:v2.24.3
+        script: |
+          #!/usr/bin/env sh
+          cd "$(workspaces.source.path)"
+
+          receivedCommit="$(git rev-parse HEAD)"
+          if [ "$receivedCommit" != "$(params.expected-commit)" ]; then
+            echo "Expected commit $(params.expected-commit) but received $receivedCommit."
+            exit 1
+          else
+            echo "Received commit $receivedCommit as expected."
+          fi
+
+          detectedUID="$(ls -l ./README.md | awk '{ print $3 }')"
+          if [ "$detectedUID" != "$(params.expected-readme-uid)" ]; then
+            echo "Expected README UID of $(params.expected-readme-uid) but received $detectedUID."
+            exit 2
+          else
+            echo "Saw README with owner of $detectedUID as expected."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-clone-checking-out-a-commit-
+spec:
+  pipelineRef:
+    name: checking-out-a-revision
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Mi
+  taskRunSpecs:
+  - pipelineTaskName: fetch-repo
+    taskPodTemplate:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532 # nonroot user in git-init container
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: commit
+    value: 301b41380e95382a18b391c2165fa3a6a3de93b0  # Tekton Pipeline's first ever commit!
+  - name: user-home
+    value: "/home/nonroot"
+  - name: user-uid
+    value: "65532"

--- a/task/git-clone/0.8/samples/git-clone-for-ssl-ca.yaml
+++ b/task/git-clone/0.8/samples/git-clone-for-ssl-ca.yaml
@@ -1,0 +1,84 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: cat-readme
+spec:
+  description: |
+    cat-readme takes a git repository and
+    prints the README.md file from main branch. This is an example
+    Pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a main branch for the repo which uses custom CAs for HTTPS
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the repo's README.md file to be read.
+  - name: ssl-ca-dir
+    description: |
+      This workspace contains CA certificates, this will be used by Git to
+      verify the peer with when fetching or pushing over HTTPS.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    - name: ssl-ca-directory
+      workspace: ssl-ca-dir
+    params:
+    - name: url
+      value: $(params.repo-url)
+  - name: cat-readme
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before reading the readme.
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          cat $(workspaces.source.path)/README.md
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-checking-out-a-branch
+spec:
+  pipelineRef:
+    name: cat-branch-readme
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  - name: ssl-ca-dir
+    secret:
+      secretName: my-ssl-credentials
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-ssl-credentials
+data:
+  ca-bundle.crt: jdsfjshfj122w  # base64-encoded crt ... If key/filename is other than ca-bundle.crt then set crtFileName param as explained under Parameters section.

--- a/task/git-clone/0.8/samples/git-clone-sparse-checkout.yaml
+++ b/task/git-clone/0.8/samples/git-clone-sparse-checkout.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: sparse-checkout-list-dir
+spec:
+  description: |
+    sparse-checkout-list-dir takes a git repository and a list of
+    directory patterns to match and lists all cloned files and directories.
+    This is an example pipeline demonstrating the following:
+      - Using the git-clone catalog Task to clone a specific set of
+        files based on directory patterns.
+      - Passing a cloned repo to subsequent Tasks using a Workspace.
+      - Ordering Tasks in a Pipeline using "runAfter" so that
+        git-clone completes before we try to read from the Workspace.
+      - Using a volumeClaimTemplate Volume as a Workspace.
+      - Avoiding hard-coded paths by using a Workspace's path
+        variable instead.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: sparseCheckoutDirectories
+    type: string
+    description: directory patterns to clone
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task to list all cloned files and directories.
+  tasks:
+  - name: fetch-repo
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-data
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: sparseCheckoutDirectories
+      value: $(params.sparseCheckoutDirectories)
+  - name: list-dirs
+    runAfter: ["fetch-repo"]  # Wait until the clone is done before listing all files and directories cloned
+    workspaces:
+    - name: source
+      workspace: shared-data
+    taskSpec:
+      workspaces:
+      - name: source
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          ls -R $(workspaces.source.path)/
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-sparse-checkout
+spec:
+  pipelineRef:
+    name: sparse-checkout-list-dir
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: sparseCheckoutDirectories
+    value: /*,!/*/,/docs/,/cmd/

--- a/task/git-clone/0.8/samples/using-git-clone-result.yaml
+++ b/task/git-clone/0.8/samples/using-git-clone-result.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: validate-tag-sha
+spec:
+  description: |
+    validate-tag-sha takes a git repository, tag name, and a commit SHA and
+    checks whether the given tag resolves to that commit. This example
+    Pipeline demonstrates the following:
+      - How to use the git-clone catalog Task
+      - How to use the git-clone Task's "commit" Task Result from another Task.
+      - How to discard the contents of the git repo when it isn't needed by
+        passing an `emptyDir` Volume as its "output" workspace.
+  params:
+  - name: repo-url
+    type: string
+    description: The git repository URL to clone from.
+  - name: tag-name
+    type: string
+    description: The git tag to clone.
+  - name: expected-sha
+    type: string
+    description: The expected SHA to be received for the supplied revision.
+  workspaces:
+  - name: output
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: output
+    params:
+    - name: url
+      value: $(params.repo-url)
+    - name: revision
+      value: $(params.tag-name)
+  - name: validate-revision-sha
+    params:
+    - name: revision-name
+      value: $(params.tag-name)
+    - name: expected-sha
+      value: $(params.expected-sha)
+    - name: received-sha
+      value: $(tasks.fetch-repository.results.commit)
+    taskSpec:
+      params:
+      - name: revision-name
+      - name: expected-sha
+      - name: received-sha
+      steps:
+      - image: zshusers/zsh:4.3.15
+        script: |
+          #!/usr/bin/env zsh
+          if [ "$(params.expected-sha)" != "$(params.received-sha)" ]; then
+            echo "Expected revision $(params.revision-name) to have SHA $(params.expected-sha)."
+            exit 1
+          else
+            echo "Revision $(params.revision-name) has expected SHA $(params.expected-sha)."
+          fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: using-git-clone-result-
+spec:
+  pipelineRef:
+    name: validate-tag-sha
+  workspaces:
+  - name: output
+    emptyDir: {}  # We don't care about the repo contents in this example, just the "commit" result
+  params:
+  - name: repo-url
+    value: https://github.com/tektoncd/pipeline.git
+  - name: tag-name
+    value: v0.12.1
+  - name: expected-sha
+    value: a54dd3984affab47f3018852e61a1a6f9946ecfa

--- a/task/git-clone/0.8/tests/run.yaml
+++ b/task/git-clone/0.8/tests/run.yaml
@@ -1,0 +1,160 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-noargs
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-tag
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: revision
+      value: 1.0.0
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-submodules
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/githubtraining/example-dependency
+    - name: submodules
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-no-depth-2
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: depth
+      value: "2"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-sslverify-none
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: sslVerify
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-ssl-cadirectory-empty
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+    - name: ssl-ca-directory
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: crtFileName
+      value: ""
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-subdirectory
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: subdirectory
+      value: "hellomoto"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-delete-existing
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: deleteExisting
+      value: "true"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-run-without-verbose
+spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: verbose
+      value: "false"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: git-clone-sparse
+spec:
+  workspaces:
+  - name: output
+    emptyDir: {}
+  taskRef:
+    name: git-clone
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: sparseCheckoutDirectories
+      value: "CONTRIBUTING.md,STYLE.md"

--- a/task/kn-apply/0.2/README.md
+++ b/task/kn-apply/0.2/README.md
@@ -1,0 +1,73 @@
+# Knative with `kn`
+
+This task deploys a given image to a Knative Service using
+[`kn`](https://github.com/knative/client) command line interface.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.1/kn-apply.yaml
+```
+
+## Parameters
+
+* **KN_IMAGE**: `kn` CLI container image to run this task.
+
+  _default_: `gcr.io/knative-releases/knative.dev/client/cmd/kn:latest`
+
+  You can use nightly build of the `kn` CLI using
+  `gcr.io/knative-nightly/knative.dev/client/cmd/kn`.
+
+* **SERVICE**: Name of the Knative Service to deploy the given image to.
+  The service will be created or updated if it exists.
+
+* **IMAGE**: Container image to run.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+### Authorizing the Deployment
+
+In order to create Knative services, you must first define a `ServiceAccount`
+with permission to manage Knative resources.
+
+To create a `ServiceAccount` with these permissions, you can run:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.1/support/kn-deployer.yaml
+```
+
+The service account is being created for 'default' namespace, please edit the
+file before applying if you are operating in different namespace.
+
+### Running the Task
+
+- Following TaskRun deploys a Knative Service using given image.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: kn-apply-
+spec:
+  serviceAccountName: kn-deployer-account  # <-- run as the authorized SA
+  taskRef:
+    name: kn-apply
+  params:
+  - name: SERVICE
+    value: "hello"
+  - name: IMAGE
+    value: "gcr.io/knative-samples/helloworld-go:latest"
+```
+
+Run this with:
+
+```
+kubectl create -f kn-apply-taskrun.yaml
+```
+
+For the first run, this will create the service 'hello' and any subsequent
+runs will update the 'hello' service based on your image updates.

--- a/task/kn-apply/0.2/README.md
+++ b/task/kn-apply/0.2/README.md
@@ -6,7 +6,7 @@ This task deploys a given image to a Knative Service using
 ## Install the Task
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.1/kn-apply.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.2/kn-apply.yaml
 ```
 
 ## Parameters
@@ -37,7 +37,7 @@ with permission to manage Knative resources.
 To create a `ServiceAccount` with these permissions, you can run:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.1/support/kn-deployer.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.2/support/kn-deployer.yaml
 ```
 
 The service account is being created for 'default' namespace, please edit the

--- a/task/kn-apply/0.2/kn-apply.yaml
+++ b/task/kn-apply/0.2/kn-apply.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.2"
   annotations:
+    tekton.dev/displayName: "kn apply"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Deployment
     tekton.dev/tags: cli

--- a/task/kn-apply/0.2/kn-apply.yaml
+++ b/task/kn-apply/0.2/kn-apply.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kn-apply
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Deployment
+    tekton.dev/tags: cli
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    This task deploys a given image to a Knative Service.
+
+    It uses `kn service apply` to create or update given knative service.
+  params:
+  - name: KN_IMAGE
+    description: kn CLI container image to run this task
+    default: gcr.io/knative-releases/knative.dev/client/cmd/kn:latest
+  - name: SERVICE
+    description: Knative service name
+  - name: IMAGE
+    description: Image to deploy
+  steps:
+  - name: kn
+    image: "$(params.KN_IMAGE)"
+    command: ["/ko-app/kn"]
+    args: ["service", "apply", "$(params.SERVICE)", "--image", "$(params.IMAGE)"]
+    env:
+    - name: HOME
+      value: /tekton/home

--- a/task/kn-apply/0.2/kn-apply.yaml
+++ b/task/kn-apply/0.2/kn-apply.yaml
@@ -27,6 +27,9 @@ spec:
     image: "$(params.KN_IMAGE)"
     command: ["/ko-app/kn"]
     args: ["service", "apply", "$(params.SERVICE)", "--image", "$(params.IMAGE)"]
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65532
     env:
     - name: HOME
-      value: /tekton/home
+      value: /home/nonroot

--- a/task/kn-apply/0.2/kn-apply.yaml
+++ b/task/kn-apply/0.2/kn-apply.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: kn-apply
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Deployment

--- a/task/kn-apply/0.2/support/kn-deployer.yaml
+++ b/task/kn-apply/0.2/support/kn-deployer.yaml
@@ -1,0 +1,31 @@
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kn-deployer-account
+  namespace: default
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services", "revisions", "routes"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kn-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: kn-deployer-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io

--- a/task/kn/0.2/README.md
+++ b/task/kn/0.2/README.md
@@ -1,0 +1,130 @@
+# Knative with `kn`
+
+This Task performs operations on Knative resources (services, revisions, routes) using
+[`kn`](https://github.com/knative/client) CLI.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.1/kn.yaml
+```
+
+## Parameters
+
+* **kn-image**: `kn` CLI container image to run this task.
+
+  _default_: `gcr.io/knative-releases/knative.dev/client/cmd/kn:latest`
+
+  You can use nightly build of the `kn` CLI using
+  `gcr.io/knative-nightly/knative.dev/client/cmd/kn`.
+
+
+* **ARGS**: The arguments to pass to `kn` CLI.  _default_: `["help"]`
+
+## Resources
+
+### Inputs
+
+* **image**: An `image`-type `PipelineResource` specifying the location of the
+  container image to deploy for Knative Service.
+
+  User provides the `image`-type resource to kn CLI in parameter `ARGS` as an
+  element of the array, for e.g. `"--image=$(inputs.resources.image.url)"`.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+### Authorizing the Deployment
+
+In order to create Knative services, you must first define a `ServiceAccount`
+with permission to manage Knative resources.
+
+To create a `ServiceAccount` with these permissions, you can run:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.1/support/kn-deployer.yaml
+```
+
+### Running the Task
+
+Let's take examples of creating and updating a Knative Service using `kn` task.
+
+1. Following TaskRun runs the Task to create a Knative Service using given image.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: kn-create-
+spec:
+  serviceAccountName: kn-deployer-account  # <-- run as the authorized SA
+  taskRef:
+    name: kn
+  resources:
+    inputs:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/knative-samples/helloworld-go
+  params:
+  - name: ARGS
+    value:
+    - "service"
+    - "create"
+    - "hello"
+    - "--force"
+    - "--image=$(inputs.resources.image.url)"
+```
+
+Run this with:
+
+```
+kubectl create -f kn-create-taskrun.yaml
+```
+
+2. Following TaskRun runs the Task to update a Knative Service using given image or parameters.
+
+```
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: kn-update-
+spec:
+  serviceAccountName: kn-deployer-account  # <-- run as the authorized SA
+  taskRef:
+    name: kn
+  resources:
+    inputs:
+    - name: image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: gcr.io/knative-samples/helloworld-go
+  params:
+  - name: ARGS
+    value:
+    - "service"
+    - "update"
+    - "hello"
+    - "--image=$(inputs.resources.image.url)"
+    - "--env=TARGET=Tekton"
+```
+
+Run this with:
+
+```
+kubectl create -f kn-update-taskrun.yaml
+```
+
+In these examples, the `image` resource can be built before hand, most
+likely using a previous task.
+
+## Pipeline
+Checkout the sample Pipelines for building your git source and deploying
+as Knative Service [here](./knative-dockerfile-deploy/README.md).

--- a/task/kn/0.2/README.md
+++ b/task/kn/0.2/README.md
@@ -6,7 +6,7 @@ This Task performs operations on Knative resources (services, revisions, routes)
 ## Install the Task
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.1/kn.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/kn.yaml
 ```
 
 ## Parameters
@@ -45,7 +45,7 @@ with permission to manage Knative resources.
 To create a `ServiceAccount` with these permissions, you can run:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.1/support/kn-deployer.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/support/kn-deployer.yaml
 ```
 
 ### Running the Task

--- a/task/kn/0.2/kn.yaml
+++ b/task/kn/0.2/kn.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: kn
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: CLI

--- a/task/kn/0.2/kn.yaml
+++ b/task/kn/0.2/kn.yaml
@@ -28,3 +28,6 @@ spec:
     image: "$(params.kn-image)"
     command: ["/ko-app/kn"]
     args: ["$(params.ARGS)"]
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 65532

--- a/task/kn/0.2/kn.yaml
+++ b/task/kn/0.2/kn.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.2"
   annotations:
+    tekton.dev/displayName: "kn"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: CLI
     tekton.dev/tags: cli

--- a/task/kn/0.2/kn.yaml
+++ b/task/kn/0.2/kn.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kn
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    This Task performs operations on Knative resources
+    (services, revisions, routes) using kn CLI
+
+  params:
+  - name: kn-image
+    description: kn CLI container image to run this task
+    default: gcr.io/knative-releases/knative.dev/client/cmd/kn:latest
+  - name: ARGS
+    type: array
+    description: kn CLI arguments to run
+    default:
+    - "help"
+  steps:
+  - name: kn
+    image: "$(params.kn-image)"
+    command: ["/ko-app/kn"]
+    args: ["$(params.ARGS)"]

--- a/task/kn/0.2/knative-dockerfile-deploy/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/README.md
@@ -1,0 +1,103 @@
+# Git Source with Dockerfile to Knative Service
+
+This documents the example Pipeline to build the source code with a Dockerfile in
+the git repo and deploy it as Knative Service.
+It uses [buildah task](../../buildah/README.md) for building the source code and
+[kn task](../README.md) to create or update a Knative Service.
+
+## Prerequisites:
+
+1. Latest Tekton Pipelines [install](https://github.com/tektoncd/pipeline/blob/main/docs/install.md)ed.
+2. `kubectl` CLI [install](https://kubernetes.io/docs/tasks/tools/install-kubectl/)ed.
+3. `tkn` CLI [install](https://github.com/tektoncd/cli#installing-tkn)ed.
+4. User account exists at a container registry (e.g. [quay.io](https://quay.io))
+5. A ServiceAccount to enable access to perform the required operations in the Pipeline,
+   we'll configure one in following section.
+
+### One time setup:
+
+1 - Create a sample namespace `tkn-kn`, we'll reference this namespace in the subsequent operations.
+```bash
+kubectl create namespace tkn-kn
+```
+
+2 - Create a `docker-registry` type secrets for pushing/pulling the built container images.
+```bash
+kubectl create secret docker-registry container-registry --docker-server=<DOCKER-REGISTRY> --docker-username=<USERNAME> --docker-password=<PASSWORD> --docker-email=<EMAIL>
+```
+More about secrets for [`interacting with a private registry`](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
+#### Note:
+- For using `docker.io`: Please [create a new](https://hub.docker.com/repository/create) empty public repository and refer it in subsequent steps.
+- For using `quay.io`: No need to create a repository beforehand.
+
+3 - Create a ServiceAccount `kn-deployer-account` and
+ - link `container-registry` secret created above in step 2
+ - create cluster role `kn-deployer` to access the Knative resources
+ - binds the ServiceAccount with cluster role `kn-deployer` in namespace `tkn-kn`
+ - Save following YAML in e.g. `kn_deployer.yaml` and apply using `kubectl apply -f kn_deployer.yaml`.
+
+```yaml
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kn-deployer-account
+  namespace: tkn-kn
+# Link the container registry secrets
+secrets:
+  - name: container-registry
+# To be able to pull the (private) image from the container registry
+imagePullSecrets:
+  - name: container-registry
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kn-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: kn-deployer-account
+  namespace: tkn-kn
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io
+```
+
+  - If you've used the same names for namespace and secrets as mentioned above, you can configure the ServiceAccount with the YAML file in this repo using:
+```bash
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/kn_deployer.yaml
+```
+
+4 - Install buildah task from tektoncd/catalog
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/buildah/buildah.yaml
+```
+
+5 - Install the kn task from the tektoncd/catalog
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/kn.yaml
+```
+
+5 - Install the git-clone task from the tektoncd/catalog
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml
+```
+
+## Pipelines:
+
+Let's create some Pipelines using `git-clone`, `buildah` and `kn` tasks:
+1. Create an image from git source and deploy to the Knative Service [pipeline](./build_deploy/README.md)
+2. Deploy a new Revision to the Knative Service [pipeline](./service_update/README.md)
+3. Perform traffic operations on the Knative Service [pipeline](./service_traffic/README.md)

--- a/task/kn/0.2/knative-dockerfile-deploy/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/README.md
@@ -77,22 +77,22 @@ roleRef:
 
   - If you've used the same names for namespace and secrets as mentioned above, you can configure the ServiceAccount with the YAML file in this repo using:
 ```bash
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/kn_deployer.yaml
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/knative-dockerfile-deploy/kn_deployer.yaml
 ```
 
 4 - Install buildah task from tektoncd/catalog
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/buildah/buildah.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.4/buildah.yaml
 ```
 
 5 - Install the kn task from the tektoncd/catalog
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/kn.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/kn.yaml
 ```
 
 5 - Install the git-clone task from the tektoncd/catalog
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/git/git-clone.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.8/git-clone.yaml
 ```
 
 ## Pipelines:

--- a/task/kn/0.2/knative-dockerfile-deploy/build_deploy/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/build_deploy/README.md
@@ -1,0 +1,163 @@
+# Build and Deploy Pipeline
+
+Let's create a container image from a git source having a Dockerfile and deploy it to a Knative Service.
+This Pipeline clones source code using `git-clone` builds and push the git source using `buildah` and deploys the container as Knative Service using `kn`.
+
+## Pipeline:
+
+The following Pipeline definition refers:
+- `git-clone` to clone the source code
+- `buildah` and `kn` tasks (we've installed these tasks in One time Setup section)
+- PersistentVolumeClaim for shared workspace
+- Save the following YAML in a file e.g.: `build_deploy_pipeline.yaml` and create the Pipeline using
+  `kubectl create -f build_deploy_pipeline.yaml`
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: buildah-build-kn-create
+spec:
+  workspaces:
+  - name: source
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  - name: GIT_URL
+    type: string
+    description: Git url to clone
+  - name: IMAGE
+    type: string
+    description: The application image built by Buildah and used by kn task.
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: source
+    params:
+    - name: url
+      value: $(params.GIT_URL)
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: buildah-build
+    taskRef:
+      name: buildah
+    runAfter:
+      - fetch-repository
+    workspaces:
+    - name: source
+      workspace: source
+    params:
+    - name: IMAGE
+      value: "$(params.IMAGE)"
+  - name: kn-service-create
+    taskRef:
+      name: kn
+    runAfter:
+      - buildah-build
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"
+```
+
+ - You can also create this Pipeline using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+```
+## Shared Workspace
+
+Let's create PersistentVolumeClaim for the workspace shared by individual tasks. The PVC is referenced in the PipelineRun below.
+
+### Note:
+ - Make sure the git repository has a Dockerfile at root of the repo.
+ - Make sure the container repository URL is correct, and you have push access to.
+ - If you are using docker.io container registry, please [create a new](https://hub.docker.com/repository/create) empty repository in advance.
+
+Save the following YAML for resources in a file e.g.: `resources.yaml`.
+Create the resource as `kubectl create -f resources.yaml`.
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clone-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+```
+
+## PipelineRun:
+
+- Let's trigger the Pipeline we've created above referencing the resources via PipelineRun.
+- Note that we've referenced ServiceAccount `kn-deployer-account` in `kn` CLI arguments,
+  it tells `kn` which ServiceAccount to use while pulling the image from (private) container registry.
+- Also note that, we're creating a service named `hello` and asking to create Revision
+  `hello-v1`, we'll use this Revision name in subsequent Pipeline operations.
+
+Save the following YAML in a file e.g.: `pipeline_run.yaml` and create PipelineRun as
+`kubectl create -f pipeline_run.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: buildah-build-kn-create-
+spec:
+  serviceAccountName: kn-deployer-account
+  pipelineRef:
+    name: buildah-build-kn-create
+  workspaces:
+    - name: source
+      persistentvolumeclaim:
+        claimName: clone-source-pvc
+  params:
+    - name: GIT_URL
+      value: "https://github.com/navidshaikh/helloworld-go"
+    - name: IMAGE
+      value: "quay.io/navidshaikh/helloworld-go"
+    - name: ARGS
+      value:
+        - "service"
+        - "create"
+        - "hello"
+        - "--revision-name=hello-v1"
+        - "--image=quay.io/navidshaikh/helloworld-go"
+        - "--env=TARGET=Tekton"
+        - "--service-account=kn-deployer-account"
+```
+
+ - You can also create this PipelineRun using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+```
+
+- We can monitor the logs of this PipelineRun using `tkn` CLI
+```bash
+tkn pr list
+tkn pr logs <pipelinerun-name> logs -f
+```
+
+- After the successful PipelineRun, we should have the source built, pushed to the repo and deployed as Knative Service. Let's check it:
+
+```bash
+kubectl get ksvc hello
+```
+
+## What's Next:
+- We've built a container image from git source, pushed it to a container registry, deployed a Knative Service using the image.
+- You can use other available `kn` options to configure the Service, just add them to `params.ARGS` field in above `pipeline_run.yaml`. Check the list of supported options in `kn` [here](https://github.com/knative/client/blob/master/docs/cmd/kn.md).
+- We've further Pipeline examples showing [service update](../service_update/README.md) and [service traffic](../service_traffic/README.md) operations.

--- a/task/kn/0.2/knative-dockerfile-deploy/build_deploy/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/build_deploy/README.md
@@ -72,7 +72,7 @@ spec:
 
  - You can also create this Pipeline using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
 ```
 ## Shared Workspace
 
@@ -142,7 +142,7 @@ spec:
 
  - You can also create this PipelineRun using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
 ```
 
 - We can monitor the logs of this PipelineRun using `tkn` CLI

--- a/task/kn/0.2/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/build_deploy/build_deploy_pipeline.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: buildah-build-kn-create
+spec:
+  workspaces:
+  - name: source
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  - name: GIT_URL
+    type: string
+    description: Git url to clone
+  - name: IMAGE
+    type: string
+    description: The application image to be built by Buildah and deployed by kn task.
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: source
+    params:
+    - name: url
+      value: $(params.GIT_URL)
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: buildah-build
+    taskRef:
+      name: buildah
+    runAfter:
+      - fetch-repository
+    workspaces:
+    - name: source
+      workspace: source
+    params:
+    - name: IMAGE
+      value: "$(params.IMAGE)"
+  - name: kn-service-create
+    taskRef:
+      name: kn
+    runAfter:
+      - buildah-build
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"

--- a/task/kn/0.2/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/build_deploy/pipeline_run.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: buildah-build-kn-create-
+spec:
+  serviceAccountName: kn-deployer-account
+  pipelineRef:
+    name: buildah-build-kn-create
+  workspaces:
+    - name: source
+      persistentvolumeclaim:
+        claimName: clone-source-pvc
+  params:
+    - name: GIT_URL
+      value: "https://github.com/navidshaikh/helloworld-go"
+    - name: IMAGE
+      value: "quay.io/navidshaikh/helloworld-go"
+    - name: ARGS
+      value:
+        - "service"
+        - "create"
+        - "hello"
+        - "--revision-name=hello-v1"
+        - "--image=quay.io/navidshaikh/helloworld-go"
+        - "--env=TARGET=Tekton"
+        - "--service-account=kn-deployer-account"

--- a/task/kn/0.2/knative-dockerfile-deploy/build_deploy/resources.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/build_deploy/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clone-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/kn/0.2/knative-dockerfile-deploy/kn_deployer.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/kn_deployer.yaml
@@ -1,0 +1,35 @@
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kn-deployer-account
+  namespace: tkn-kn
+# Link the container registry secrets
+secrets:
+  - name: container-registry
+# To be able to pull the (private) image from the container registry
+imagePullSecrets:
+  - name: container-registry
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kn-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: kn-deployer-account
+  namespace: tkn-kn
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io

--- a/task/kn/0.2/knative-dockerfile-deploy/service_traffic/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_traffic/README.md
@@ -37,7 +37,7 @@ spec:
 
  - You can also create this Pipeline using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
 ```
 
 ## PipelineRun:
@@ -69,7 +69,7 @@ spec:
 ```
 - You can also create this PipelineRun using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
 ```
 
 - Let's monitor the logs of the Pipeline run using `tkn`

--- a/task/kn/0.2/knative-dockerfile-deploy/service_traffic/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_traffic/README.md
@@ -1,0 +1,85 @@
+# Set Traffic for Knative Service
+
+Let's perform traffic splitting on the Knative Service using Pipeline.
+If you followed the earlier two Pipeline examples, you already have a couple of Revisions available, that we'll reference in PipelineRun to
+configure the Service to route 50-50% traffic to each Revision.
+
+## Pipeline:
+
+- The following Pipeline is focused only on performing traffic operations
+  on Service. It does not define/require any Pipeline resources.
+- Save the following YAML in a file say e.g.: `kn_service_traffic_pipeline.yaml` and create using
+ `kubectl create -f kn_service_traffic_pipeline.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kn-service-traffic-splitting
+spec:
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-traffic-splitting
+    taskRef:
+      name: kn
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"
+```
+
+ - You can also create this Pipeline using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
+```
+
+## PipelineRun:
+
+- Create the PipelineRun to trigger the Pipeline and provide the kn CLI arguments to perform the traffic splitting.
+- Note that, we're referencing Revisions `hello-v1` and `hello-v2` here, which we've created in earlier Pipeline examples.
+- Save the following YAML in a file e.g: `pipeline_run.yaml` and create using
+ `kubectl create -f pipeline_run.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-traffic-splitting-
+spec:
+  serviceAccountName: kn-deployer-account
+  pipelineRef:
+    name: kn-service-traffic-splitting
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--tag=hello-v1=v1"
+        - "--tag=hello-v2=v2"
+        - "--traffic=v1=50"
+        - "--traffic=v2=50"
+```
+- You can also create this PipelineRun using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+```
+
+- Let's monitor the logs of the Pipeline run using `tkn`
+```bash
+tkn pr list
+tkn pr logs <pipelinerun-name> logs -f
+```
+
+- After the successful run of the Pipeline, we should have the Knative Service updated with mentioned traffic settings
+```bash
+kubectl get ksvc hello
+kubectl describe ksvc hello
+```

--- a/task/kn/0.2/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_traffic/kn_service_traffic_splitting_pipeline.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kn-service-traffic-splitting
+spec:
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-traffic-splitting
+    taskRef:
+      name: kn
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"

--- a/task/kn/0.2/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_traffic/pipeline_run.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-traffic-splitting-
+spec:
+  serviceAccountName: kn-deployer-account
+  pipelineRef:
+    name: kn-service-traffic-splitting
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--tag=hello-v1=v1"
+        - "--tag=hello-v2=v2"
+        - "--traffic=v1=50"
+        - "--traffic=v2=50"

--- a/task/kn/0.2/knative-dockerfile-deploy/service_update/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_update/README.md
@@ -1,0 +1,86 @@
+# Deploy new revision to a Knative Service
+
+Let's create a Pipeline which deploys a new Revision to the deployed Knative Service.
+A new Revision is created if you update the Configuration of the Service.
+
+## Pipeline:
+- The following Pipeline is generic `kn` Pipeline, which can update (or even create a new) Knative Service based to the parameters you provide.
+- Save the following YAML in a file say e.g.: `kn_service_update_pipeline.yaml` and create using `kubectl create -f kn_service_update_pipeline.yaml`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kn-service-update
+spec:
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-update
+    taskRef:
+      name: kn
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"
+```
+
+ - You can also create this Pipeline using the YAML file present in this repo using 
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
+```
+
+## PipelineRun
+
+- Create the PipelineRun to trigger the Pipeline and input the kn CLI parameters to 
+deploy a new Revision to `hello` Service. Note that in the below example, we're referencing a 
+different image, other than the one we created earlier using buildah.
+
+- Save the following YAML in a file e.g.: `pipeline_run.yaml` and create using `kubectl create -f pipeline_run.yaml`
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-update-
+spec:
+  serviceAccountName: kn-deployer-account
+  pipelineRef:
+    name: kn-service-update
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=gcr.io/knative-samples/helloworld-go"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"
+```
+
+- You can also create this PipelineRun using the YAML file present in this repo using
+```
+kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+```
+
+Let's monitor the logs of the Pipeline run using `tkn`
+```bash
+tkn pr list
+tkn pr logs <pipelinerun-name> logs -f
+```
+
+After the successful run of the Pipeline, we should have the Service updated, let's check
+```bash
+kubectl get ksvc hello
+```
+
+## What's Next:
+- We've updated the Knative Service and now we've two Revisions present, we can use this state to also perform
+  some traffic splitting operation on the Service, check out the [next Pipeline example](../service_traffic/README.md).

--- a/task/kn/0.2/knative-dockerfile-deploy/service_update/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_update/README.md
@@ -33,7 +33,7 @@ spec:
 
  - You can also create this Pipeline using the YAML file present in this repo using 
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
 ```
 
 ## PipelineRun
@@ -67,7 +67,7 @@ spec:
 
 - You can also create this PipelineRun using the YAML file present in this repo using
 ```
-kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/v1beta1/kn/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/knative-dockerfile-deploy/service_update/pipeline_run.yaml
 ```
 
 Let's monitor the logs of the Pipeline run using `tkn`

--- a/task/kn/0.2/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_update/kn_service_update_pipeline.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kn-service-update
+spec:
+  params:
+  - name: ARGS
+    type: array
+    description: Arguments to pass to kn CLI
+    default:
+      - "help"
+  tasks:
+  - name: kn-service-update
+    taskRef:
+      name: kn
+    params:
+    - name: kn-image
+      value: "gcr.io/knative-nightly/knative.dev/client/cmd/kn"
+    - name: ARGS
+      value:
+        - "$(params.ARGS)"

--- a/task/kn/0.2/knative-dockerfile-deploy/service_update/pipeline_run.yaml
+++ b/task/kn/0.2/knative-dockerfile-deploy/service_update/pipeline_run.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: kn-service-update-
+spec:
+  serviceAccountName: kn-deployer-account
+  pipelineRef:
+    name: kn-service-update
+  params:
+    - name: ARGS
+      value:
+        - "service"
+        - "update"
+        - "hello"
+        - "--revision-name=hello-v2"
+        - "--image=gcr.io/knative-samples/helloworld-go"
+        - "--env=TARGET=v2"
+        - "--service-account=kn-deployer-account"

--- a/task/kn/0.2/support/kn-deployer.yaml
+++ b/task/kn/0.2/support/kn-deployer.yaml
@@ -1,0 +1,31 @@
+# Define a ServiceAccount named kn-deployer-account that has permission to
+# manage Knative services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kn-deployer-account
+  namespace: default
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kn-deployer
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["services", "revisions", "routes"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kn-deployer-binding
+subjects:
+- kind: ServiceAccount
+  name: kn-deployer-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kn-deployer
+  apiGroup: rbac.authorization.k8s.io

--- a/task/skopeo-copy/0.2/README.md
+++ b/task/skopeo-copy/0.2/README.md
@@ -1,0 +1,109 @@
+# Skopeo
+
+
+[Skopeo](https://github.com/containers/skopeo) is a command line tool for working with remote image registries. Skopeo doesn’t require a daemon to be running while performing its operations. In particular, the handy skopeo command called `copy` will ease the whole image copy operation. Without further ado, you can copy an image from a registry to another simply by running:
+```
+skopeo copy docker://internal.registry/myimage:latest /
+docker://production.registry/myimage:v1.0
+```
+The copy command will take care of copying the image from `internal.registry` to `production.registry`
+
+If your production registry requires credentials to login in order to push the image, skopeo can handle that as well.
+
+```
+skopeo copy --dest-creds prod_user:prod_pass docker://internal.registry/myimage:latest /
+docker://production.registry/myimage:v1.0
+```
+
+The same goes for credentials for the source registry (internal.registry) by using the `--src-creds` flag.
+
+It is also useful for copying images between two remote docker registries, such as the registries of two different OpenShift clusters, as shown
+```
+skopeo copy docker://busybox:latest oci:busybox_ocilayout:latest
+```
+Skopeo copy isn’t limited to remote containers registries. The image prefix `docker://` from the above command define the transport to be used when handling the image.
+
+There are others also similar to that:
+
+- atomic
+- containers-storage
+- dir
+- docker
+- docker-daemon
+- docker-tar
+- oci
+- ostree
+
+This `task` can be used to copy one or more than one images to-and fro various storage mechanisms.
+
+## Install the Task
+
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/skopeo-copy/0.1/skopeo-copy.yaml
+```
+
+## Parameters
+
+- **srcImageURL**: The URL of the image to be copied to the `destination` registry.
+- **destImageURL**: The URL of the image where the image from `source` should be copied to.
+- **srcTLSverify**: Verify the TLS on the src registry endpoint
+- **destTLSverify**: Verify the TLS on the dest registry endpoint
+
+## Workspace
+
+- **images-url**: To mount file containing multiple source and destination images registries URL, which is mounted as configMap.
+
+
+## Secrets and ConfigMap
+* `Secret` to provide the credentials of the source and destination registry where the image needs to be copied from and to.
+* `ConfigMap` to provide support for copying multiple images, this contains file `url.txt` which stores images registry URL's.
+
+  [This](../0.1/samples/quay-secret.yaml) example can help to use secrets for providing credentials of image registries.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+This task will use the `Service Account` with access to the secrets containing source and destination image registry credentials, this will authorize it to the respective image registries. 
+
+In case of multiple source and destination image registries that needs to be copied to and fro, a file named `url.txt` should be created containing all the source and destination image registries `URL` seperated by a space and each set of images should be written in the new line, as shown below.
+
+```
+docker://quay.io/temp/kubeconfigwriter:v1 docker://quay.io/skopeotest/kube:v1
+docker://quay.io/temp/kubeconfigwriter:v2 docker://quay.io/skopeotest/kube:v2
+```
+
+`ConfigMap` should be created using this file. Following `command` can be used to create configMap from the `file`.
+```
+kubectl create configmap image-configmap --from-file=url.txt
+```
+In case there is only one source and destination image that needs to be copied then, Source and destination image URL needs to be provided in the input params of the task.
+
+This will result in the image getting copied from the source registry to the destination registry.
+
+
+[This](../0.1/samples/serviceaccount.yaml) will guide the user to use service account for authorization to image registries.
+
+See [here](../0.1/samples/run.yaml) for example of `TaskRun`.
+### Note
+
+- `Source credentials` are only required, if the source image registry needs authentication to pull the image, whereas `Destination credentials` are always required.
+
+- In case of multiple source and destination images, `secret` containing `credentials` of all the image registries must be added to the `service account` and configMap containing `url.txt` should be mounted into the workspace, as shown
+    ```
+    workspaces:
+      - name: images-url
+        configmap:
+          name: image-configmap
+    ```
+
+
+- If there is only one source and destination image registry URL, then `emptyDir` needs to be mounted in the `workspace` as shown below:
+
+    ```
+    workspaces:
+      - name: images-url
+        emptyDir: {}
+    ```

--- a/task/skopeo-copy/0.2/README.md
+++ b/task/skopeo-copy/0.2/README.md
@@ -39,7 +39,7 @@ This `task` can be used to copy one or more than one images to-and fro various s
 ## Install the Task
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/skopeo-copy/0.1/skopeo-copy.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/skopeo-copy/0.2/skopeo-copy.yaml
 ```
 
 ## Parameters
@@ -58,7 +58,7 @@ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sk
 * `Secret` to provide the credentials of the source and destination registry where the image needs to be copied from and to.
 * `ConfigMap` to provide support for copying multiple images, this contains file `url.txt` which stores images registry URL's.
 
-  [This](../0.1/samples/quay-secret.yaml) example can help to use secrets for providing credentials of image registries.
+  [This](../0.2/samples/quay-secret.yaml) example can help to use secrets for providing credentials of image registries.
 
 ## Platforms
 
@@ -84,9 +84,9 @@ In case there is only one source and destination image that needs to be copied t
 This will result in the image getting copied from the source registry to the destination registry.
 
 
-[This](../0.1/samples/serviceaccount.yaml) will guide the user to use service account for authorization to image registries.
+[This](../0.2/samples/serviceaccount.yaml) will guide the user to use service account for authorization to image registries.
 
-See [here](../0.1/samples/run.yaml) for example of `TaskRun`.
+See [here](../0.2/samples/run.yaml) for example of `TaskRun`.
 ### Note
 
 - `Source credentials` are only required, if the source image registry needs authentication to pull the image, whereas `Destination credentials` are always required.

--- a/task/skopeo-copy/0.2/samples/docker-secret.yaml
+++ b/task/skopeo-copy/0.2/samples/docker-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-creds
+  annotations:
+    tekton.dev/docker-0: https://docker.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: test
+  password: test@1

--- a/task/skopeo-copy/0.2/samples/quay-secret.yaml
+++ b/task/skopeo-copy/0.2/samples/quay-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quay-creds
+  annotations:
+    tekton.dev/docker-0: https://quay.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: skopeotest
+  password: Skopeo@1

--- a/task/skopeo-copy/0.2/samples/run.yaml
+++ b/task/skopeo-copy/0.2/samples/run.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: skopeo-run
+spec:
+  serviceAccountName: secret-service-account
+  taskRef:
+    name: skopeo-copy
+  workspaces:
+  - name: images-url
+    configmap:
+      name: image-configmap

--- a/task/skopeo-copy/0.2/samples/serviceaccount.yaml
+++ b/task/skopeo-copy/0.2/samples/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-service-account
+secrets:
+  - name: docker-creds
+  - name: quay-creds

--- a/task/skopeo-copy/0.2/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.2/skopeo-copy.yaml
@@ -46,8 +46,8 @@ spec:
         # Function to copy multiple images.
         #
         copyimages() {
-          filename='$(workspaces.images-url.path)/url.txt'
-          while IFS= read line || [ -n "$line" ]
+          filename="$(workspaces.images-url.path)/url.txt"
+          while IFS= read -r line || [ -n "$line" ]
           do
             cmd=""
             for url in $line
@@ -56,15 +56,15 @@ spec:
               cmd="$cmd \
                   $url"
             done
-            skopeo copy $cmd --src-tls-verify=$(params.srcTLSverify) --dest-tls-verify=$(params.destTLSverify)
-            echo $cmd
+            skopeo copy "$cmd" --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
+            echo "$cmd"
           done < "$filename"
         }
         #
         # If single image is to be copied then, it can be passed through
         # params in the taskrun.
         if [ "$(params.srcImageURL)" != "" ] && [ "$(params.destImageURL)" != "" ] ; then
-          skopeo copy "$(params.srcImageURL)" "$(params.destImageURL)" --src-tls-verify=$(params.srcTLSverify) --dest-tls-verify=$(params.destTLSverify)
+          skopeo copy "$(params.srcImageURL)" "$(params.destImageURL)" --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
         else
           # If file is provided as a configmap in the workspace then multiple images can be copied.
           #

--- a/task/skopeo-copy/0.2/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.2/skopeo-copy.yaml
@@ -1,0 +1,72 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: skopeo-copy
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/displayName: "skopeo copy"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    Skopeo is a command line tool for working with remote image registries.
+
+    Skopeo doesn’t require a daemon to be running while performing its operations.
+    In particular, the handy skopeo command called copy will ease the whole image
+    copy operation. The copy command will take care of copying the image from
+    internal.registry to production.registry. If your production registry requires
+    credentials to login in order to push the image, skopeo can handle that as well.
+
+  workspaces:
+    - name: images-url
+  params:
+    - name: srcImageURL
+      description: URL of the image to be copied to the destination registry
+      type: string
+      default: ""
+    - name: destImageURL
+      description: URL of the image where the image from source should be copied to
+      type: string
+      default: ""
+    - name: srcTLSverify
+      description: Verify the TLS on the src registry endpoint
+      type: string
+      default: "true"
+    - name: destTLSverify
+      description: Verify the TLS on the dest registry endpoint
+      type: string
+      default: "true"
+  steps:
+    - name: skopeo-copy
+      image: quay.io/skopeo/stable:v1.3.0
+      script: |
+        # Function to copy multiple images.
+        #
+        copyimages() {
+          filename='$(workspaces.images-url.path)/url.txt'
+          while IFS= read line || [ -n "$line" ]
+          do
+            cmd=""
+            for url in $line
+            do
+              # echo $url
+              cmd="$cmd \
+                  $url"
+            done
+            skopeo copy $cmd --src-tls-verify=$(params.srcTLSverify) --dest-tls-verify=$(params.destTLSverify)
+            echo $cmd
+          done < "$filename"
+        }
+        #
+        # If single image is to be copied then, it can be passed through
+        # params in the taskrun.
+        if [ "$(params.srcImageURL)" != "" ] && [ "$(params.destImageURL)" != "" ] ; then
+          skopeo copy "$(params.srcImageURL)" "$(params.destImageURL)" --src-tls-verify=$(params.srcTLSverify) --dest-tls-verify=$(params.destTLSverify)
+        else
+          # If file is provided as a configmap in the workspace then multiple images can be copied.
+          #
+          copyimages
+        fi

--- a/task/skopeo-copy/0.2/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.2/skopeo-copy.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: skopeo-copy
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: CLI

--- a/task/skopeo-copy/0.2/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.2/skopeo-copy.yaml
@@ -70,3 +70,6 @@ spec:
           #
           copyimages
         fi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532

--- a/task/skopeo-copy/0.2/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.2/skopeo-copy.yaml
@@ -41,7 +41,7 @@ spec:
       default: "true"
   steps:
     - name: skopeo-copy
-      image: quay.io/skopeo/stable:v1.3.0
+      image: quay.io/skopeo/stable:v1.9.0
       script: |
         # Function to copy multiple images.
         #

--- a/task/skopeo-copy/0.2/tests/pre-apply-task-hook.sh
+++ b/task/skopeo-copy/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests without having to go to an external registry.
+add_sidecar_registry ${TMPF}

--- a/task/skopeo-copy/0.2/tests/run.yaml
+++ b/task/skopeo-copy/0.2/tests/run.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: skopeo-run
+spec:
+  params:
+    - name: srcImageURL
+      value: docker://quay.io/temp/kubeconfigwriter:v1
+    - name: destImageURL
+      value: docker://localhost:5000/kube:latest
+    - name: destTLSverify
+      value: "false"
+  taskRef:
+    name: skopeo-copy
+  workspaces:
+  - name: images-url
+    emptyDir: {}

--- a/task/tkn/0.4/README.md
+++ b/task/tkn/0.4/README.md
@@ -1,0 +1,74 @@
+# tkn
+
+This task performs operations on Tekton resources using
+[`tkn`](https://github.com/tektoncd/cli).
+
+## Install the Task
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.3/tkn.yaml
+```
+
+## Parameters
+
+| name      | description                                 | default                               |
+| --------- | ------------------------------------------- | ------------------------------------- |
+| TKN_IMAGE | `tkn` CLI container image to run this task. | gcr.io/tekton-releases/dogfooding/tkn |
+| ARGS      | The arguments to pass to the `tkn` CLI.     | --help                                |
+| SCRIPT    | `tkn` CLI script to execute                 | tkn \$@                               |
+
+## Workspaces
+
+- **kubeconfig**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks) that allows you to provide a `.kube/config` file for `tkn` to access the cluster. The file should be placed at the root of the Workspace with name `kubeconfig`.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+## Usage
+
+1. Passing only `ARGS`
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tkn-run
+spec:
+  taskRef:
+    name: tkn
+  params:
+    - name: ARGS
+      value:
+        - task
+        - list
+```
+
+2. Passing `SCRIPT` and `ARGS` and `WORKSPACE`
+
+   1. Sample secret can be found [here](https://github.com/tektoncd/catalog/tree/main/task/tkn/0.3/samples/secrets.yaml)
+
+   2. Create `TaskRun`
+
+   ```yaml
+   apiVersion: tekton.dev/v1beta1
+   kind: TaskRun
+   metadata:
+     name: tkn-run
+   spec:
+     taskRef:
+       name: tkn
+     workspaces:
+       - name: kubeconfig
+         secret:
+           secretName: kubeconfig
+     params:
+       - name: SCRIPT
+         value: |
+           tkn task start $1
+           tkn taskrun list
+           tkn task logs $1 -f
+       - name: ARGS
+         value:
+           - taskRunName
+   ```

--- a/task/tkn/0.4/README.md
+++ b/task/tkn/0.4/README.md
@@ -6,7 +6,7 @@ This task performs operations on Tekton resources using
 ## Install the Task
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.3/tkn.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.4/tkn.yaml
 ```
 
 ## Parameters
@@ -46,7 +46,7 @@ spec:
 
 2. Passing `SCRIPT` and `ARGS` and `WORKSPACE`
 
-   1. Sample secret can be found [here](https://github.com/tektoncd/catalog/tree/main/task/tkn/0.3/samples/secrets.yaml)
+   1. Sample secret can be found [here](https://github.com/tektoncd/catalog/tree/main/task/tkn/0.4/samples/secrets.yaml)
 
    2. Create `TaskRun`
 

--- a/task/tkn/0.4/samples/run-with-workspace.yaml
+++ b/task/tkn/0.4/samples/run-with-workspace.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tkn-run-with-workspace
+spec:
+  taskRef:
+    name: tkn
+  workspaces:
+    - name: kubeconfig
+      secret:
+        secretName: kubeconfig
+  params:
+    - name: SCRIPT
+      value: |
+        tkn task list
+        tkn pipeline list

--- a/task/tkn/0.4/samples/run-without-worksapce.yaml
+++ b/task/tkn/0.4/samples/run-without-worksapce.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tkn-run-without-workspace
+spec:
+  taskRef:
+    name: tkn
+  params:
+    - name: SCRIPT
+      value: |
+        tkn task list
+        tkn pipeline list

--- a/task/tkn/0.4/samples/secrets.yaml
+++ b/task/tkn/0.4/samples/secrets.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeconfig
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    preferences: {}
+    clusters:
+    - cluster:
+        certificate-authority-data: LS0exampleexampleexample=
+        server: https://cluster.example.com:8443
+      name: my-cluster
+    contexts:
+    - context:
+        cluster: my-cluster
+        user: my-cluster-user
+      name: my-cluster
+    current-context: my-cluster
+    users:
+    - name: my-cluster-user
+      user:
+        client-certificate-data: LS0exampleexampleexample=
+        client-key-data: LS0exampleexampleexample=

--- a/task/tkn/0.4/tests/resources.yaml
+++ b/task/tkn/0.4/tests/resources.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tkn-account
+  namespace: tkn-0-3
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tkn-role
+  namespace: tkn-0-3
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tkn-binding
+  namespace: tkn-0-3
+subjects:
+  - kind: ServiceAccount
+    name: tkn-account
+    namespace: tkn-0-3
+roleRef:
+  kind: Role
+  name: tkn-role
+  apiGroup: rbac.authorization.k8s.io

--- a/task/tkn/0.4/tests/resources.yaml
+++ b/task/tkn/0.4/tests/resources.yaml
@@ -3,13 +3,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tkn-account
-  namespace: tkn-0-3
+  namespace: tkn-0-4
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tkn-role
-  namespace: tkn-0-3
+  namespace: tkn-0-4
 rules:
   - apiGroups: ["tekton.dev"]
     resources: ["*"]
@@ -19,11 +19,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: tkn-binding
-  namespace: tkn-0-3
+  namespace: tkn-0-4
 subjects:
   - kind: ServiceAccount
     name: tkn-account
-    namespace: tkn-0-3
+    namespace: tkn-0-4
 roleRef:
   kind: Role
   name: tkn-role

--- a/task/tkn/0.4/tests/run.yaml
+++ b/task/tkn/0.4/tests/run.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: tkn-run-without-workspace
+spec:
+  serviceAccountName: tkn-account
+  taskRef:
+    name: tkn
+  params:
+    - name: SCRIPT
+      value: |
+        tkn task list
+        echo "-----------"
+        tkn task describe tkn

--- a/task/tkn/0.4/tkn.yaml
+++ b/task/tkn/0.4/tkn.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: tkn
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/displayName: "Tekton CLI"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  workspaces:
+    - name: kubeconfig
+      description: >-
+        An optional workspace that allows you to provide a .kube/config
+        file for tkn to access the cluster. The file should be placed at
+        the root of the Workspace with name kubeconfig.
+      optional: true
+  description: >-
+    This task performs operations on Tekton resources using tkn
+
+  params:
+    - name: TKN_IMAGE
+      description: tkn CLI container image to run this task
+      default: gcr.io/tekton-releases/dogfooding/tkn@sha256:d17fec04f655551464a47dd59553c9b44cf660cc72dbcdbd52c0b8e8668c0579
+    - name: SCRIPT
+      description: tkn CLI script to execute
+      type: string
+      default: "tkn $@"
+    - name: ARGS
+      type: array
+      description: tkn CLI arguments to run
+      default: ["--help"]
+  steps:
+    - name: tkn
+      image: "$(params.TKN_IMAGE)"
+      script: |
+        if [ "$(workspaces.kubeconfig.bound)" == "true" ] && [[ -e $(workspaces.kubeconfig.path)/kubeconfig ]]; then
+          export KUBECONFIG=$(workspaces.kubeconfig.path)/kubeconfig
+        fi
+
+        $(params.SCRIPT)
+      args: ["$(params.ARGS)"]

--- a/task/tkn/0.4/tkn.yaml
+++ b/task/tkn/0.4/tkn.yaml
@@ -38,11 +38,11 @@ spec:
     - name: tkn
       image: "$(params.TKN_IMAGE)"
       script: |
-        if [ "$(workspaces.kubeconfig.bound)" == "true" ] && [[ -e $(workspaces.kubeconfig.path)/kubeconfig ]]; then
-          export KUBECONFIG=$(workspaces.kubeconfig.path)/kubeconfig
+        if [ "$(workspaces.kubeconfig.bound)" = "true" ] && [ -e $(workspaces.kubeconfig.path)/kubeconfig ]; then
+          export KUBECONFIG="$(workspaces.kubeconfig.path)"/kubeconfig
         fi
 
-        $(params.SCRIPT)
+        eval "$(params.SCRIPT)"
       args: ["$(params.ARGS)"]
       securityContext:
         runAsNonRoot: true

--- a/task/tkn/0.4/tkn.yaml
+++ b/task/tkn/0.4/tkn.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: tkn
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/categories: CLI

--- a/task/tkn/0.4/tkn.yaml
+++ b/task/tkn/0.4/tkn.yaml
@@ -44,3 +44,6 @@ spec:
 
         $(params.SCRIPT)
       args: ["$(params.ARGS)"]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532


### PR DESCRIPTION
# Changes

This PR aims at running tasks as nonroot unless root is required. When tasks are deployed on a Kubernetes cluster (or on OpenShift with anyuid SCC), they run as the root user which is not ideal from a security perspective as it leaves the node exposed to attacks if a bad actor is able to escape the pod.

The best way to review this PR is sequentially commit by commit.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---