### PR TITLE
Set HOME to /tekton/home for nonroot tasks

### DIFF
--- a/task/git-clone/0.8/git-clone.yaml
+++ b/task/git-clone/0.8/git-clone.yaml
@@ -107,7 +107,7 @@ spec:
       description: |
         Absolute path to the user's home directory.
       type: string
-      default: "/home/nonroot"
+      default: "/tekton/home"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task.

--- a/task/kn-apply/0.2/kn-apply.yaml
+++ b/task/kn-apply/0.2/kn-apply.yaml
@@ -33,4 +33,4 @@ spec:
       runAsUser: 65532
     env:
     - name: HOME
-      value: /home/nonroot
+      value: /tekton/home

--- a/task/kn/0.2/kn.yaml
+++ b/task/kn/0.2/kn.yaml
@@ -26,6 +26,9 @@ spec:
     - "help"
   steps:
   - name: kn
+    env:
+    - name: HOME
+      value: /tekton/home
     image: "$(params.kn-image)"
     command: ["/ko-app/kn"]
     args: ["$(params.ARGS)"]

--- a/task/skopeo-copy/0.2/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.2/skopeo-copy.yaml
@@ -41,6 +41,9 @@ spec:
       default: "true"
   steps:
     - name: skopeo-copy
+      env:
+      - name: HOME
+        value: /tekton/home
       image: quay.io/skopeo/stable:v1.9.0
       script: |
         # Function to copy multiple images.

--- a/task/tkn/0.4/tkn.yaml
+++ b/task/tkn/0.4/tkn.yaml
@@ -36,6 +36,9 @@ spec:
       default: ["--help"]
   steps:
     - name: tkn
+      env:
+      - name: HOME
+        value: /tekton/home
       image: "$(params.TKN_IMAGE)"
       script: |
         if [ "$(workspaces.kubeconfig.bound)" = "true" ] && [ -e $(workspaces.kubeconfig.path)/kubeconfig ]; then


### PR DESCRIPTION
# Changes

In an effort to reduce permissions for certain tasks in #1034, the HOME
directory was either set to `/home/nonroot` or was unchanged. This
caused the tasks to fail when being run under limited permissions as
they could not create `/home/nonroot` or write to `/` in some cases.

This commit follows suit with #860 where HOME is set to `/tekton/home`
so that the task can perform actions in it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention
