### PR TITLE
Fix skopeo image reference

### DIFF
--- a/task/skopeo-copy/0.1/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.1/skopeo-copy.yaml
@@ -41,7 +41,7 @@ spec:
       default: "true"
   steps:
     - name: skopeo-copy
-      image: quay.io/skopeo/stable:v1.3.0
+      image: quay.io/skopeo/stable:v1
       script: |
         # Function to copy multiple images.
         #

--- a/task/skopeo-copy/0.2/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.2/skopeo-copy.yaml
@@ -44,7 +44,7 @@ spec:
       env:
       - name: HOME
         value: /tekton/home
-      image: quay.io/skopeo/stable:v1.9.0
+      image: quay.io/skopeo/stable:v1
       script: |
         # Function to copy multiple images.
         #

--- a/task/skopeo-copy/0.3/skopeo-copy.yaml
+++ b/task/skopeo-copy/0.3/skopeo-copy.yaml
@@ -44,7 +44,7 @@ spec:
       env:
       - name: HOME
         value: /tekton/home
-      image: quay.io/skopeo/stable:v1.9.0
+      image: quay.io/skopeo/stable:v1
       script: |
         # Function to copy multiple images.
         #


### PR DESCRIPTION


# Changes

The previous tag, quay.io/skopeo/stable:v1.9.0, no longer exists. This commit updates the image reference to use the `v1` floating tag.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
