### PR TITLE
Remove newline character from buildah results

### DIFF
--- a/task/buildah/0.5/buildah.yaml
+++ b/task/buildah/0.5/buildah.yaml
@@ -84,7 +84,7 @@ spec:
         --digestfile /tmp/image-digest $(params.IMAGE) \
         docker://$(params.IMAGE)
       cat /tmp/image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
+      echo -n "$(params.IMAGE)" | tee $(results.IMAGE_URL.path)
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers

--- a/task/buildah/0.5/tests/run.yaml
+++ b/task/buildah/0.5/tests/run.yaml
@@ -36,6 +36,22 @@ spec:
       params:
       - name: IMAGE
         value: registry:5000/nocode
+    - name: test-buildah-results
+      params:
+        - name: OUTPUT_IMAGE
+          value: "$(tasks.buildah.results.IMAGE_URL)"
+        - name: ORIGINAL_IMAGE
+          value: registry:5000/nocode
+      taskSpec:
+        params:
+          - name: ORIGINAL_IMAGE
+          - name: OUTPUT_IMAGE
+        steps:
+          - name: evaluate
+            image: alpine
+            script: |
+              #!/usr/bin/env sh
+              [[ "$(params.ORIGINAL_IMAGE)" = "$(params.OUTPUT_IMAGE)" ]] && exit 0 || exit 1
   workspaces:
   - name: shared-workspace
     volumeClaimTemplate:


### PR DESCRIPTION
# Changes

While consuming the result `IMAGE_URL` produced by buildah task, a new line character '\n' was getting appended and the same was causing issues which using the task.

- Added `-n` flag with echo in order to remove the newline character
- Modified the tests for the same

/kind bug

fixes #1133

Signed-off-by: vinamra28 <jvinamra776@gmail.com>
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
