### PR TITLE
Added optional workspace gradle-config

### DIFF
--- a/task/gradle/0.3/README.md
+++ b/task/gradle/0.3/README.md
@@ -1,0 +1,69 @@
+# Gradle
+
+This Task can be used to run a Gradle build on a gradle project.
+
+## Install the Task
+
+```bash
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gradle/0.3/raw
+```
+
+## Parameters
+
+- **GRADLE_IMAGE**: The base image for gradle (_default_: `gradle:7.6-jdk8`)
+- **PROJECT_DIR**: The project directory containing `build.gradle` (_default_: `.`)
+- **TASKS**: The gradle tasks to run (_default_: `build`)
+
+## Workspaces
+
+- **source**: `PersistentVolumeClaim`-type so that the volume can be shared among `git-clone` and `gradle` task
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gradle-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+```
+
+- **gradle-config**: A volume containing the gradle.properties to be used during the gradle run. Is `optional`.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gradle-config
+data:
+  gradle.properties: |-
+    artifactory_contextUrl=https://jfrog.com/artifactory
+```
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x` and `linux/ppc64le` platforms.
+
+## Usage
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: run-gradle-build
+spec:
+  taskRef:
+    name: gradle
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+    - name: gradle-config
+      configmap:
+        name: gradle-config        
+  params:
+    - name: PROJECT_DIR
+      value: my-workspace
+```

--- a/task/gradle/0.3/gradle.yaml
+++ b/task/gradle/0.3/gradle.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: gradle
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/displayName: Gradle
+    tekton.dev/categories: Build Tools
+    tekton.dev/tags: build-tool
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  description: >-
+    This Task can be used to run a Gradle build.
+
+  workspaces:
+    - name: source
+      description: The workspace consisting of the gradle project.
+    - name: gradle-config
+      description: The workspace consisting of the custom gradle properties provided by the user.
+      optional: true
+  params:
+    - name: GRADLE_IMAGE
+      description: Gradle base image.
+      type: string
+      default: docker.io/library/gradle:7.6-jdk8@sha256:ebda657f66e04cfa9f152896b4fa70bea4b80561a836adddca3ed85d622f8898
+    - name: PROJECT_DIR
+      description: The directory containing build.gradle
+      type: string
+      default: "."
+    - name: TASKS
+      description: 'The gradle tasks to run (default: build)'
+      type: array
+      default:
+        - build
+  steps:
+    - name: gradle-tasks
+      image: $(params.GRADLE_IMAGE)
+      env:
+        - name: GRADLE_USER_HOME
+          value: "/home/gradle"
+      workingDir: $(workspaces.source.path)/$(params.PROJECT_DIR)
+      args:
+        - "$(params.TASKS)"
+      script: |
+        #!/usr/bin/env bash
+
+        if [[ "$(workspaces.gradle-config.bound)" == "true" ]]; then
+          echo "gradle-config workspace is bound"
+          if [[ -f $(workspaces.gradle-config.path)/gradle.properties ]]; then
+            echo "copying gradle.properties to /home/gradle"
+            cp "$(workspaces.gradle-config.path)/gradle.properties" /home/gradle
+          fi
+        fi
+
+        cmd="gradle $*"
+        echo "Running gradle task with command below"
+        echo "$cmd"
+        eval "$cmd"
+      volumeMounts:
+        - mountPath: /home/gradle
+          name: empty-dir
+  volumes:
+    - name: empty-dir
+      emptyDir: {}

--- a/task/gradle/0.3/tests/pre-apply-task-hook.sh
+++ b/task/gradle/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+add_task git-clone 0.7

--- a/task/gradle/0.3/tests/resources.yaml
+++ b/task/gradle/0.3/tests/resources.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gradle-source-pvc
+spec:
+  resources:
+    requests:
+      storage: 500Mi
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gradle-config
+data:
+  gradle.properties: |-
+    artifactory_contextUrl=https://jfrog.com/artifactory

--- a/task/gradle/0.3/tests/run.yaml
+++ b/task/gradle/0.3/tests/run.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: gradle-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: gradle-config
+  tasks:
+    - name: fetch-code
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/crshnburn/simple-gradle
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: gradle-run
+      taskRef:
+        name: gradle
+      runAfter:
+        - fetch-code
+      params:
+        - name: TASKS
+          value:
+            - build
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: gradle-config
+          workspace: gradle-config
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: gradle-test-pipeline-rune
+spec:
+  pipelineRef:
+    name: gradle-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: gradle-source-pvc
+    - name: gradle-config
+      configmap:
+        name: gradle-config


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Added optional workspace gradle-config, the gradle.properties in this workspace wil be copied to the home directory of the gradle user. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              This Task can be used to run a Gradle build.

          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages

/kind feature