### PR TITLE
Add extra sync flags to argocd-task-sync-and-wait

### DIFF
--- a/task/argocd-task-sync-and-wait/0.3/README.md
+++ b/task/argocd-task-sync-and-wait/0.3/README.md
@@ -1,0 +1,77 @@
+# Argo CD
+
+This task syncs (deploys) an [Argo CD](https://argoproj.github.io/argo-cd/) application and waits for it to be healthy. To do so, it requires the address of the Argo CD server and some form of authentication - either a username/password or an authentication token.
+
+## Install the Task
+
+```
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/argocd-task-sync-and-wait/0.2/raw
+```
+
+## Parameters
+
+* **application-name:** Name of the application to sync
+
+* **revision:** The revision to sync to (_default:_ `HEAD`)
+
+* **flags:** Flags to append after commands, e.g. `--insecure` (_default:_ `--`)
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.
+
+## Usage
+
+This `Pipeline` implements the typical CD flow using GitOps, as explained [here](https://argoproj.github.io/argo-cd/user-guide/ci_automation/). It runs a sample `Task` that makes and pushes a change to a Git repository, after which it runs the Argo CD `Task` to sync an application based on that repository.
+
+The `ConfigMap` and `Secret` give an example of how to define the Argo CD server address and give credentials for logging in.
+
+```YAML
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-env-configmap
+data:
+  ARGOCD_SERVER: <Argo CD server address>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-env-secret
+data:
+  # choose one of username/password or auth token
+  ARGOCD_USERNAME: <username>
+  ARGOCD_PASSWORD: <password>
+  ARGOCD_AUTH_TOKEN: <token>
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: argocd-pipeline
+spec:
+  tasks:
+    - name: push-to-git
+      taskRef:
+        name: some-git-task # pushes to the Git repository used by the application in the next task
+    - name: sync-application
+      taskRef:
+        name: argocd-task-sync-and-wait
+      params:
+        - name: application-name
+          value: some-application
+        - name: flags
+          value: --insecure # needed in this example only because the Argo CD server is locally hosted
+```
+
+For the `Secret`, choose one of username/password or auth token for logging in. Either of the following are acceptable:
+
+```YAML
+data:
+  ARGOCD_USERNAME: <username>
+  ARGOCD_PASSWORD: <password>
+```
+
+```YAML
+data:
+  ARGOCD_AUTH_TOKEN: <token>
+```

--- a/task/argocd-task-sync-and-wait/0.3/README.md
+++ b/task/argocd-task-sync-and-wait/0.3/README.md
@@ -14,7 +14,9 @@ kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/argocd-task-
 
 * **revision:** The revision to sync to (_default:_ `HEAD`)
 
-* **flags:** Flags to append after commands, e.g. `--insecure` (_default:_ `--`)
+* **flags:** Common flags to append after commands for sync and wait, e.g. `--insecure`
+
+* **extra-sync-flags:** Sync flags to append after commands, e.g. `--prune --resouce apps:Deployment:test`
 
 ## Platforms
 
@@ -61,6 +63,8 @@ spec:
           value: some-application
         - name: flags
           value: --insecure # needed in this example only because the Argo CD server is locally hosted
+        - name: extra-sync-flags
+          value: --prune
 ```
 
 For the `Secret`, choose one of username/password or auth token for logging in. Either of the following are acceptable:

--- a/task/argocd-task-sync-and-wait/0.3/argocd-task-sync-and-wait.yaml
+++ b/task/argocd-task-sync-and-wait/0.3/argocd-task-sync-and-wait.yaml
@@ -1,0 +1,48 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: argocd-task-sync-and-wait
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Deployment
+    tekton.dev/tags: deploy
+    tekton.dev/displayName: "argocd"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This task syncs (deploys) an Argo CD application and waits for it to be healthy.
+
+    To do so, it requires the address of the Argo CD server and some form of
+    authentication either a username/password or an authentication token.
+
+  params:
+    - name: application-name
+      description: name of the application to sync
+      type: string
+    - name: revision
+      description: the revision to sync to
+      default: HEAD
+      type: string
+    - name: flags
+      default: --
+      type: string
+    - name: argocd-version
+      default: v2.2.2
+      type: string
+  stepTemplate:
+    envFrom:
+      - configMapRef:
+          name: argocd-env-configmap  # used for server address
+      - secretRef:
+          name: argocd-env-secret  # used for authentication (username/password or auth token)
+  steps:
+    - name: login
+      image: quay.io/argoproj/argocd:$(params.argocd-version)
+      script: |
+        if [ -z "$ARGOCD_AUTH_TOKEN" ]; then
+          yes | argocd login "$ARGOCD_SERVER" --username="$ARGOCD_USERNAME" --password="$ARGOCD_PASSWORD";
+        fi
+        argocd app sync "$(params.application-name)" --revision "$(params.revision)" "$(params.flags)"
+        argocd app wait "$(params.application-name)" --health "$(params.flags)"

--- a/task/argocd-task-sync-and-wait/0.3/argocd-task-sync-and-wait.yaml
+++ b/task/argocd-task-sync-and-wait/0.3/argocd-task-sync-and-wait.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: argocd-task-sync-and-wait
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Deployment
@@ -26,10 +26,15 @@ spec:
       default: HEAD
       type: string
     - name: flags
-      default: --
+      description: common flags for sync and wait
+      default: ""
+      type: string
+    - name: extra-sync-flags
+      description: flags for sync other than revision
+      default: ""
       type: string
     - name: argocd-version
-      default: v2.2.2
+      default: latest
       type: string
   stepTemplate:
     envFrom:
@@ -44,5 +49,5 @@ spec:
         if [ -z "$ARGOCD_AUTH_TOKEN" ]; then
           yes | argocd login "$ARGOCD_SERVER" --username="$ARGOCD_USERNAME" --password="$ARGOCD_PASSWORD";
         fi
-        argocd app sync "$(params.application-name)" --revision "$(params.revision)" "$(params.flags)"
-        argocd app wait "$(params.application-name)" --health "$(params.flags)"
+        argocd app sync "$(params.application-name)" --revision "$(params.revision)" $(params.flags) $(params.extra-sync-flags)
+        argocd app wait "$(params.application-name)" --health $(params.flags)


### PR DESCRIPTION
# Changes

There is a `flags` parameter, which is common to both sync and wait, and we cannot pass any specific options to sync. In practical Argo CD use cases, we might utilize `--prune` or `--resource`. 
Therefore, I added `extra-sync-flags` to allow specifying any optional arguments for sync.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
