### PR TITLE
fix: Add "Content-Type" header

### DIFF
--- a/task/github-open-pr/0.2/github-open-pr.yaml
+++ b/task/github-open-pr/0.2/github-open-pr.yaml
@@ -107,9 +107,10 @@ spec:
         import sys
         import http.client
 
-        github_token = open("/etc/github-open-pr/$(params.GITHUB_TOKEN_SECRET_KEY)", "r").read()
+        with open("/etc/github-open-pr/$(params.GITHUB_TOKEN_SECRET_KEY)", "r", encoding="utf-8") as file:
+            github_token = file.read()
 
-        open_pr_url = "$(params.API_PATH_PREFIX)" + "/repos/$(params.REPO_FULL_NAME)/pulls"
+        open_pr_url = "$(params.API_PATH_PREFIX)/repos/$(params.REPO_FULL_NAME)/pulls"
 
         data = {
             "head": "$(params.HEAD)",
@@ -120,7 +121,7 @@ spec:
         print("Sending this data to GitHub: ")
         print(data)
 
-        authHeader = "$(params.AUTH_TYPE) " + github_token
+        authHeader = f"$(params.AUTH_TYPE) {github_token}"
 
         # This is for our fake github server
         if "$(params.GITHUB_HOST_URL)".startswith("http://"):
@@ -137,18 +138,22 @@ spec:
                 "User-Agent": "TektonCD, the peaceful cat",
                 "Authorization": authHeader,
                 "Accept": "application/vnd.github.v3+json ",
+                "Content-Type": "application/vnd.github.v3+json",
             })
         resp = conn.getresponse()
         if not str(resp.status).startswith("2"):
-            print("Error: %d" % (resp.status))
+            print(f"Error: {resp.status}")
             print(resp.read())
             sys.exit(1)
         else:
             # https://docs.github.com/en/rest/reference/pulls#create-a-pull-request
             body = json.loads(resp.read().decode())
 
-            open(os.environ.get('PULLREQUEST_NUMBER_PATH'), 'w').write(f'{body["number"]}')
-            open(os.environ.get('PULLREQUEST_URL_PATH'), 'w').write(body["html_url"])
+            with open(os.environ.get('PULLREQUEST_NUMBER_PATH'), 'w', encoding="utf-8") as f:
+                f.write(f'{body["number"]}')
+
+            with open(os.environ.get('PULLREQUEST_URL_PATH'), 'w', encoding="utf-8") as f:
+                f.write(body["html_url"])
 
             print("GitHub pull request created for $(params.REPO_FULL_NAME): "
                   f'number={body["number"]} url={body["html_url"]}')


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The `github-open-pr` task was missing a `"Content-Type"` header so I added it. Believe it or not, this single missing header makes the task not work for my use case so I need this to be merged 😭.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
