### PR TITLE
1124 Fix output_format in samples\rox-pipeline.yaml

### DIFF
--- a/task/stackrox-image-scan/0.2/README.md
+++ b/task/stackrox-image-scan/0.2/README.md
@@ -1,0 +1,44 @@
+# StackRox/Red Hat Advanced Cluster Security Image Scan Task
+
+This tasks allows you to return full vulnerability scan results for an image in JSON, CSV, or Pretty format.  It's a companion to the stackrox-image-check task, which checks an image against build-time policies.
+
+## Prerequisites
+
+This task requires an active installation of [Red Hat Advanced Cluster Security (RHACS)](https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet) or [StackRox](https://www.stackrox.io/).  It also requires configuration of secrets for the Central endpoint and an API token with at least CI privileges.  `samples\rox-secrets.yaml` shows how to create the appropriate secrets.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/stackrox-image-scan/0.1/raw
+```
+
+## Parameters
+
+- **rox_central_endpoint**: Secret containing the address:port tuple for StackRox Central (example - rox.stackrox.io:443)
+- **rox_api_token**: Secret containing the StackRox API token with CI permissions
+- **image**: Full name of image to scan (example -- gcr.io/rox/sample:5.0-rc1)
+- **output_format**:  Output format (json | csv | pretty).  This parameter is optional -- if omitted, the default format it JSON.
+- **insecure-skip-tls-verify**: When set to `"true"`, skip verifying the TLS certs of the Central endpoint.  Defaults to `"false"`.
+
+## Usage
+
+StackRox/RHACS scans images that have been pushed to a registry.  This enables scanning regardless of whether the build is using traditional Docker-based approaches, hosted/SaaS-based approaches where the Docker socket may not be directly available, or rootless approaches like `kaniko` and `buildah`.
+
+`samples\rox-pipeline.yaml` is a sample pipeline that takes the image to scan as a parameter.  Calling the task directly looks like this:
+
+```yaml
+  tasks:
+    - name: image-scan
+        taskRef:
+        name: rox-image-scan
+        kind: ClusterTask
+        params:
+            - name: image
+            value: docker.io/stackrox/kube-linter:0.2.2
+            - name: rox_api_token
+            value: roxsecrets
+            - name: rox_central_endpoint
+            value: roxsecrets
+            - name: output_format
+            value: pretty
+```

--- a/task/stackrox-image-scan/0.2/samples/rox-pipeline.yaml
+++ b/task/stackrox-image-scan/0.2/samples/rox-pipeline.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rox-pipeline
+  namespace: pipeline-demo
+spec:
+  description: Rox demo pipeline
+  params:
+    - name: image
+      type: string
+      description: |
+        Full name of image to scan (example -- gcr.io/rox/sample:5.0-rc1)
+  tasks:
+    - name: image-scan
+      taskRef:
+        name: rox-image-scan
+        kind: ClusterTask
+      params:
+        - name: image
+          value: $(params.image)
+        - name: rox_api_token
+          value: roxsecrets
+        - name: rox_central_endpoint
+          value: roxsecrets
+        - name: output_format
+          value: pretty

--- a/task/stackrox-image-scan/0.2/samples/rox-pipeline.yaml
+++ b/task/stackrox-image-scan/0.2/samples/rox-pipeline.yaml
@@ -24,4 +24,4 @@ spec:
         - name: rox_central_endpoint
           value: roxsecrets
         - name: output_format
-          value: pretty
+          value: json

--- a/task/stackrox-image-scan/0.2/samples/rox-secrets.yaml
+++ b/task/stackrox-image-scan/0.2/samples/rox-secrets.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+stringData:
+  rox_central_endpoint: "{{ central_addr }}:{{ central_port }}"
+  # The address:port tuple for StackRox Central (example - rox.stackrox.io:443)
+  # This must include the port number
+  rox_api_token: "{{ rox_api_token }}"
+  # StackRox API token with CI permissions
+  # Refer to below
+  # https://help.stackrox.com/docs/use-the-api/#generate-an-access-token
+kind: Secret
+metadata:
+  name: roxsecrets
+  namespace: pipeline-demo
+type: Opaque

--- a/task/stackrox-image-scan/0.2/stackrox-image-scan.yaml
+++ b/task/stackrox-image-scan/0.2/stackrox-image-scan.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: stackrox-image-scan
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/tags: security
+    tekton.dev/categories: Security
+    tekton.dev/displayName: "Scan an image with StackRox/RHACS"
+    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/pipelines.minVersion: "0.18.0"
+spec:
+  description: >-
+    Scan an image with StackRox/RHACS
+    This tasks allows you to return full vulnerability scan results for an image
+    in JSON, CSV, or Pretty format.
+    It's a companion to the stackrox-image-check task,
+    which checks an image against build-time policies.
+  params:
+    - name: rox_central_endpoint
+      type: string
+      description: |
+        Secret containing the address:port tuple for StackRox Central
+        (example - rox.stackrox.io:443)
+    - name: rox_api_token
+      type: string
+      description: Secret containing the StackRox API token with CI permissions
+    - name: image
+      type: string
+      description: |
+        Full name of image to scan (example -- gcr.io/rox/sample:5.0-rc1)
+    - name: output_format
+      type: string
+      description: Output format (json | csv | pretty)
+      default: json
+    - name: insecure-skip-tls-verify
+      type: string
+      description: |
+        When set to `"true"`, skip verifying the TLS certs of the Central
+        endpoint.  Defaults to `"false"`.
+      default: "false"
+  steps:
+    - name: rox-image-scan
+      image: docker.io/centos@sha256:a1801b843b1bfaf77c501e7a6d3f709401a1e0c83863037fa3aab063a7fdb9dc
+      env:
+        - name: ROX_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_api_token)
+              key: rox_api_token
+        - name: ROX_CENTRAL_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_central_endpoint)
+              key: rox_central_endpoint
+      script: |
+        #!/usr/bin/env bash
+        set +x
+        export NO_COLOR="True"
+        curl -s -k -L -H "Authorization: Bearer $ROX_API_TOKEN" \
+          "https://$ROX_CENTRAL_ENDPOINT/api/cli/download/roxctl-linux" \
+          --output ./roxctl  > /dev/null; echo "Getting roxctl"
+        chmod +x ./roxctl > /dev/null
+        ./roxctl image scan \
+          $( [ "$(params.insecure-skip-tls-verify)" = "true" ] && \
+          echo -n "--insecure-skip-tls-verify") \
+          -e "$ROX_CENTRAL_ENDPOINT" --image "$(params.image)" \
+          --output "$(params.output_format)"


### PR DESCRIPTION
# Changes

Change the output_format from `pretty` to `json` to fix issue #1124
- this has been tested on RHACS.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
