### PR TITLE
Fix hardcoded result path usage in Tasks

### DIFF
--- a/task/boskos-acquire/0.1/boskos-acquire.yaml
+++ b/task/boskos-acquire/0.1/boskos-acquire.yaml
@@ -41,12 +41,12 @@ spec:
         --state=free \
         --target-state=busy)
       echo $RESOURCE > /workspace/full-resource-output.json
-      echo $RESOURCE | jq -rj ".name" > /tekton/results/leased-resource
+      echo $RESOURCE | jq -rj ".name" > $(results.leased-resource.path)
   - name: create-heartbeat-pod-yaml
     image: docker.io/lachlanevenson/k8s-kubectl@sha256:3a5e22a406a109f4f26ec06b5f1f6a66ae0cd0e185bc28499eb7b7a3bbf1fe09
     script: |
       FULL_RESOURCE_OUTPUT=$(cat /workspace/full-resource-output.json)
-      LEASED_RESOURCE=$(cat /tekton/results/leased-resource)
+      LEASED_RESOURCE=$(cat $(results.leased-resource.path))
       cat <<EOF | kubectl apply -f -
       apiVersion: v1
       kind: Pod

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -87,7 +87,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)
-    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/image-digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: varlibcontainers

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -89,7 +89,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)
-    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/image-digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: varlibcontainers

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -93,7 +93,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)
-    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/image-digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: varlibcontainers

--- a/task/gke-cluster-create/0.1/gke-cluster-create.yaml
+++ b/task/gke-cluster-create/0.1/gke-cluster-create.yaml
@@ -107,4 +107,4 @@ spec:
         --allow=tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767 \
         --target-tags=$INSTANCE_TAG
 
-      printf $UNIQUE_NAME > /tekton/results/cluster-name
+      printf $UNIQUE_NAME > $(results.cluster-name.path)

--- a/task/jib-gradle/0.2/jib-gradle.yaml
+++ b/task/jib-gradle/0.2/jib-gradle.yaml
@@ -97,7 +97,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)
-    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/image-digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/image-digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: empty-dir-volume

--- a/task/jib-gradle/0.3/jib-gradle.yaml
+++ b/task/jib-gradle/0.3/jib-gradle.yaml
@@ -101,7 +101,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.BUILDER_IMAGE)
-    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/image-digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/image-digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: empty-dir-volume

--- a/task/jib-maven/0.2/jib-maven.yaml
+++ b/task/jib-maven/0.2/jib-maven.yaml
@@ -67,7 +67,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.MAVEN_IMAGE)
-    script: cat $(workspaces.source.path)/target/jib-image.digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/target/jib-image.digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: empty-dir-volume

--- a/task/jib-maven/0.3/jib-maven.yaml
+++ b/task/jib-maven/0.3/jib-maven.yaml
@@ -77,7 +77,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.MAVEN_IMAGE)
-    script: cat $(workspaces.source.path)/target/jib-image.digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/target/jib-image.digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: empty-dir-volume

--- a/task/jib-maven/0.4/jib-maven.yaml
+++ b/task/jib-maven/0.4/jib-maven.yaml
@@ -77,7 +77,7 @@ spec:
 
   - name: digest-to-results
     image: $(params.MAVEN_IMAGE)
-    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/target/jib-image.digest | tee /tekton/results/IMAGE_DIGEST
+    script: cat $(workspaces.source.path)/$(params.DIRECTORY)/target/jib-image.digest | tee $(results.IMAGE_DIGEST.path)
 
   volumes:
   - name: empty-dir-volume

--- a/task/kaniko/0.1/kaniko.yaml
+++ b/task/kaniko/0.1/kaniko.yaml
@@ -73,4 +73,4 @@ spec:
     workingDir: $(workspaces.source.path)
     image: docker.io/stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09
     script: |
-      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE-DIGEST
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee $(results.IMAGE-DIGEST.path)

--- a/task/kaniko/0.2/kaniko.yaml
+++ b/task/kaniko/0.2/kaniko.yaml
@@ -72,4 +72,4 @@ spec:
     workingDir: $(workspaces.source.path)
     image: docker.io/stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09
     script: |
-      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE-DIGEST
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee $(results.IMAGE-DIGEST.path)

--- a/task/kaniko/0.3/kaniko.yaml
+++ b/task/kaniko/0.3/kaniko.yaml
@@ -72,4 +72,4 @@ spec:
     workingDir: $(workspaces.source.path)
     image: docker.io/stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09
     script: |
-      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE-DIGEST
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee $(results.IMAGE-DIGEST.path)

--- a/task/kaniko/0.4/kaniko.yaml
+++ b/task/kaniko/0.4/kaniko.yaml
@@ -77,4 +77,4 @@ spec:
     workingDir: $(workspaces.source.path)
     image: $(params.JQ_IMAGE)
     script: |
-      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee /tekton/results/IMAGE-DIGEST
+      cat $(params.CONTEXT)/image-digested | jq '.[0].value' -rj | tee $(results.IMAGE-DIGEST.path)

--- a/task/kaniko/0.5/kaniko.yaml
+++ b/task/kaniko/0.5/kaniko.yaml
@@ -54,7 +54,7 @@ spec:
     - --dockerfile=$(params.DOCKERFILE)
     - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
     - --destination=$(params.IMAGE)
-    - --digest-file=/tekton/results/IMAGE-DIGEST
+    - --digest-file=$(results.IMAGE-DIGEST.path)
     # kaniko assumes it is running as root, which means this example fails on platforms
     # that default to run containers as random uid (like OpenShift). Adding this securityContext
     # makes it explicit that it needs to run as root.

--- a/task/pull-request/0.1/samples/static.yaml
+++ b/task/pull-request/0.1/samples/static.yaml
@@ -16,7 +16,7 @@ spec:
       set -xe
 
       NUM=$(ls $(workspaces.pr.path)/comments | wc -l )
-      echo -n $NUM > /tekton/results/count
+      echo -n $NUM > $(results.count.path)
 ---
 # TODO(pipeline#1986) Once we have some kind of "auto workspace mode" we can avoid
 # having to manually create a PVC and manually clear it repeatedly

--- a/task/s2i/0.2/s2i.yaml
+++ b/task/s2i/0.2/s2i.yaml
@@ -82,7 +82,7 @@ spec:
           name: varlibcontainers
     - name: digest-to-results
       image: $(params.BUILDER_IMAGE)
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+      script: cat $(workspaces.source.path)/image-digest | tee $(results.IMAGE_DIGEST.path)
   volumes:
     - emptyDir: {}
       name: varlibcontainers

--- a/task/s2i/0.3/s2i.yaml
+++ b/task/s2i/0.3/s2i.yaml
@@ -71,7 +71,7 @@ spec:
         [[ "$(workspaces.dockerconfig.bound)" == "true" ]] && export DOCKER_CONFIG="$(workspaces.dockerconfig.path)"
         buildah ${CERT_DIR_FLAG} push --tls-verify=$(params.TLSVERIFY) --digestfile $(workspaces.source.path)/image-digest \
           $(params.IMAGE) docker://$(params.IMAGE)
-        cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+        cat $(workspaces.source.path)/image-digest | tee $(results.IMAGE_DIGEST.path)
       volumeMounts:
       - name: varlibcontainers
         mountPath: /var/lib/containers


### PR DESCRIPTION
Some tasks were referencing absolute paths for `results`. It is recommended to use variable replacement syntax in the API spec. This PR migrates the absolute paths for results to variable syntax notation. This PR addresses Issue https://github.com/tektoncd/catalog/issues/1163.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
/kind cleanup