### PR TITLE
Fixed typo In Readme

### DIFF
--- a/task/git-clone/0.9/README.md
+++ b/task/git-clone/0.9/README.md
@@ -249,9 +249,9 @@ hold your credentials and bind to this workspace.
 ## Using basic-auth Credentials
 
 **Note**: It is strongly advised that you use `ssh` credentials when the option
-is available to you before using basic auth. You can use generate a short
-lived token from WebVCS platforms (Github, Gitlab, Bitbucket etc..) to be use
-as password and generally be able to use `git` as the username.
+is available to you before using basic auth. You can generate a short
+lived token from WebVCS platforms (Github, Gitlab, Bitbucket etc..) to be used
+as a password and generally be able to use `git` as the username.
 On bitbucket server the token may have a / into it so you would need
 to urlquote them before in the `Secret`, see this stackoverflow answer :
 


### PR DESCRIPTION
The "using basic-auth section" of the readme for the `git-clone` task  had a few typos

# Changes
Fixed a typo in the basic authentication section of the readme

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
