### PR TITLE
Update default helm image for helm-upgrade-from- tasks

### DIFF
--- a/task/helm-upgrade-from-repo/0.3/README.md
+++ b/task/helm-upgrade-from-repo/0.3/README.md
@@ -1,0 +1,60 @@
+# Helm
+
+These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift Cluster using [Helm](https://github.com/helm/helm).
+
+## Install the Task
+
+#### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) volume containing the helm chart.
+
+### helm install / upgrade from repo
+
+```
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-repo/0.2/raw
+```
+
+#### Parameters
+
+- **chart_name**: The directory in the source repository where the installable chart should be found.
+- **release_version**: The version of the release (*default: v1.0.0*)
+- **release_name**: The name of the release (*default: helm-release*)
+- **release_namespace**: The namespace in which the release is to be installed (*default: ""*)
+- **overwrite_values**: The values to be overwritten (*default: ""*)
+- **helm_image**: The helm image which should be used (default: lachlanevenson/k8s-helm:v3.5.0)
+
+#### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+### PipelineRun
+
+An example `Pipeline` with a `PipelineRun` can be found in the subdirectory `tests`.
+
+### TaskRun
+
+This `TaskRun` runs the task to retrieve a Git repo and then installs/updates the helm chart that is in the Git repo.
+
+```yaml
+# example upgrade from repo
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-helm-upgrade-from-repo
+spec:
+  taskRef:
+    name: helm-upgrade-from-repo
+  params:
+  - name: helm_repo
+    value: https://kubernetes-charts.storage.googleapis.com
+  - name: chart_name
+    value: stable/envoy
+  - name: release_version
+    value: v1.0.0
+  - name: release_name
+    value: helm-repo-sample
+  - name: overwrite_values
+    value: autoscaling.enabled=true,autoscaling.maxReplicas=3
+```

--- a/task/helm-upgrade-from-repo/0.3/README.md
+++ b/task/helm-upgrade-from-repo/0.3/README.md
@@ -11,7 +11,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from repo
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-repo/0.2/raw
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-repo/0.3/raw
 ```
 
 #### Parameters

--- a/task/helm-upgrade-from-repo/0.3/helm-upgrade-from-repo.yaml
+++ b/task/helm-upgrade-from-repo/0.3/helm-upgrade-from-repo.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: helm-upgrade-from-repo
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.3"
   annotations:
     tekton.dev/categories: Deployment
     tekton.dev/pipelines.minVersion: "0.12.1"

--- a/task/helm-upgrade-from-repo/0.3/helm-upgrade-from-repo.yaml
+++ b/task/helm-upgrade-from-repo/0.3/helm-upgrade-from-repo.yaml
@@ -34,7 +34,7 @@ spec:
       default: ""
     - name: helm_image
       description: "Specify a specific helm image"
-      default: "docker.io/lachlanevenson/k8s-helm@sha256:5c792f29950b388de24e7448d378881f68b3df73a7b30769a6aa861061fd08ae" #tag: v3.6.0
+      default: "docker.io/lachlanevenson/k8s-helm@sha256:0a068ae407e21d1836c6a89a1e9e81af1e55fa56890998e33d5caabdbb51e77b" # tag: v3.10.2
   steps:
     - name: upgrade-from-repo
       image: $(params.helm_image)

--- a/task/helm-upgrade-from-repo/0.3/helm-upgrade-from-repo.yaml
+++ b/task/helm-upgrade-from-repo/0.3/helm-upgrade-from-repo.yaml
@@ -1,0 +1,51 @@
+# This Task will do a helm upgrade based on the given helm repo and chart
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: helm-upgrade-from-repo
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/categories: Deployment
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: helm
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    These tasks will install / upgrade a helm chart into your Kubernetes /
+    OpenShift Cluster using Helm
+
+  params:
+    - name: helm_repo
+      description: "Specify a specific helm repo"
+    - name: chart_name
+      description: "Specify chart name that will be deployed"
+    - name: release_version
+      description: The helm release version in semantic versioning format
+      default: "v1.0.0"
+    - name: release_name
+      description: The helm release name
+      default: "helm-release"
+    - name: release_namespace
+      description: The helm release namespace
+      default: ""
+    - name: overwrite_values
+      description: "Specify the values you want to overwrite, comma separated: autoscaling.enabled=true,replicas=1"
+      default: ""
+    - name: helm_image
+      description: "Specify a specific helm image"
+      default: "docker.io/lachlanevenson/k8s-helm@sha256:5c792f29950b388de24e7448d378881f68b3df73a7b30769a6aa861061fd08ae" #tag: v3.6.0
+  steps:
+    - name: upgrade-from-repo
+      image: $(params.helm_image)
+      script: |
+        echo current installed helm releases
+        helm list --namespace "$(params.release_namespace)"
+        echo parsing helms repo name...
+        REPO=`echo "$(params.chart_name)" | cut -d "/" -f 1`
+        echo adding helm repo...
+        helm repo add $REPO "$(params.helm_repo)"
+        echo adding updating repo...
+        helm repo update
+        echo installing helm chart...
+        helm upgrade --wait --install --namespace "$(params.release_namespace)" $(params.release_name) $(params.chart_name) --debug --set "$(params.overwrite_values)"

--- a/task/helm-upgrade-from-repo/0.3/samples/helm-upgrade-from-repo-task-run.yaml.tmpl
+++ b/task/helm-upgrade-from-repo/0.3/samples/helm-upgrade-from-repo-task-run.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-helm-upgrade-from-repo
+spec:
+  taskRef:
+    name: helm-upgrade-from-repo
+  params:
+  - name: helm_repo
+    value: https://charts.helm.sh/stable
+  - name: chart_name
+    value: stable/envoy
+  - name: release_version
+    value: v1.0.0
+  - name: release_name
+    value: helm-repo-sample
+  - name: overwrite_values
+    value: autoscaling.enabled=true,autoscaling.maxReplicas=3

--- a/task/helm-upgrade-from-repo/0.3/tests/pre-apply-task-hook.sh
+++ b/task/helm-upgrade-from-repo/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Add service account
+kubectl -n ${tns} create serviceaccount helm-pipeline-run-sa
+
+# Add edit role to service account
+kubectl -n ${tns} create rolebinding helm-pipeline-run-sa-edit --clusterrole edit --serviceaccount ${tns}:helm-pipeline-run-sa -o yaml --dry-run=client | kubectl apply -f -

--- a/task/helm-upgrade-from-repo/0.3/tests/run.yaml
+++ b/task/helm-upgrade-from-repo/0.3/tests/run.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: helm-upgrade-test-pipeline
+spec:
+  tasks:
+    - name: helm-upgrade-from-repo
+      taskRef:
+        name: helm-upgrade-from-repo
+      params:
+        - name: helm_repo
+          value: https://dunefro.github.io/sample-charts/
+        - name: chart_name
+          value: sample-charts/sample-nginx
+        - name: release_version
+          value: v1.0.0
+        - name: release_name
+          value: helm-repo-sample
+        - name: overwrite_values
+          value: autoscaling.enabled=false,autoscaling.maxReplicas=3
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: helm-upgrade-test-pipeline-run
+spec:
+  serviceAccountName: helm-pipeline-run-sa
+  pipelineRef:
+    name: helm-upgrade-test-pipeline

--- a/task/helm-upgrade-from-source/0.4/README.md
+++ b/task/helm-upgrade-from-source/0.4/README.md
@@ -1,0 +1,65 @@
+# Helm
+
+These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift Cluster using [Helm](https://github.com/helm/helm).
+
+## Install the Task
+
+### helm install / upgrade from source code
+
+```
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-source/0.3/raw
+```
+
+#### Parameters
+
+- **charts_dir**: The directory in the source repository where the installable chart should be found.
+- **release_version**: The version of the release (*default: v1.0.0*)
+- **release_name**: The name of the release (*default: helm-release*)
+- **release_namespace**: The namespace in which the release is to be installed (*default: ""*)
+- **overwrite_values**: The values to be overwritten (*default: ""*)
+- **values_file**: The values file to be used,
+    assumes the values file is in the same dir as your charts_dir (*default: "values.yaml"*)
+- **helm_image**: The helm image which should be used (*default: lachlanevenson/k8s-helm:v3.3.4*)
+- **upgrade_extra_params**: Extra parameters passed for the helm upgrade command (*default: ""*)
+
+#### Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the helm chart.
+
+#### Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+### PipelineRun
+
+An example `Pipeline` with a `PipelineRun` can be found in the subdirectory `tests`.
+
+### TaskRun
+
+This `TaskRun` runs the task to retrieve a Git repo and then installs/updates the helm chart that is in the Git repo.
+
+```yaml
+# example upgrade from source
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-helm-upgrade-from-source
+spec:
+  taskRef:
+    name: helm-upgrade-from-source
+  params:
+  - name: charts_dir
+    value: helm-sample-chart
+  - name: releases_version
+    value: v1.0.0
+  - name: release_name
+    value: helm-source-sample
+  - name: overwrite_values
+    value: "autoscaling.enabled=true,autoscaling.maxReplicas=3"
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```

--- a/task/helm-upgrade-from-source/0.4/helm-upgrade-from-source.yaml
+++ b/task/helm-upgrade-from-source/0.4/helm-upgrade-from-source.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: helm-upgrade-from-source
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/categories: Deployment
+    tekton.dev/tags: helm
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    These tasks will install / upgrade a helm chart into your Kubernetes /
+    OpenShift Cluster using Helm
+
+  params:
+    - name: charts_dir
+      description: The directory in source that contains the helm chart
+    - name: release_version
+      description: The helm release version in semantic versioning format
+      default: "v1.0.0"
+    - name: release_name
+      description: The helm release name
+      default: "helm-release"
+    - name: release_namespace
+      description: The helm release namespace
+      default: ""
+    - name: overwrite_values
+      description: "Specify the values you want to overwrite, comma separated: autoscaling.enabled=true,replicas=1"
+      default: ""
+    - name: values_file
+      description: "The values file to be used"
+      default: "values.yaml"
+    - name: helm_image
+      description: "helm image to be used"
+      default: "docker.io/lachlanevenson/k8s-helm@sha256:5c792f29950b388de24e7448d378881f68b3df73a7b30769a6aa861061fd08ae" #tag: v3.6.0
+    - name: upgrade_extra_params
+      description: "Extra parameters passed for the helm upgrade command"
+      default: ""
+  workspaces:
+    - name: source
+  steps:
+    - name: upgrade
+      image: $(params.helm_image)
+      workingDir: /workspace/source
+      script: |
+        echo current installed helm releases
+        helm list --namespace "$(params.release_namespace)"
+
+        echo installing helm chart...
+        helm upgrade --install --wait --values "$(params.charts_dir)/$(params.values_file)" --namespace "$(params.release_namespace)" --version "$(params.release_version)" "$(params.release_name)" "$(params.charts_dir)" --debug --set "$(params.overwrite_values)" $(params.upgrade_extra_params)

--- a/task/helm-upgrade-from-source/0.4/helm-upgrade-from-source.yaml
+++ b/task/helm-upgrade-from-source/0.4/helm-upgrade-from-source.yaml
@@ -34,7 +34,7 @@ spec:
       default: "values.yaml"
     - name: helm_image
       description: "helm image to be used"
-      default: "docker.io/lachlanevenson/k8s-helm@sha256:5c792f29950b388de24e7448d378881f68b3df73a7b30769a6aa861061fd08ae" #tag: v3.6.0
+      default: "docker.io/lachlanevenson/k8s-helm@sha256:0a068ae407e21d1836c6a89a1e9e81af1e55fa56890998e33d5caabdbb51e77b" # tag: v3.10.2
     - name: upgrade_extra_params
       description: "Extra parameters passed for the helm upgrade command"
       default: ""

--- a/task/helm-upgrade-from-source/0.4/helm-upgrade-from-source.yaml
+++ b/task/helm-upgrade-from-source/0.4/helm-upgrade-from-source.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: helm-upgrade-from-source
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Deployment

--- a/task/helm-upgrade-from-source/0.4/samples/helm-upgrade-from-source-task-run.yaml.tmpl
+++ b/task/helm-upgrade-from-source/0.4/samples/helm-upgrade-from-source-task-run.yaml.tmpl
@@ -1,0 +1,20 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: example-helm-upgrade-from-source
+spec:
+  taskRef:
+    name: helm-upgrade-from-source
+  params:
+    - name: charts_dir
+      value: helm-sample-chart
+    - name: releases_version
+      value: v1.0.0
+    - name: release_name
+      value: helm-source-sample
+    - name: overwrite_values
+      value: "autoscaling.enabled=true,autoscaling.maxReplicas=3"
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source

--- a/task/helm-upgrade-from-source/0.4/tests/pre-apply-task-hook.sh
+++ b/task/helm-upgrade-from-source/0.4/tests/pre-apply-task-hook.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Add git-clone
+add_task git-clone latest
+
+# Add service account
+kubectl -n ${tns} create serviceaccount helm-pipeline-run-sa
+
+# Add edit role to service account
+kubectl -n ${tns} create rolebinding helm-pipeline-run-sa-edit --clusterrole edit --serviceaccount ${tns}:helm-pipeline-run-sa -o yaml --dry-run=client | kubectl apply -f -

--- a/task/helm-upgrade-from-source/0.4/tests/resources.yaml
+++ b/task/helm-upgrade-from-source/0.4/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: helm-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Mi

--- a/task/helm-upgrade-from-source/0.4/tests/run.yaml
+++ b/task/helm-upgrade-from-source/0.4/tests/run.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: helm-upgrade-test-pipeline
+spec:
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+      params:
+        - name: url
+          value: https://github.com/helm/examples
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+    - name: helm-upgrade-from-source
+      taskRef:
+        name: helm-upgrade-from-source
+      runAfter:
+        - fetch-repository
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      params:
+        - name: charts_dir
+          value: charts/hello-world
+        - name: release_version
+          value: v1.0.0
+        - name: release_name
+          value: helm-source-sample
+        - name: overwrite_values
+          value: "autoscaling.enabled=true,autoscaling.maxReplicas=3"
+        - name: upgrade_extra_params
+          value: "--force"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: helm-upgrade-test-pipeline-run
+spec:
+  serviceAccountName: helm-pipeline-run-sa
+  pipelineRef:
+    name: helm-upgrade-test-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentvolumeclaim:
+        claimName: helm-source-pvc


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR updates the default image used in the `helm-upgrade-from-repo` and `helm-upgrade-from-source` tasks from [v3.6.0](https://hub.docker.com/layers/lachlanevenson/k8s-helm/v3.6.0/images/sha256-b3510a2fb35cad3631e245e416b5e8b1d03b0184e0d125a4797e055201852ba3?context=explore) to [v3.10.2](https://hub.docker.com/layers/lachlanevenson/k8s-helm/v3.10.2/images/sha256-4ea644ab5330f22864ca12bde02414360d371de9db25f0c177638fa81bc69908?context=explore).

The main motivation for this change is that the existing version does not include [the `--dependency-upgrade` option](https://github.com/helm/helm/pull/9659). This change therefore provides the ability for charts to _not_ package their dependencies.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
