### PR TITLE
Fixing maven/0.3 test fail due to more that one PVC is bound

### DIFF
--- a/task/maven/0.3/maven.yaml
+++ b/task/maven/0.3/maven.yaml
@@ -20,9 +20,6 @@ spec:
       description: >-
         The workspace consisting of the custom maven settings
         provided by the user.
-    - name: maven-local-repo
-      description: Local repo (m2) workspace
-      optional: true
   params:
     - name: MAVEN_IMAGE
       type: string
@@ -151,4 +148,4 @@ spec:
         - -s
         - $(workspaces.maven-settings.path)/settings.xml
         - "$(params.GOALS)"
-        - '-Dmaven.repo.local=$(workspaces.maven-local-repo.path)/.m2'
+        - '-Dmaven.repo.local=$(workspaces.maven-settings.path)/.m2'

--- a/task/maven/0.3/tests/resources.yaml
+++ b/task/maven/0.3/tests/resources.yaml
@@ -8,15 +8,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Mi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: maven-local-m2-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
       storage: 3Gi

--- a/task/maven/0.3/tests/run.yaml
+++ b/task/maven/0.3/tests/run.yaml
@@ -7,7 +7,6 @@ spec:
   workspaces:
     - name: shared-workspace
     - name: maven-settings
-    - name: maven-local-m2
   tasks:
     - name: fetch-repository
       taskRef:
@@ -40,8 +39,6 @@ spec:
           workspace: maven-settings
         - name: source
           workspace: shared-workspace
-        - name: maven-local-repo
-          workspace: maven-local-m2
     - name: maven-run-build-2
       taskRef:
         name: maven
@@ -60,8 +57,6 @@ spec:
           workspace: maven-settings
         - name: source
           workspace: shared-workspace
-        - name: maven-local-repo
-          workspace: maven-local-m2
 ---
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
@@ -76,6 +71,3 @@ spec:
     - name: shared-workspace
       persistentvolumeclaim:
         claimName: maven-source-pvc
-    - name: maven-local-m2
-      persistentvolumeclaim:
-        claimName: maven-local-m2-pvc


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

An extra PVC resource has been added in the workspace of new test cases maven/0.3. It's Taskrun is failing due to more than one PVC with message: "**more than one PersistentVolumeClaim is bound**"
We found that this is a known issue and found few Pipelines issue links with this discussion: [Issue#3480](https://github.com/tektoncd/pipeline/issues/3480), [Issue#3085](https://github.com/tektoncd/pipeline/issues/3085), [Issue#2979](https://github.com/tektoncd/pipeline/issues/2979)
/kind bug
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
