### PR TITLE
Make yq task more accepting of whatever is put in SCRIPT

### DIFF
--- a/task/yq/0.4/yq.yaml
+++ b/task/yq/0.4/yq.yaml
@@ -45,8 +45,14 @@ spec:
         /usr/bin/env sh
         set -e
 
+        SCRIPT=$(cat <<EOF
+        $(params.SCRIPT)
+
+        EOF
+        )
+
         # For backwards compatibility with previous versions
-        if [ "$(params.SCRIPT)" = "" ]; then
+        if [ -z "$SCRIPT" ]; then
           for var in "$@"
           do
               /usr/bin/yq eval -i "$(params.expression)" "$var"
@@ -54,4 +60,4 @@ spec:
           exit $?
         fi
 
-        $(params.SCRIPT)
+        eval "$SCRIPT"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This make the yq task more accepting of whatever is put in the SCRIPT param. 
I currently had some issues with SCRIPT values as

```
            # Retrieve old neo4j instance name
            yq eval ".myName" ./apps/myApp/values-$(params.environment).yaml | tr -d "\n" > $(results.yq.path)

            # Overwrite it
            yq eval -i "myName=\"$(params.newName)\"" ./apps/myApp/values-$(params.environment).yaml
```

or 

```
            yq eval ".myName" ./apps/myApp/values-$(params.environment).yaml | tr -d "\n" > $(results.yq.path)
            yq eval -i "del(.myApps.$(params.myName))" ./apps/app-of-apps/values.yaml
```

both should just work, since they're valid scripts.

This is fixed now (and I've used them both in my pipeline so it seems to actually work)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations][authoring]
- [X] Includes [docs][docs] (if user facing)
- [X] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [X] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [X] Commit messages follow [commit message best practices][commit]
- [X] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
