### PR TITLE
Use CHECKOUT_DIR for git-clone safe.directory

### DIFF
--- a/task/git-clone/0.9/git-clone.yaml
+++ b/task/git-clone/0.9/git-clone.yaml
@@ -220,7 +220,7 @@ spec:
         test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
         test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
-        git config --global --add safe.directory "${WORKSPACE_OUTPUT_PATH}"
+        git config --global --add safe.directory "${CHECKOUT_DIR}"
         /ko-app/git-init \
           -url="${PARAM_URL}" \
           -revision="${PARAM_REVISION}" \


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

git safe.directory should be the directory where "git clone" places. Currently, it have not consider subdirectory.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
