### PR TITLE
feat: add Camel K run task

### DIFF
--- a/task/kamel-run/0.1/README.md
+++ b/task/kamel-run/0.1/README.md
@@ -1,0 +1,52 @@
+# Kamel run
+
+This Task creates and run a [Camel K](https://github.com/apache/camel-k) Integration.
+
+If you have installed Camel K operator, you can configure the `kamel-run` task the step to create the Integration that will be operated by Camel K. You can configure the parameter to delegate the build of your application to Camel K or do it as a part of previous pipelines steps.
+
+## Install the Task
+
+```shell
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kamel-run/0.1/raw
+```
+
+## Parameters
+
+- **camel-k-image**: The name of the image containing the Kamel CLI (_default:_ docker.io/apache/camel-k:1.12.0).
+- **filename**: the file containing the Integration source.
+- **namespace**: the namespace where to run the Integration (_default:_ the task execution namespace).
+- **container-image**: the container image to use for this Integration. Useful when you want to build your own container for the Integration (_default:_ empty, will trigger an Integration build).
+- **wait**: wait for the Integration to run before finishing the task. Useful when you want to get the **integration-phase** result (_default:_ "false").
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the Integration source to run.
+
+## Results
+
+- **integration-name**: the Integration name which was created/updated.
+- **integration-phase**: the status of the Integration, tipycally used with **wait: true** input parameter.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+The Task can be used in several ways to accomodate the different build and deployment strategy you may have.
+
+### Create the Service Account
+
+As we will do delegate the task, the creation of an Integration, we need to provide a `ServiceAccount` with the privileges required by the tasks:
+
+```shell
+kubectl apply -f  https://raw.githubusercontent.com/tektoncd/catalog/main/task/kamel-run/0.1/support/camel-k-tekton.yaml
+```
+
+### Delegate build to operator
+
+Use the [Tekton Camel K operator builder sample](../0.1/samples/run-operator-build.yaml) in order to fetch a Git repository and run a Camel K Integration delegating the build to the Camel K operator.
+
+### Full pipeline with custom build
+
+Use the [Tekton Camel K external builder sample](../0.1/samples/run-external-build.yaml) as a reference for a full pipeline where you define your own process of building the Camel application and using the `kamel-run` Task as last step in order to deploy the Integration and let Camel K operator managing it.

--- a/task/kamel-run/0.1/kamel-run.yaml
+++ b/task/kamel-run/0.1/kamel-run.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: kamel-run
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Deployment
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: cli
+    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/displayName: "kamel run"
+spec:
+  description: >-
+    Run a Camel Integration
+
+    Kamel-run task creates a Camel K Integration which will be taken and operated by Camel K operator. You can either use this task to
+    run a build from source or build the application in previous tasks and use this last task to deploy and let Camel K operates it.
+  params:
+    - name: camel-k-image
+      description: The location of Camel K CLI image.
+      default: docker.io/apache/camel-k:2.0.0
+    - name: filename
+      description: the Integration source we want to run
+    - name: namespace
+      description: the namespace where to run the integration
+      default: ""
+    - name: container-image
+      description: the custom container image to use (if the build was performed as part of previous tasks)
+      default: ""
+    - name: wait
+      description: wait for the Integration to run before exiting the task
+      default: "false"
+  results:
+    - name: integration-name
+      description: The name of the integration created
+    - name: integration-phase
+      description: The phase of the integration created (when used with input `wait` parameter)
+  workspaces:
+  - name: source
+  steps:
+  - name: execute
+    image: $(params.camel-k-image)
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/usr/bin/env bash
+
+      KAMEL_RUN_ARGS="$(params.filename)"
+      [[ ! "$(params.namespace)" == "" ]] && KAMEL_RUN_ARGS="$KAMEL_RUN_ARGS -n $(params.namespace)"
+      [[ ! "$(params.container-image)" == "" ]] && KAMEL_RUN_ARGS="$KAMEL_RUN_ARGS -t container.image=$(params.container-image)"
+      [[ "$(params.wait)" == "true" ]] && KAMEL_RUN_ARGS="$KAMEL_RUN_ARGS --wait"
+      kamel_output=$(kamel run "$KAMEL_RUN_ARGS")
+      echo "$kamel_output"
+      # Let's use the output produced to scrape the integration name and phase
+      echo "$kamel_output" | grep -oP 'Integration ".*?" (updated|created|unchanged)' | awk -F ' ' '{print $2}' | sed "s/\"//g" | tr -d '\n' | tee "$(results.integration-name.path)"
+      kamel get "$(cat "$(results.integration-name.path)")" 2>/dev/null | tail -n +2 | awk -F ' ' '{print $2}' | tee "$(results.integration-phase.path)"

--- a/task/kamel-run/0.1/samples/run-external-build.yaml
+++ b/task/kamel-run/0.1/samples/run-external-build.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: external-build
+spec:
+  workspaces:
+  - name: shared-workspace
+  - name: maven-settings
+  tasks:
+  # Fetch git repo
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/apache/camel-k-runtime
+  # Build the application
+  - name: maven-build
+    taskRef:
+      name: maven
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    - name: maven-settings
+      workspace: maven-settings
+    params:
+    - name: CONTEXT_DIR
+      value: "examples/yaml"
+    - name: GOALS
+      value:
+        - clean
+        - package
+  # Create the dockerfile (could be already in the git project, in such case, just skip this task)
+  - name: create-dockerfile
+    runAfter:
+    - maven-build
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    taskSpec:
+      steps:
+      - name: bash
+        image: ubuntu
+        script: |
+          echo "FROM docker.io/eclipse-temurin:17-jdk" > $(workspaces.source.path)/examples/yaml/Dockerfile
+          echo "COPY target/quarkus-app/ /deployments/dependencies/" >> $(workspaces.source.path)/examples/yaml/Dockerfile
+  # Build and push the container with the Camel application
+  - name: docker-build
+    taskRef:
+      name: buildah
+    runAfter:
+    - create-dockerfile
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: IMAGE
+      # Provide your container registry configuration accordingly!
+      value: 10.110.149.72/camel-k/my-camel-image
+    - name: TLSVERIFY
+      value: "false"
+    - name: CONTEXT
+      value: $(workspaces.source.path)/examples/yaml
+  # Run the Camel Integration, using the container image built previously
+  - name: kamel-run
+    taskRef:
+      name: kamel-run
+    runAfter:
+    - docker-build
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: filename
+      value: examples/yaml/data/routes.yaml
+    - name: container-image
+      value: $(tasks.docker-build.results.IMAGE_URL)
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: external-build-run
+spec:
+  pipelineRef:
+    name: external-build
+  taskRunSpecs:
+    - pipelineTaskName: kamel-run
+      taskServiceAccountName: camel-k-tekton
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  - name: maven-settings
+    emptyDir: {}

--- a/task/kamel-run/0.1/samples/run-operator-build.yaml
+++ b/task/kamel-run/0.1/samples/run-operator-build.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: operator-build
+spec:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/apache/camel-k-examples/
+  - name: kamel-run
+    taskRef:
+      name: kamel-run
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: filename
+      value: generic-examples/languages/routes.yaml
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: operator-build-run
+spec:
+  pipelineRef:
+    name: operator-build
+  taskRunSpecs:
+    - pipelineTaskName: kamel-run
+      taskServiceAccountName: camel-k-tekton
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/task/kamel-run/0.1/support/camel-k-tekton.yaml
+++ b/task/kamel-run/0.1/support/camel-k-tekton.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camel-k-tekton
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-integrations
+rules:
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - integrations
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - camelcatalogs
+  verbs:
+  - list
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-tekton-integrations
+subjects:
+- kind: ServiceAccount
+  name: camel-k-tekton
+roleRef:
+  kind: Role
+  name: camel-k-integrations
+  apiGroup: rbac.authorization.k8s.io

--- a/task/kamel-run/0.1/tests/pre-apply-task-hook.sh
+++ b/task/kamel-run/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+add_sidecar_registry ${TMPF}
+
+# Install Camel K operator
+wget https://github.com/apache/camel-k/releases/download/v2.0.0/camel-k-client-2.0.0-linux-amd64.tar.gz
+tar -xvf camel-k-client-2.0.0-linux-amd64.tar.gz
+./kamel install --registry localhost:5000 --registry-insecure --wait
+
+# Add git-clone
+add_task git-clone 0.7

--- a/task/kamel-run/0.1/tests/resources.yaml
+++ b/task/kamel-run/0.1/tests/resources.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camel-k-tekton
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-integrations
+rules:
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - integrations
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - camelcatalogs
+  verbs:
+  - list
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: camel-k-tekton-integrations
+subjects:
+- kind: ServiceAccount
+  name: camel-k-tekton
+roleRef:
+  kind: Role
+  name: camel-k-integrations
+  apiGroup: rbac.authorization.k8s.io

--- a/task/kamel-run/0.1/tests/run.yaml
+++ b/task/kamel-run/0.1/tests/run.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kamel-run-test
+spec:
+  workspaces:
+  - name: shared-workspace
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/apache/camel-k-examples/
+  - name: kamel-run
+    taskRef:
+      name: kamel-run
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: filename
+      value: generic-examples/languages/routes.yaml
+    - name: wait
+      value: "true"
+  - name: verify-it-phase
+    runAfter:
+    - kamel-run
+    params:
+    - name: it-name
+      value: $(tasks.kamel-run.results.integration-name)
+    - name: it-phase
+      value: $(tasks.kamel-run.results.integration-phase)
+    taskSpec:
+      params:
+      - name: it-name
+      - name: it-phase
+      steps:
+      - name: bash
+        image: ubuntu
+        script: |
+          if [[ ! $(params.it-name) == "sample"]]; then
+            echo "Expected integration name sample (was $(params.it-name))"
+            exit 1
+          fi
+          if [[ ! $(params.it-phase) == "running"]]; then
+            echo "Expected integration phase running (was $(params.it-phase))"
+            exit 1
+          fi
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: kamel-run-test-run
+spec:
+  pipelineRef:
+    name: kamel-run-test
+  taskRunSpecs:
+    - pipelineTaskName: kamel-run
+      taskServiceAccountName: camel-k-tekton
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/task/kamel-run/OWNERS
+++ b/task/kamel-run/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- squakez
+reviewers:
+- squakez


### PR DESCRIPTION
Closes https://github.com/apache/camel-k/issues/3795
Closes https://github.com/apache/camel-k/issues/682

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

With this PR we are introducing the first version of `kamel-run` task which will allow [Camel K](https://github.com/apache/camel-k) users to integration Tekton pipelines when building and deploying Camel application in their CICD pipelines. The task is based on the same container image used by the Camel K operator, which contains the `kamel` CLI. The task is opinionated to let the user use the CLI as a deployment task only in a generic pipeline used to build Camel applications on K8S.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
