### PR TITLE
add RHACS networkpolicy generation task

### DIFF
--- a/task/rhacs-networkpolicy-generate/3.73/README.md
+++ b/task/rhacs-networkpolicy-generate/3.73/README.md
@@ -1,0 +1,86 @@
+# Red Hat Advanced Cluster Security Generate NetworkPolicy Task
+
+Generate suggested NetworkPolicy artifacts given source Kubernetes manifests using `roxctl`.
+
+See the [RHACS documentation](https://docs.openshift.com/acs/3.73/operating/manage-network-policies.html) for more detail.
+
+**This is a Technology Preview feature**
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see <https://access.redhat.com/support/offerings/techpreview/>
+
+## Prerequisites
+
+This task requires an active installation of [Red Hat Advanced Cluster Security (RHACS)](https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet).  It also requires configuration of secrets for the Central endpoint and an API token with at least CI privileges.
+
+<https://www.redhat.com/en/technologies/cloud-computing/openshift/advanced-cluster-security-kubernetes>
+
+## Install the Task
+
+```bash
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-networkpolicy-generate/3.73/raw
+```
+
+## Parameters
+
+- **`manifests`**: Directory holding deployment manifests. May be relative to workspace root or fully qualified. Examples: _"k8s"_
+- **`insecure-skip-tls-verify`**: Skip verification the TLS certs of the Central endpoint and registry. Examples: _"true", **"false"**_.
+- **`networkpolicy-dir`**: Directory to store generated policies in. Example: _$(workspaces.source.path)/networkpolicies_
+- **`rox_api_token`**: Secret containing the StackRox API token with CI permissions. Default: _**rox-api-token**_
+- **`rox_central_endpoint`**: Secret containing the address:port tuple for StackRox Central. Default: _**rox-central-endpoint**_
+- **`rox_image`**: Container image providing `roxctl`. Examples: _**quay.io/stackrox-io/roxctl:3.73.1**, registry.redhat.io/advanced-cluster-security/rhacs-roxctl-rhel8:3.73_
+
+## Workspaces
+
+- **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the application manifests.
+
+## Usage
+
+Create secrets for authentication to RHACS Central endpoint and supply filesystem path to deployment manifests for analysis.
+
+Run this task after checking out application manifest source code.
+
+**Example secret creation:**
+
+```bash
+kubectl create secret generic rox-api-token \
+  --from-literal=rox_api_token="$ROX_API_TOKEN"
+kubectl create secret generic rox-central-endpoint \
+  --from-literal=rox_central_endpoint=central.stackrox.svc:443
+```
+
+**Example task use:**
+
+```yaml
+  tasks:
+    - name: generate-networkpolicy
+    taskRef:
+      name: rhacs-networkpolicy-generate
+      kind: Task
+    workspaces:
+      - name: source
+        workspace: shared-workspace
+    params:
+      - name: manifests
+        value: $(workspaces.source.path)/k8s
+      - name: networkpolicy-dir
+        value: '$(workspaces.source.path)/networkpolicy'
+    runAfter:
+      - fetch-repository
+```
+
+**Samples:**
+
+* [secrets.yaml](samples/secrets.yaml) example secret
+* [pipeline.yaml](samples/pipeline.yaml) demonstrates use in a pipeline.
+* [pipelinerun.yaml](samples/pipelinerun.yaml) demonstrates use in a pipelinerun.
+
+# Known Issues
+
+* Skipping TLS Verify is currently required. TLS trust bundle not working for quay.io etc.
+* It is not strictly true that a endpoint and token are required to generate network policies. The generate command acts locally, and does not contact Central. I'm not yet aware if the product could change to require a connection later, so these values are currently required by this task for consistency with related tasks.
+* Even with empty values, `--output-dir` and `--output-file` may not be supplied simultaneously. This task takes the opinion that `--output-dir` is best and eschews other options for now.
+  > _ERROR:    Flags [-d|--output-dir, -f|--output-file] cannot be used together_
+  * **Possible RFE for roxctl:**
+    * Permit both `--output-dir` and `--output-file` flags  to exist simultaneously.
+    * In case of _non-null_ values for both, `exit 1`
+    * In case of _non-null_ values for one, write to that location
+    * In case of _null_ values for both, write to `STDOUT`

--- a/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
@@ -99,7 +99,7 @@ spec:
 
     - name: save-results
       workingDir: $(workspaces.source.path)
-      image: ubi8:latest
+      image: registry.access.redhat.com/ubi8/ubi-minimal@sha256:e7ac72a1704622c46ca2f21f6d2aac3770b9408fa3add45f9d37008dad8f24ec
       script: |
         #!/usr/bin/env bash
         echo -n "NETWORKPOLICY_DIR="

--- a/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
@@ -103,10 +103,10 @@ spec:
       script: |
         #!/usr/bin/env bash
         echo -n "NETWORKPOLICY_DIR="
-        echo $NETWORKPOLICY_DIR  | tee $(results.networkpolicy_dir.path) 
+        echo "$NETWORKPOLICY_DIR"  | tee "$(results.networkpolicy_dir.path)"
         echo ''
 
-        for policy in $NETWORKPOLICY_DIR/*; do
+        for policy in "$NETWORKPOLICY_DIR"/*; do
           echo '---'
           cat "$policy"
         done

--- a/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
@@ -84,11 +84,11 @@ spec:
             secretKeyRef:
               name: $(params.rox_central_endpoint)
               key: rox_central_endpoint
-      command: 
+      command:
         - /roxctl
       args:
         - generate
-        - netpol 
+        - netpol
         - --endpoint=$(ROX_CENTRAL_ENDPOINT)
         - --fail
         - --insecure-skip-tls-verify=$(INSECURE)

--- a/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
@@ -92,7 +92,6 @@ spec:
         - --endpoint=$(ROX_CENTRAL_ENDPOINT)
         - --fail
         - --insecure-skip-tls-verify=$(INSECURE)
-        # - --output-file=$(NETWORKPOLICY_FILE)
         - --output-dir=$(NETWORKPOLICY_DIR)
         - --remove
         - $(MANIFESTS)

--- a/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/rhacs-networkpolicy-generate.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: rhacs-networkpolicy-generate
+  labels:
+    app.kubernetes.io/version: "3.73"
+  annotations:
+    tekton.dev/tags: security
+    tekton.dev/categories: Security
+    tekton.dev/displayName: "Generate NetworkPolicy manifests with Red Hat Advanced Cluster Security"
+    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/pipelines.minVersion: "0.18.0"
+spec:
+  description: >-
+    Generate NetworkPolicy manifests with Red Hat Advanced Cluster Security.
+
+    This tasks allows you to generate NetworkPolicy manifests from application manifests
+    using a technology preview feature of roxctl.
+    https://github.com/stackrox/stackrox/blob/master/roxctl/generate/README.md
+
+  params:
+    - name: rox_api_token
+      type: string
+      description: Name of secret containing the RHACS StackRox API token with CI permissions.
+      default: rox-api-token
+    - name: rox_central_endpoint
+      type: string
+      description: Name of secret containing the address:port tuple for RHACS Stackrox Central.
+      default: rox-central-endpoint
+    - name: rox_image
+      description: Image providing the roxctl tool.
+      default: quay.io/stackrox-io/roxctl:3.73.1
+    - name: manifests
+      type: string
+      description: |
+        Path to manifests to analyze and generate NetworkPolicies for.
+        Examples: '$(workspaces.source.path)/k8s'
+      default: '$(workspaces.source.path)'
+    - name: networkpolicy-dir
+      type: string
+      description: |
+        Directory to store generated NetworkPolicies in. One policy per file.
+        Examples: '$(workspaces.source.path)/networkpolicy'
+      default: '$(workspaces.source.path)/networkpolicy'
+    - name: insecure-skip-tls-verify
+      type: string
+      description: |
+        Do not verify TLS certificates.
+
+        When set to "true", skip verifying the TLS certs of the Central endpoint and registry.
+      default: "false"
+
+  workspaces:
+    - name: source
+
+  results:
+    - name: networkpolicy_dir
+      description: Location of output from `roxctl generate netpol --output-dir`
+
+  stepTemplate:
+    env:
+      - name: HOME
+        value: /tekton/home
+      - name: NETWORKPOLICY_DIR
+        value: $(params.networkpolicy-dir)
+
+  steps:
+    - name: rox-generate-netpol
+      workingDir: $(workspaces.source.path)
+      image: $(params.rox_image)
+      env:
+        - name: INSECURE
+          value: $(params.insecure-skip-tls-verify)
+        - name: MANIFESTS
+          value: $(params.manifests)
+        - name: ROX_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_api_token)
+              key: rox_api_token
+        - name: ROX_CENTRAL_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: $(params.rox_central_endpoint)
+              key: rox_central_endpoint
+      command: 
+        - /roxctl
+      args:
+        - generate
+        - netpol 
+        - --endpoint=$(ROX_CENTRAL_ENDPOINT)
+        - --fail
+        - --insecure-skip-tls-verify=$(INSECURE)
+        # - --output-file=$(NETWORKPOLICY_FILE)
+        - --output-dir=$(NETWORKPOLICY_DIR)
+        - --remove
+        - $(MANIFESTS)
+
+    - name: save-results
+      workingDir: $(workspaces.source.path)
+      image: ubi8:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n "NETWORKPOLICY_DIR="
+        echo $NETWORKPOLICY_DIR  | tee $(results.networkpolicy_dir.path) 
+        echo ''
+
+        for policy in $NETWORKPOLICY_DIR/*; do
+          echo '---'
+          cat "$policy"
+        done

--- a/task/rhacs-networkpolicy-generate/3.73/samples/pipeline.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/samples/pipeline.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: rox-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+
+  params:
+    - name: networkpolicy-dir
+      type: string
+      description: directory to hold generated networkpolicies
+      default: '$(workspaces.source.path)/networkpolicy'
+    - name: git-url
+      type: string
+      description: url of the git repo for the code of deployment
+    - name: git-revision
+      type: string
+      description: revision to be used from repo of the code for deployment
+    - name: manifests
+      type: string
+      description: Path to manifests to analyze and generate NetworkPolicies for.
+      default: '$(workspaces.source.path)'
+
+  tasks:
+    # checkout source code
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+        - name: revision
+          value: $(params.git-revision)
+
+    # generate NetworkPolicies through static analysis
+    - name: generate-networkpolicy
+      taskRef:
+        name: rhacs-networkpolicy-generate
+        kind: Task
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: networkpolicy-dir
+          value: $(params.networkpolicy-dir)
+        - name: manifests
+          value: $(params.manifests)
+        - name: insecure-skip-tls-verify
+          value: "true"
+      runAfter:
+        - fetch-repository

--- a/task/rhacs-networkpolicy-generate/3.73/samples/pipelinerun.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/samples/pipelinerun.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: rox-pipelinerun
+spec:
+  pipelineRef:
+    name: rox-pipeline
+
+  params:
+    - name: networkpolicy-dir
+      value: '$(workspaces.source.path)/networkpolicy'
+    - name: git-url
+      value: 'https://github.com/GoogleCloudPlatform/microservices-demo.git'
+    - name: manifests
+      value: 'kubernetes-manifests'
+    - name: git-revision
+      value: main
+    - name: insecure-skip-tls-verify
+      value: "true"
+
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 50Mi

--- a/task/rhacs-networkpolicy-generate/3.73/samples/secrets.yaml
+++ b/task/rhacs-networkpolicy-generate/3.73/samples/secrets.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: rox-api-token
+data:
+  rox_api_token: EXAMPLE
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  rox_central_endpoint: Y2VudHJhbC5zdGFja3JveC5zdmM6NDQz
+metadata:
+  name: rox-central-endpoint

--- a/task/rhacs-networkpolicy-generate/OWNERS
+++ b/task/rhacs-networkpolicy-generate/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- dlbewley
+- MoOyeg
+reviewers:
+- dlbewley
+- MoOyeg


### PR DESCRIPTION
# Changes

Adds rhacs-networkpolicy-generate task.

This task uses `roxctl` to analyze Kubernetes resources such as Service, Deployment, and ConfigMap to generate corresponding Kubernetes NetworkPolicy manifests as output.

# Submitter Checklist

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

/kind feature