### PR TITLE
Use kind on CI to run e2e tests

### DIFF
--- a/test/e2e-tests-kind-prow.env
+++ b/test/e2e-tests-kind-prow.env
@@ -1,0 +1,3 @@
+E2E_SKIP_CLUSTER_CREATION=true
+KO_DOCKER_REPO=registry.local:5000
+ARTIFACTS=/workspace/source/artifacts

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -30,7 +30,9 @@ trap clean EXIT
 [[ -z ${LOCAL_CI_RUN} ]] && {
 
     # Initialize cluster
-    initialize "$@"
+    if [ "${E2E_SKIP_CLUSTER_CREATION}" != "true" ]; then
+        initialize "$@"
+    fi
 
     # Install the latest Tekton CRDs.
     install_pipeline_crd


### PR DESCRIPTION
# Changes

With PR in plumbing https://github.com/tektoncd/plumbing/pull/1596, and the current changes, we should be able to use kind during e2e tests

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
