### PR TITLE
Fix typo in build-push-gke-deploy-example walkthrough

### DIFF
--- a/pipeline/build-push-gke-deploy/0.1/samples/build-push-gke-deploy-example.md
+++ b/pipeline/build-push-gke-deploy/0.1/samples/build-push-gke-deploy-example.md
@@ -66,7 +66,7 @@ Install the Tekton Pipelines CLI to view your logs by following the instructions
 
   ```bash
   IMAGE_REGISTRY_PROJECT=[PROJECT_ID]
-  sed -i "s/@IMAGE_REGISTRY_PROJECT@/$IMAGE_REGISTRY_PROJECT/g" gke-deploy/example/app/config/app.yaml
+  sed -i "s/@IMAGE_REGISTRY_PROJECT@/$IMAGE_REGISTRY_PROJECT/g" pipeline/build-push-gke-deploy/0.1/samples/app/config/app.yaml
   ```
 
 4. Commit and push your changes to a new branch.


### PR DESCRIPTION
# Changes

The path in the `build-push-gke-deploy-example` walkthrough appears to be out of date. I've updated it with what I believe is the correct path.