### PR TITLE
Fix markdown link resolution in PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,17 +35,14 @@ review them:
               Paragraph(s) to describe the resource.
           ```
 
-_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
-for more details._
-
----
+_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._
 
 [TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
 [example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
 [validation]: https://github.com/tektoncd/catalog/issues/413
 [authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
-[docs] https://github.com/tektoncd/community/blob/master/standards.md#docs
-[tests] https://github.com/tektoncd/community/blob/master/standards.md#tests
-[e2e] https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
-[contributor] https://github.com/tektoncd/community/blob/main/standards.md
-[commit] https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
+[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
+[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
+[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
+[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
+[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR inserts colons that I missed in #1040 (oops 🤷🏾) so that the `pull_request_template`
formats correctly in markdown.

Also: fixes whitespace in note to _See the contribution guide_.

/kind documentation
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
