### PR TITLE
Bump sonarqube-scanner task to 0.3 and deprecate the existing ones

### DIFF
--- a/task/sonarqube-scanner/0.1/sonarqube-scanner.yaml
+++ b/task/sonarqube-scanner/0.1/sonarqube-scanner.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: security
     tekton.dev/displayName: "sonarqube scanner"
     tekton.dev/platforms: "linux/amd64"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     The following task can be used to perform static analysis on the source code

--- a/task/sonarqube-scanner/0.2/sonarqube-scanner.yaml
+++ b/task/sonarqube-scanner/0.2/sonarqube-scanner.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: security
     tekton.dev/displayName: "sonarqube scanner"
     tekton.dev/platforms: "linux/amd64"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     The following task can be used to perform static analysis on the source code

--- a/task/sonarqube-scanner/0.3/README.md
+++ b/task/sonarqube-scanner/0.3/README.md
@@ -1,0 +1,70 @@
+# SonarQube
+
+SonarQube™ is the leading tool for continuously inspecting the Code Quality and Security™ of your codebases, all while empowering development teams. Analyze over 25 popular programming languages including C#, VB.Net, JavaScript, TypeScript and C++. It detects bugs, vulnerabilities and code smells across project branches and pull requests.
+
+The following task can be used to perform static analysis on the source code provided the SonarQube server is hosted.
+
+For creating your own `sonar-project.properties` please follow the guide [here](https://docs.sonarqube.org/latest/analysis/analysis-parameters/). Sample properties file can be found [here](./samples/sonar-project.properties)
+
+## Install the Task
+
+```
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-scanner/0.3/raw
+```
+
+## Pre-requisite
+
+Install the `git-clone` task from the catalog
+
+```
+https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.7/raw
+```
+
+## Parameters
+
+- **SONAR_HOST_URL**: SonarQube server URL
+- **SONAR_PROJECT_KEY**: Project's unique key
+- **PROJECT_VERSION**: Version of the project (_Default_: 1.0)
+- **SOURCE_TO_SCAN**: Comma-separated paths to directories containing main source files (_Default_: ".")
+- **SONAR_ORGANIZATION**: The organization in sonarqube where the project exists
+- **SONAR_SCANNER_IMAGE**: The sonarqube scanner CLI image which will run the scan (_Default_: docker.io/sonarsource/sonar-scanner-cli:4.6)
+
+> _Note_ : Parameters are provided in that case when we want to override the corresponding values in `sonar-project.properties` or there is no `sonar-project.properties` present for the project which needs to be analyzed
+
+## Workspaces
+
+- **source**: `PersistentVolumeClaim`-type so that volume can be shared among git-clone and sonarqube task. Sample PVC can be found [here](../0.3/tests/resources.yaml)
+- **sonar-settings**: To mount the `sonar-project.properties` via the `ConfigMap`. It's an optional workspace.
+
+  To mount via the `ConfigMap`:
+
+  ```
+  kubectl create configmap sonar-properties --from-file="sonar-project.properties"
+  ```
+
+## Running SonarQube Server locally using Docker
+
+1. Boot SonarQube
+
+   ```
+   docker run --name="sonarqube" -d sonarqube
+   ```
+
+2. Get the IP address exposed by docker image to access sonarqube server
+
+   ```
+   docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <container_id or container_name>
+   ```
+
+Sample IPAddress we will obtain using above command is like http://172.17.0.2:9000
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+1. `sonar-project.properties` present in Github Repository. For example :- following [repo](https://github.com/vinamra28/sonartest) contains the properties file and Sonar Host URL needs to be updated via the `params`.
+   The sample run for this scenario can be found [here](../0.1/samples/run.yaml)
+
+2. In case when no `sonar-project.properties` file is present then above parameters are mandatory to create a `sonar-project.properties` file with the required fields or the file can be mounted via the `ConfigMap`.

--- a/task/sonarqube-scanner/0.3/samples/sonar-project.properties
+++ b/task/sonarqube-scanner/0.3/samples/sonar-project.properties
@@ -1,0 +1,19 @@
+# required metdata
+sonar.projectKey=node-test-app
+sonar.projectVersion=1.0
+sonar.sourceEncoding=UTF-8
+sonar.organization=default
+sonar.host.url=http://172.17.0.2:9000
+# sonar.language=js
+sonar.eslint.eslintconfigpath=app/eslintrc.json
+
+# path to srouce directories
+sonar.sources=app
+# sonar.tests=app/test/integration/api/
+
+# excludes
+sonar.exclusions=app/node_modules/*,app/coverage/lcov-report/*,app/test/integration/api/v1/*,app/middlewares/common-middleware.js
+
+# coverage reporting
+sonar.javascript.lcov.reportPaths=app/coverage/lcov.info
+# sonar.surefire.reportPaths=app/coverage/lcov-report

--- a/task/sonarqube-scanner/0.3/sonarqube-scanner.yaml
+++ b/task/sonarqube-scanner/0.3/sonarqube-scanner.yaml
@@ -1,0 +1,136 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: sonarqube-scanner
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: Security
+    tekton.dev/tags: security
+    tekton.dev/displayName: "sonarqube scanner"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    The following task can be used to perform static analysis on the source code
+    provided the SonarQube server is hosted
+
+    SonarQube is the leading tool for continuously inspecting the Code Quality and Security
+    of your codebases, all while empowering development teams. Analyze over 25 popular
+    programming languages including C#, VB.Net, JavaScript, TypeScript and C++. It detects
+    bugs, vulnerabilities and code smells across project branches and pull requests.
+
+  workspaces:
+    - name: source
+      description: "Workspace containing the code which needs to be scanned by SonarQube"
+    - name: sonar-settings
+      description: "Optional workspace where SonarQube properties can be mounted"
+      optional: true
+  params:
+    - name: SONAR_HOST_URL
+      description: SonarQube server URL
+      default: ""
+    - name: SONAR_PROJECT_KEY
+      description: Project's unique key
+      default: ""
+    - name: PROJECT_VERSION
+      description: "Version of the project. Default: 1.0"
+      default: "1.0"
+    - name: SOURCE_TO_SCAN
+      description: "Comma-separated paths to directories containing main source files"
+      default: "."
+    - name: SONAR_ORGANIZATION
+      description: "The organization in sonarqube where the project exists"
+      default: ""
+    - name: SONAR_SCANNER_IMAGE
+      description: "The sonarqube scanner CLI image which will run the scan"
+      default: "docker.io/sonarsource/sonar-scanner-cli:4.6@sha256:7a976330a8bad1beca6584c1c118e946e7a25fdc5b664d5c0a869a6577d81b4f"
+  steps:
+    - name: sonar-properties-create
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: SONAR_HOST_URL
+          value: $(params.SONAR_HOST_URL)
+        - name: SONAR_PROJECT_KEY
+          value: $(params.SONAR_PROJECT_KEY)
+        - name: PROJECT_VERSION
+          value: $(params.PROJECT_VERSION)
+        - name: SOURCE_TO_SCAN
+          value: $(params.SOURCE_TO_SCAN)
+        - name: SONAR_ORGANIZATION
+          value: $(params.SONAR_ORGANIZATION)
+      script: |
+        #!/usr/bin/env bash
+
+        replaceValues() {
+          filename=$1
+          thekey=$2
+          newvalue=$3
+
+          if ! grep -R "^[#]*\s*${thekey}=.*" $filename >/dev/null; then
+            echo "APPENDING because '${thekey}' not found"
+            echo "" >>$filename
+            echo "$thekey=$newvalue" >>$filename
+          else
+            echo "SETTING because '${thekey}' found already"
+            sed -ir "s|^[#]*\s*${thekey}=.*|$thekey=$newvalue|" $filename
+          fi
+        }
+
+        if [[ "$(workspaces.sonar-settings.bound)" == "true" ]]; then
+          if [[ -f $(workspaces.sonar-settings.path)/sonar-project.properties ]]; then
+            echo "using user provided sonar-project.properties file"
+            cp -RL $(workspaces.sonar-settings.path)/sonar-project.properties $(workspaces.source.path)/sonar-project.properties
+          fi
+        fi
+
+        if [[ -f $(workspaces.source.path)/sonar-project.properties ]]; then
+          if [[ -n "${SONAR_HOST_URL}" ]]; then
+            echo "replacing sonar host URL"
+            replaceValues $(workspaces.source.path)/sonar-project.properties sonar.host.url "${SONAR_HOST_URL}"
+          fi
+          if [[ -n "${SONAR_PROJECT_KEY}" ]]; then
+            echo "replacing sonar project key"
+            replaceValues $(workspaces.source.path)/sonar-project.properties sonar.projectKey "${SONAR_PROJECT_KEY}"
+          fi
+          echo "Values in sonar-project.properties file replaced successfully..."
+        else
+          echo "Creating sonar-project.properties file..."
+          touch sonar-project.properties
+          [[ -n "${SONAR_PROJECT_KEY}" ]] && {
+            echo "sonar.projectKey=${SONAR_PROJECT_KEY}" >> sonar-project.properties
+          } || {
+            echo "missing property SONAR_PROJECT_KEY"
+            exit 1
+          }
+
+          [[ -n "${SONAR_HOST_URL}" ]] && {
+            echo "sonar.host.url=${SONAR_HOST_URL}" >> sonar-project.properties
+          } || {
+            echo "missing property SONAR_HOST_URL"
+            exit 1
+          }
+
+          [[ -n "${PROJECT_VERSION}" ]] && {
+            echo "sonar.projectVersion=${PROJECT_VERSION}" >> sonar-project.properties
+          } || {
+            echo "missing property PROJECT_VERSION"
+            exit 1
+          }
+
+          [[ -n "${SONAR_ORGANIZATION}" ]] && {
+            echo "sonar.organization=${SONAR_ORGANIZATION}" >> sonar-project.properties
+          } || {
+            echo "missing property SONAR_ORGANIZATION"
+            exit 1
+          }
+          echo "sonar.sources=${SOURCE_TO_SCAN}" >> sonar-project.properties
+          echo "---------------------------"
+          cat $(workspaces.source.path)/sonar-project.properties
+        fi
+    - name: sonar-scan
+      image: $(params.SONAR_SCANNER_IMAGE)
+      workingDir: $(workspaces.source.path)
+      command:
+        - sonar-scanner

--- a/task/sonarqube-scanner/0.3/tests/pre-apply-task-hook.sh
+++ b/task/sonarqube-scanner/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+add_task git-clone 0.7

--- a/task/sonarqube-scanner/0.3/tests/resources.yaml
+++ b/task/sonarqube-scanner/0.3/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonar-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/task/sonarqube-scanner/0.3/tests/run.yaml
+++ b/task/sonarqube-scanner/0.3/tests/run.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: sonarqube-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/vinamra28/sonartest
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: code-analysis
+      taskRef:
+        name: sonarqube-scanner
+      params:
+        - name: SONAR_PROJECT_KEY
+          value: sonarqube-scanner
+        - name: SONAR_HOST_URL
+          value: https://sonarcloud.io/
+        - name: PROJECT_VERSION
+          value: "1.0"
+        - name: SONAR_ORGANIZATION
+          value: tekton-catalog-test
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: sonarqube-run
+spec:
+  pipelineRef:
+    name: sonarqube-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentVolumeClaim:
+        claimName: sonar-source-pvc


### PR DESCRIPTION
# Changes

Deprecate existing versions of sonarqube-scanner
    
    As of now, sonarqube-scanner task version 0.1 and 0.2 are using an older
    version of sonarqube-scanner-cli image ie 4.5 which is around 2 years
    old which makes it incompatible with existing versions of compatible
    node. So deprecating. Will be adding the stable 0.3 version for the
    same.

Add SonarQube version 0.3
    
    The following new version of SonarQube consists of various enhancements
    such as:
    
    - Basic sonar properties can now be passed via parameters
    - `sonar-settings` workspace is now optional
    - Image is now paramterized so that if anyone wants to use their own
      sonar-scanner-cli image then they can easily use it
    - Script improvements
    
/kind feature

Signed-off-by: vinamra28 <jvinamra776@gmail.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations][authoring]
- [X] Includes [docs][docs] (if user facing)
- [X] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [X] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [X] Commit messages follow [commit message best practices][commit]
- [X] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
