### PR TITLE
Make directory safe only right before the git-init

### DIFF
--- a/task/git-clone/0.9/git-clone.yaml
+++ b/task/git-clone/0.9/git-clone.yaml
@@ -174,8 +174,6 @@ spec:
           set -x
         fi
 
-        git config --global --add safe.directory "${WORKSPACE_OUTPUT_PATH}"
-
         if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
           cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
           cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
@@ -220,6 +218,7 @@ spec:
         test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
         test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
+        git config --global --add safe.directory "${WORKSPACE_OUTPUT_PATH}"
         /ko-app/git-init \
           -url="${PARAM_URL}" \
           -revision="${PARAM_REVISION}" \


### PR DESCRIPTION
We were doing the git safe add-directory first but when having a
WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND we would erase the .gitconfig and
that safe variable would not be there anymore.

Do this only right before calling the git-init so we know the setting
would be applied.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

cc @jhonis 