### PR TITLE
feat: introduce new task redhat-dependency-analytics for RHDA v0.7.0-alpha

### DIFF
--- a/task/redhat-dependency-analytics/0.1/README.md
+++ b/task/redhat-dependency-analytics/0.1/README.md
@@ -1,0 +1,166 @@
+# `Red Hat Dependency Analytics`
+
+**Please Note: this Task is only compatible with Tekton Pipelines versions 0.37.5 and greater!**
+
+## Overview
+The redhat-dependency-analytics task is an interface between Tekton and Red Hat Dependency Analytics (RHDA) platform version `0.7.0-alpha`. 
+It provides vulnerability and compliance analysis for your applications dependencies in your software supply chain.
+
+The redhat-dependency-analytics task for Tekton Pipelines utilizes the [Exhort JavaScript API](https://github.com/RHEcosystemAppEng/exhort-javascript-api), mirroring the functionality of the [VSCode Red Hat Dependency Analytics plugin](https://marketplace.visualstudio.com/items?itemName=redhat.fabric8-analytics).
+
+**Note: Currently this Task only supports Maven and NPM ecosystems, support for other ecosystems will be provided very soon.**
+
+## Prerequisite
+
+Prior to executing the redhat-dependency-analytics task, ensure that you have set up the two necessary components.
+
+### 1. Workspace
+Workspace is used as a common filesystem between tasks. It provides a designated area for the input, output, and intermediate files used during the execution of the pipeline by the redhat-dependency-analytics task.
+
+This [sample](samples/workspace.yaml) file can be referred to in order to create a workspace.
+
+The following command can be used to create a workspace from the sample file.
+
+```
+kubectl apply -f samples/workspace.yaml -n <NAMESPACE>
+```
+
+### 2. Secret
+The redhat-dependency-analytics task uses the `EXHORT_SNYK_TOKEN` token to authenticate with Snyk (vulnerability data provider).
+This Token must be saved in a secret by the name of `exhort`.<br />
+To generate a new Snyk token please visit the following [link](https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9).
+
+This [sample](samples/secret.yaml) file can be referred to in order to create a secret, replace `{{ EXHORT_SNYK_TOKEN }}` with the generated Snyk token before running.
+
+The following command can be used to create a secret from the sample file.
+
+```
+kubectl apply -f samples/secret.yaml -n <NAMESPACE>
+```
+
+## Parameters
+- **manifest-file-path**: Path to target manifest file (ex. pom.xml, package.json etc.) within the project directory to perform analysis upon.
+- **project-directory-path**: Path to directory within workspace where all project files are located or where project has been cloned to. `(default: project-package)`
+- **output-file-path**: Path to file within workspace where the Red Hat Dependency Analytics report will be saved. `(default: redhat-dependency-analytics-report.json)`
+- **image**: Image where Exhort Javascript API and required dependencies are installed. `(default: quay.io/ecosystem-appeng/exhort-javascript-api:0.7.0-alpha)`. 
+<br />
+List of images for different ecosystem versions can be found [here](https://github.com/RHEcosystemAppEng/exhort-javascript-api/tree/main/docker-image)
+
+## Output
+The complete response of Red Hat Dependency Analytics is saved in JSON format within the workspace directory under file name defined by parameter `output-file-name`. <br />
+This response provides both a summary and a comprehensive report detailing all discovered vulnerabilities. <br />
+The provided response may be used by a subsequent task for decision making, such as Passing or Failing a build.  
+
+In the logs, a simplified report summary will be displayed, example:
+```
+Red Hat Dependency Analytics task is being executed.
+==================================================
+Red Hat Dependency Analytics Report
+==================================================
+Total Scanned Dependencies            :  10 
+Total Scanned Transitive Dependencies :  218 
+Total Vulnerabilities                 :  22 
+Direct Vulnerable Dependencies        :  5 
+Snyk Provider Status                  :  OK 
+Critical Vulnerabilities              :  1 
+High Vulnerabilities                  :  3 
+Medium Vulnerabilities                :  12 
+Low Vulnerabilities                   :  6 
+==================================================
+Full report is saved into file: redhat-dependency-analytics-report.json
+Task is completed.
+```
+
+## Installation
+
+### Install task on environment using kubectl
+```
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/redhat-dependency-analytics/0.1/redhat-dependency-analytics.yaml -n <NAMESPACE>
+```
+
+### Install task on environment using tkn
+```
+tkn hub install task redhat-dependency-analytics -n <NAMESPACE>
+```
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+You can apply the specified task to resources such as TaskRun, Pipeline, and PipelineRun using the following configuration:
+
+```
+...
+...
+- name: redhat-dependency-analytics
+  taskRef:
+    name: redhat-dependency-analytics
+  workspaces:
+    - name: output
+      workspace: output
+  params:
+    - name: manifest-file-path
+      value: /path/to/manifest/file/in/project/directory
+    - name: project-directory-path
+      value: /path/to/project/directory/in/workspace
+    - name: output-file-path
+      value: /path/to/output/file/in/workspace
+    - name: image
+      value: your-image-name:tag
+...
+...
+```
+
+## Demo
+
+An example PipelineRun and TaskRun are provided in the `samples` directory in order to demonstrate the usage of the redhat-dependency-analytics task. 
+
+### Deployment Instructions:
+
+1. Deploy a new workspace with [workspace.yaml](samples/workspace.yaml), run:
+    ```
+    kubectl apply -f samples/workspace.yaml -n <NAMESPACE>
+    ```
+
+1. In [secret.yaml](samples/secret.yaml), first replace `{{ EXHORT_SNYK_TOKEN }}` with a generated Snyk token, then create the secret, run:
+    ```
+    kubectl apply -f samples/secret.yaml -n <NAMESPACE>
+    ```
+    To generate a new Snyk token visit the following [link](https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9).
+
+1. Deploy the redhat-dependency-analytics task by utilizing the [redhat-dependency-analytics.yaml](redhat-dependency-analytics.yaml) configuration file. You can initiate it by using the following command:
+    ```
+    kubectl apply -f redhat-dependency-analytics.yaml -n <NAMESPACE>
+    ```
+    Alternatively, you can consult the [installation guidelines](#installation) for the task setup instructions.
+
+#### For PipelineRun Example:
+
+1. Deploy the [git-clone](https://hub.tekton.dev/tekton/task/git-clone) Tekton Task to your environment. Refer to the `git-clone` documentation for instructions on setting up the pipeline with the appropriate parameters to align with your GitHub repository.
+<br >**NOTE** that the sample pipeline has been pre-configured to facilitate the cloning of public repositories in a straightforward manner. In this setup, simply providing an HTTPS URL for a public repository is adequate to ensure the functionality of the pipeline.
+
+1. Deploy the pipeline with [pipeline.yaml](samples/pipeline.yaml), run:
+    ```
+    kubectl apply -f samples/pipeline.yaml -n <NAMESPACE>
+    ```
+
+1. In [pipeline-run.yaml](samples/pipeline-run.yaml), first replace `{{ GITHUB_URL }}` with the Github URL to the project repository where the target manifest file resides, next replace `{{ MANIFEST_FILE_PATH }}` with the path to the target manifest file within the project directory (e.g., "pom.xml" or "src/pom.xml"), finally create the pipelinerun, run:
+    ```
+    kubectl apply -f samples/pipeline-run.yaml -n <NAMESPACE>
+    ```
+
+#### For TaskRun Example:
+
+1. Within workspace, create a new project directory (update parameter `project-directory-path` if needed).
+
+1. Store the target manifest file into a desired location inside the project directory.
+
+1. In [task-run.yaml](samples/task-run.yaml), replace `{{ MANIFEST_FILE_PATH }}` with the path to the target manifest file within the project directory (e.g., "pom.xml" or "src/pom.xml"), then create the taskrun, run:
+    ```
+    kubectl apply -f samples/task-run.yaml -n <NAMESPACE>
+    ```
+
+<small>**NOTE:** The redhat-dependency-analytics task expects to have a secret by the name of `exhort` configured with the `EXHORT_SNYK_TOKEN` key, 
+as well as an attached workspace with the target manifest file stored within.</small>

--- a/task/redhat-dependency-analytics/0.1/redhat-dependency-analytics.yaml
+++ b/task/redhat-dependency-analytics/0.1/redhat-dependency-analytics.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+
+metadata:
+  name: redhat-dependency-analytics
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Security
+    tekton.dev/pipelines.minVersion: "0.37.5"
+    tekton.dev/tags: Security, Vulnenrability, CVE
+    tekton.dev/displayName: "Red Hat Dependency Analytics"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    The Red Hat Dependency Analytics task is an interface between Tekton and Red Hat Dependency Analytics (RHDA) platform.
+    It provides vulnerability and compliance analysis for application dependencies in your software supply chain.
+
+  workspaces:
+    - name: output
+      description: Volume backing this workspace is used for input/output of the task.
+
+  params:
+    - name: manifest-file-path
+      description: Path to target manifest file within the project directory.
+
+    - name: project-directory-path
+      description: Path to directory within workspace, where the project is installed.
+      default: project-package
+
+    - name: output-file-path
+      description: Path to file within workspace, where the analysis report is saved.
+      default: redhat-dependency-analytics-report.json
+
+    - name: image
+      description: Image where Exhort Javascript API and required dependencies are installed.
+      default: quay.io/ecosystem-appeng/exhort-javascript-api:0.7.0-alpha
+
+  steps:
+    - name: redhat-dependency-analytics
+      image: $(params.image)
+      workingDir: $(workspaces.output.path)
+      env:
+        - name: EXHORT_SNYK_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: exhort
+              key: EXHORT_SNYK_TOKEN
+      script: |
+        #!/bin/sh
+
+        project_directory="$(params.project-directory-path)"
+        manifest_file="$(params.manifest-file-path)"
+        output_file="$(params.output-file-path)"
+
+        if [ -n "$project_directory" ]; then
+          sh /exhort.sh "$project_directory/$manifest_file" "$output_file"
+        else
+          sh /exhort.sh "$manifest_file" "$output_file"
+        fi

--- a/task/redhat-dependency-analytics/0.1/samples/pipeline-run.yaml
+++ b/task/redhat-dependency-analytics/0.1/samples/pipeline-run.yaml
@@ -1,0 +1,27 @@
+# PipelineRun for starting pipeline.
+# Prior to running the pipeline, ensure that you have attached the Workspace, created the required Secret, and deployed the 'git-clone' task within your environment.
+# Refer to https://hub.tekton.dev/tekton/task/git-clone for guidance on implementing the 'git-clone' task.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: redhat-dependency-analytics-pipelinerun
+spec:
+  pipelineRef:
+    name: redhat-dependency-analytics-pipeline
+  workspaces:
+    # Volume backing this workspace is used for input/output of the task.
+    - name: output
+      persistentvolumeclaim:
+        claimName: output
+  params:
+    - name: github-url
+      value: {{GITHUB_URL}} # Replace with Github URL to project repository.
+    - name: manifest-file-path
+      value: {{MANIFEST_FILE_PATH}} # Replace with path to target manifest file within the project directory (e.g., "pom.xml" or "src/pom.xml")
+    - name: project-directory-path
+      value: project-package
+    - name: output-file-path
+      value: redhat-dependency-analytics-report.json
+    - name: image
+      value: quay.io/ecosystem-appeng/exhort-javascript-api:0.7.0-alpha # Replace with base image where Exhort Javascript API and required dependencies are installed.

--- a/task/redhat-dependency-analytics/0.1/samples/pipeline.yaml
+++ b/task/redhat-dependency-analytics/0.1/samples/pipeline.yaml
@@ -1,0 +1,48 @@
+# End to end pipeline.
+# Prior to running the pipeline, ensure that you have attached the Workspace, created the required Secret, and deployed the 'git-clone' task within your environment.
+# Refer to https://hub.tekton.dev/tekton/task/git-clone for guidance on implementing the 'git-clone' task.
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: redhat-dependency-analytics-pipeline
+spec:
+  workspaces:
+    - name: output
+  params:
+  - name: github-url
+  - name: manifest-file-path
+  - name: project-directory-path
+  - name: output-file-path
+  - name: image
+  tasks:
+    # git-clone-project task
+    - name: git-clone-project
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: output
+      params:
+        - name: url
+          value: $(params.github-url)
+        - name: subdirectory
+          value: $(params.project-directory-path)
+    # redhat-dependency-analytics task
+    - name: redhat-dependency-analytics
+      taskRef:
+        name: redhat-dependency-analytics
+      runAfter:
+        - git-clone-project
+      workspaces:
+        - name: output
+          workspace: output
+      params:
+        - name: manifest-file-path
+          value: $(params.manifest-file-path)
+        - name: project-directory-path
+          value: $(params.project-directory-path)
+        - name: output-file-path
+          value: $(params.output-file-path)
+        - name: image
+          value: $(params.image)

--- a/task/redhat-dependency-analytics/0.1/samples/secret.yaml
+++ b/task/redhat-dependency-analytics/0.1/samples/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: exhort
+type: Opaque
+stringData:
+  EXHORT_SNYK_TOKEN: {{EXHORT_SNYK_TOKEN}} # Replace with Snyk token generated from https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9.

--- a/task/redhat-dependency-analytics/0.1/samples/task-run.yaml
+++ b/task/redhat-dependency-analytics/0.1/samples/task-run.yaml
@@ -1,0 +1,24 @@
+# Stand alone redhat-dependency-analytics TaskRun.
+# Make sure that you have attached the Workspace containing the manifest file and created the required Secret within your environment.
+
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: redhat-dependency-analytics-taskrun
+spec:
+  taskRef:
+    name: redhat-dependency-analytics
+  workspaces:
+    # Volume backing this workspace is used for input/output of the task.
+    - name: output
+      persistentvolumeclaim:
+        claimName: output
+  params:
+    - name: manifest-file-path
+      value: {{MANIFEST_FILE_PATH}} # Replace with path to target manifest file within the project directory (e.g., "pom.xml" or "src/pom.xml")
+    - name: project-directory-path
+      value: project-package
+    - name: output-file-path
+      value: redhat-dependency-analytics-report.json
+    - name: image
+      value: quay.io/ecosystem-appeng/exhort-javascript-api:0.7.0-alpha # Replace with base image where Exhort Javascript API and required dependencies are installed.

--- a/task/redhat-dependency-analytics/0.1/samples/workspace.yaml
+++ b/task/redhat-dependency-analytics/0.1/samples/workspace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: output
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/task/redhat-dependency-analytics/0.1/tests/pre-apply-task-hook.sh
+++ b/task/redhat-dependency-analytics/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+add_task git-clone 0.7

--- a/task/redhat-dependency-analytics/0.1/tests/resources.yaml
+++ b/task/redhat-dependency-analytics/0.1/tests/resources.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: output
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: exhort
+type: Opaque
+stringData:
+  EXHORT_SNYK_TOKEN: 11111111-2222-3333-4444-555555555555

--- a/task/redhat-dependency-analytics/0.1/tests/run.yaml
+++ b/task/redhat-dependency-analytics/0.1/tests/run.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: redhat-dependency-analytics-pipeline
+spec:
+  workspaces:
+    - name: output
+  params:
+  - name: github-url
+  - name: manifest-file-path
+  - name: project-directory-path
+  - name: output-file-path
+  - name: image
+  tasks:
+    - name: git-clone-project
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: output
+      params:
+        - name: url
+          value: $(params.github-url)
+        - name: subdirectory
+          value: $(params.project-directory-path)
+    - name: redhat-dependency-analytics
+      taskRef:
+        name: redhat-dependency-analytics
+      runAfter:
+        - git-clone-project
+      workspaces:
+        - name: output
+          workspace: output
+      params:
+        - name: manifest-file-path
+          value: $(params.manifest-file-path)
+        - name: project-directory-path
+          value: $(params.project-directory-path)
+        - name: output-file-path
+          value: $(params.output-file-path)
+        - name: image
+          value: $(params.image)
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: redhat-dependency-analytics-pipelinerun
+spec:
+  pipelineRef:
+    name: redhat-dependency-analytics-pipeline
+  workspaces:
+    - name: output
+      persistentvolumeclaim:
+        claimName: output
+  params:
+    - name: github-url
+      value: https://github.com/githubtraining/example-maven.git
+    - name: manifest-file-path
+      value: pom.xml
+    - name: project-directory-path
+      value: project-package
+    - name: output-file-path
+      value: redhat-dependency-analytics-report.json
+    - name: image
+      value: quay.io/ecosystem-appeng/exhort-javascript-api:0.7.0-alpha


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This pull request marks a significant milestone in the Tekton Tasks evolution. We have undergone a comprehensive refactoring process and re-branded the project from "Red Hat Codeready Dependency Analysis" to "Red Hat Dependency Analytics". 
Within this update, we've introduced a fresh Tekton Task named "redhat-dependency-analytics", aligning with the Red Hat Dependency Analytics (RHDA) platform version `0.7.0-alpha`. One of the key highlights of this update is the integration of an image utilizing the Exhort JavaScript API.
In the current version of the Red Hat Dependency Analytics Tekton Task, language support is specifically tailored to Maven and NPM. Support for GoLang and Python will be resumed in future releases.
"Red Hat Codeready Dependency Analysis" tekton task is now considered obsolete, PR to deprecation: https://github.com/tektoncd/catalog/pull/1195

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
