### PR TITLE
buildah: Allow secrets to be passed into builds safely

### DIFF
--- a/task/buildah/0.5/README.md
+++ b/task/buildah/0.5/README.md
@@ -37,6 +37,7 @@ kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.5/
 * **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
 * **sslcertdir**: An [*optional* Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry. Buildah will look for files ending with *.crt, *.cert, *.key into this workspace. See [this sample](./samples/openshift-internal-registry.yaml) for a complete example on how to use it with OpenShift internal registry.
 - **dockerconfig**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks) that allows providing a `.docker/config.json` file for Buildah to access the container registry. The file should be placed at the root of the Workspace with name `config.json`. See [this sample](./samples/dockerconfig.yaml) for a complete example on how to use `dockerconfig` to access container registry. _(optional)_
+- **secrets**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks) that allows secrets to be provided (either via passing a Secret as the workspace, or a projected volume containing multiple). They can then be securely consumed by using adding `--secret=id=id,src=path` to `BUILD_EXTRA_ARGS` and using `RUN --mount=type=secret` within the Dockerfile. _(optional)_
 
 ## Platforms
 

--- a/task/buildah/0.5/buildah.yaml
+++ b/task/buildah/0.5/buildah.yaml
@@ -56,6 +56,13 @@ spec:
   - name: source
   - name: sslcertdir
     optional: true
+  - name: secrets
+    optional: true
+    description: >-
+      An optional workspace that allows secrets to be provided (either via passing
+      a Secret as the workspace, or a projected volume containing multiple). They
+      can then be securely consumed by using adding --secret=id=id,src=path to
+      BUILD_EXTRA_ARGS and using RUN --mount=type=secret within the Dockerfile
   - name: dockerconfig
     description: >-
       An optional workspace that allows providing a .docker/config.json file


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

buildah allows secrets to be passed in a safe way that will not end up in the final image. Add this support to buildah Task:

```
FROM registry.access.redhat.com/ubi8/ubi
RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
```

```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  generateName: use-secret-
spec:
  pipelineSpec:
    workspaces:
      - name: shared-workspace
      - name: secrets-ws
        optional: true
    tasks:
      - name: buildah
        taskRef:
          name: buildah
        workspaces:
        - name: source
          workspace: shared-workspace
        - name: secrets
          workspace: secrets-ws
        params:
        - name: IMAGE
          value: docker.io/library/foo
        - name: BUILD_EXTRA_ARGS
          value: --secret=id=mysecret,src=$(workspaces.secrets.path)/config.json
  workspaces:
    - name: shared-workspace
      configMap:
        name: dockerfile
    - name: secrets-ws
      secret:
        secretName: mysecret
```


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
