### PR TITLE
Fix nightly ci and bump pipelines version to v0.44.0

### DIFF
--- a/task/pylint/0.2/pylint.yaml
+++ b/task/pylint/0.2/pylint.yaml
@@ -20,7 +20,7 @@ spec:
   params:
     - name: image
       description: The container image with pylint
-      default: registry.gitlab.com/pipeline-components/pylint:edge
+      default: registry.gitlab.com/pipeline-components/pylint:0.12.0@sha256:051b701936dfab6fa27bd1ebd50ef56b19577565661bc0227e50dd1cf94a3d6e
     - name: path
       description: The path to the module which should be analysed by pylint
       default: "."

--- a/task/upload-pypi/0.2/tests/run.yaml
+++ b/task/upload-pypi/0.2/tests/run.yaml
@@ -20,6 +20,8 @@ spec:
       value: ""
     - name: deleteExisting
       value: "true"
+    - name: revision
+      value: d4ee05fdc03e848ed6e7065d8fe8e833a3c8c0b2
   - name: upload-pypi-run
     params:
     - name: TWINE_REPOSITORY_URL

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,7 +17,7 @@
 # Configure the number of parallel tests running at the same time, start from 0
 MAX_NUMBERS_OF_PARALLEL_TASKS=7 # => 8
 
-export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.40.0/release.yaml
+export RELEASE_YAML=https://github.com/tektoncd/pipeline/releases/download/v0.44.0/release.yaml
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 source $(dirname $0)/e2e-common.sh


### PR DESCRIPTION
# Changes

- Force the version of pylint to 0.12.0 in order to fix the CI
- Bump the pipelines version from v0.40.0 to v0.44.0

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
