### PR TITLE
skopeo-copy: add ability to pass parameters and copy manifests

### DIFF
--- a/task/skopeo-copy/0.3/README.md
+++ b/task/skopeo-copy/0.3/README.md
@@ -1,0 +1,109 @@
+# Skopeo
+
+
+[Skopeo](https://github.com/containers/skopeo) is a command line tool for working with remote image registries. Skopeo doesn’t require a daemon to be running while performing its operations. In particular, the handy skopeo command called `copy` will ease the whole image copy operation. Without further ado, you can copy an image from a registry to another simply by running:
+```
+skopeo copy docker://internal.registry/myimage:latest /
+docker://production.registry/myimage:v1.0
+```
+The copy command will take care of copying the image from `internal.registry` to `production.registry`
+
+If your production registry requires credentials to login in order to push the image, skopeo can handle that as well.
+
+```
+skopeo copy --dest-creds prod_user:prod_pass docker://internal.registry/myimage:latest /
+docker://production.registry/myimage:v1.0
+```
+
+The same goes for credentials for the source registry (internal.registry) by using the `--src-creds` flag.
+
+It is also useful for copying images between two remote docker registries, such as the registries of two different OpenShift clusters, as shown
+```
+skopeo copy docker://busybox:latest oci:busybox_ocilayout:latest
+```
+Skopeo copy isn’t limited to remote containers registries. The image prefix `docker://` from the above command define the transport to be used when handling the image.
+
+There are others also similar to that:
+
+- atomic
+- containers-storage
+- dir
+- docker
+- docker-daemon
+- docker-tar
+- oci
+- ostree
+
+This `task` can be used to copy one or more than one images to-and fro various storage mechanisms.
+
+## Install the Task
+
+```
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/skopeo-copy/0.2/raw
+```
+
+## Parameters
+
+- **srcImageURL**: The URL of the image to be copied to the `destination` registry.
+- **destImageURL**: The URL of the image where the image from `source` should be copied to.
+- **srcTLSverify**: Verify the TLS on the src registry endpoint
+- **destTLSverify**: Verify the TLS on the dest registry endpoint
+
+## Workspace
+
+- **images-url**: To mount file containing multiple source and destination images registries URL, which is mounted as configMap.
+
+
+## Secrets and ConfigMap
+* `Secret` to provide the credentials of the source and destination registry where the image needs to be copied from and to.
+* `ConfigMap` to provide support for copying multiple images, this contains file `url.txt` which stores images registry URL's.
+
+  [This](../0.2/samples/quay-secret.yaml) example can help to use secrets for providing credentials of image registries.
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+This task will use the `Service Account` with access to the secrets containing source and destination image registry credentials, this will authorize it to the respective image registries. 
+
+In case of multiple source and destination image registries that needs to be copied to and fro, a file named `url.txt` should be created containing all the source and destination image registries `URL` seperated by a space and each set of images should be written in the new line, as shown below.
+
+```
+docker://quay.io/temp/kubeconfigwriter:v1 docker://quay.io/skopeotest/kube:v1
+docker://quay.io/temp/kubeconfigwriter:v2 docker://quay.io/skopeotest/kube:v2
+```
+
+`ConfigMap` should be created using this file. Following `command` can be used to create configMap from the `file`.
+```
+kubectl create configmap image-configmap --from-file=url.txt
+```
+In case there is only one source and destination image that needs to be copied then, Source and destination image URL needs to be provided in the input params of the task.
+
+This will result in the image getting copied from the source registry to the destination registry.
+
+
+[This](../0.2/samples/serviceaccount.yaml) will guide the user to use service account for authorization to image registries.
+
+See [here](../0.2/samples/run.yaml) for example of `TaskRun`.
+### Note
+
+- `Source credentials` are only required, if the source image registry needs authentication to pull the image, whereas `Destination credentials` are always required.
+
+- In case of multiple source and destination images, `secret` containing `credentials` of all the image registries must be added to the `service account` and configMap containing `url.txt` should be mounted into the workspace, as shown
+    ```
+    workspaces:
+      - name: images-url
+        configmap:
+          name: image-configmap
+    ```
+
+
+- If there is only one source and destination image registry URL, then `emptyDir` needs to be mounted in the `workspace` as shown below:
+
+    ```
+    workspaces:
+      - name: images-url
+        emptyDir: {}
+    ```

--- a/task/skopeo-copy/0.3/README.md
+++ b/task/skopeo-copy/0.3/README.md
@@ -75,6 +75,12 @@ docker://quay.io/temp/kubeconfigwriter:v1 docker://quay.io/skopeotest/kube:v1
 docker://quay.io/temp/kubeconfigwriter:v2 docker://quay.io/skopeotest/kube:v2
 ```
 
+Each copy can be customized by adding *skopeo copy* parameters before images transport.
+
+```
+--all docker://quay.io/temp/kubeconfigwriter:v1 docker://quay.io/skopeotest/kube:v1
+```
+
 `ConfigMap` should be created using this file. Following `command` can be used to create configMap from the `file`.
 ```
 kubectl create configmap image-configmap --from-file=url.txt

--- a/task/skopeo-copy/0.3/samples/docker-secret.yaml
+++ b/task/skopeo-copy/0.3/samples/docker-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-creds
+  annotations:
+    tekton.dev/docker-0: https://docker.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: test
+  password: test@1

--- a/task/skopeo-copy/0.3/samples/quay-secret.yaml
+++ b/task/skopeo-copy/0.3/samples/quay-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quay-creds
+  annotations:
+    tekton.dev/docker-0: https://quay.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: skopeotest
+  password: Skopeo@1

--- a/task/skopeo-copy/0.3/samples/run.yaml
+++ b/task/skopeo-copy/0.3/samples/run.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: skopeo-run
+spec:
+  serviceAccountName: secret-service-account
+  taskRef:
+    name: skopeo-copy
+  workspaces:
+  - name: images-url
+    configmap:
+      name: image-configmap

--- a/task/skopeo-copy/0.3/samples/serviceaccount.yaml
+++ b/task/skopeo-copy/0.3/samples/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-service-account
+secrets:
+  - name: docker-creds
+  - name: quay-creds

--- a/task/skopeo-copy/0.3/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.3/skopeo-copy.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: skopeo-copy
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: cli
+    tekton.dev/displayName: "skopeo copy"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    Skopeo is a command line tool for working with remote image registries.
+
+    Skopeo doesn’t require a daemon to be running while performing its operations.
+    In particular, the handy skopeo command called copy will ease the whole image
+    copy operation. The copy command will take care of copying the image from
+    internal.registry to production.registry. If your production registry requires
+    credentials to login in order to push the image, skopeo can handle that as well.
+
+  workspaces:
+    - name: images-url
+  params:
+    - name: srcImageURL
+      description: URL of the image to be copied to the destination registry
+      type: string
+      default: ""
+    - name: destImageURL
+      description: URL of the image where the image from source should be copied to
+      type: string
+      default: ""
+    - name: srcTLSverify
+      description: Verify the TLS on the src registry endpoint
+      type: string
+      default: "true"
+    - name: destTLSverify
+      description: Verify the TLS on the dest registry endpoint
+      type: string
+      default: "true"
+  steps:
+    - name: skopeo-copy
+      env:
+      - name: HOME
+        value: /tekton/home
+      image: quay.io/skopeo/stable:v1.9.0
+      script: |
+        # Function to copy multiple images.
+        #
+        copyimages() {
+          filename="$(workspaces.images-url.path)/url.txt"
+          while IFS= read -r line || [ -n "$line" ]
+          do
+            cmd=""
+            for url in $line
+            do
+              # echo $url
+              cmd="$cmd \
+                  $url"
+            done
+            skopeo copy "$cmd" --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
+            echo "$cmd"
+          done < "$filename"
+        }
+        #
+        # If single image is to be copied then, it can be passed through
+        # params in the taskrun.
+        if [ "$(params.srcImageURL)" != "" ] && [ "$(params.destImageURL)" != "" ] ; then
+          skopeo copy "$(params.srcImageURL)" "$(params.destImageURL)" --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
+        else
+          # If file is provided as a configmap in the workspace then multiple images can be copied.
+          #
+          copyimages
+        fi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532

--- a/task/skopeo-copy/0.3/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.3/skopeo-copy.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: skopeo-copy
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: CLI

--- a/task/skopeo-copy/0.3/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.3/skopeo-copy.yaml
@@ -45,22 +45,18 @@ spec:
       - name: HOME
         value: /tekton/home
       image: quay.io/skopeo/stable:v1.9.0
+      imagePullPolicy: IfNotPresent
       script: |
         # Function to copy multiple images.
         #
         copyimages() {
           filename="$(workspaces.images-url.path)/url.txt"
-          while IFS= read -r line || [ -n "$line" ]
+          while read -r line || [ -n "$line" ]
           do
-            cmd=""
-            for url in $line
-            do
-              # echo $url
-              cmd="$cmd \
-                  $url"
-            done
-            skopeo copy "$cmd" --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
-            echo "$cmd"
+            (
+              set +x
+              skopeo copy $line --src-tls-verify="$(params.srcTLSverify)" --dest-tls-verify="$(params.destTLSverify)"
+            )
           done < "$filename"
         }
         #

--- a/task/skopeo-copy/0.3/tests/pre-apply-task-hook.sh
+++ b/task/skopeo-copy/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Add an internal registry as sidecar to the task so we can upload it directly
+# from our tests without having to go to an external registry.
+add_sidecar_registry ${TMPF}

--- a/task/skopeo-copy/0.3/tests/run.yaml
+++ b/task/skopeo-copy/0.3/tests/run.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: skopeo-run
+spec:
+  params:
+    - name: srcImageURL
+      value: docker://quay.io/temp/kubeconfigwriter:v1
+    - name: destImageURL
+      value: docker://localhost:5000/kube:latest
+    - name: destTLSverify
+      value: "false"
+  taskRef:
+    name: skopeo-copy
+  workspaces:
+  - name: images-url
+    emptyDir: {}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add ability to pass parameters to *skopeo copy* command.
This allows to copy full manifests.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

