### PR TITLE
Fix catalog test for ppc64le

### DIFF
--- a/task/gradle/0.4/tests/run.yaml
+++ b/task/gradle/0.4/tests/run.yaml
@@ -62,7 +62,7 @@ spec:
         - name: PROJECT_DIR
           value: "wrapper-test"
         - name: GRADLE_IMAGE
-          value: docker.io/library/eclipse-temurin:17-jdk-alpine@sha256:16d70818ae1d9dfca5e8d05de8e74a23c959ae59968010f013a4cfe5aa5b0038
+          value: docker.io/library/eclipse-temurin:17-ubi9-minimal@sha256:19c66566a0a802df5674301b223683ffbcf56cf18488a37a21d53e3d09df57d1
       workspaces:
         - name: source
           workspace: shared-workspace

--- a/test/linux-ppc64le.sh
+++ b/test/linux-ppc64le.sh
@@ -39,3 +39,14 @@ find task/gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipe
 
 echo "Add extra BUILDER_IMAGE parameter"
 find task/jib-gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "BUILDER_IMAGE","value": env(BUILDER_IMAGE)}' -i {}
+
+echo "Add extra MAVEN_IMAGE parameter for maven-0-3 test"
+yq eval '(..|select(.kind?=="Pipeline")|select(.metadata.name?=="jib-maven-test-pipeline"|"maven-test-pipeline")|.spec.tasks[2].params) |= . +{"name": "MAVEN_IMAGE","value": env(MAVEN_IMAGE)}' -i task/maven/0.3/tests/run.yaml
+
+echo "Patch to Enable Step Actions on the cluster"
+kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-step-actions":"true"}}'
+
+echo "Patch to Disable Affinity Assistant (Needed to allow binding of two PVCs for Maven-0-3 test)"
+kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"disable-affinity-assistant":"true"}}'
+
+


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Replaces the GRADLE_IMAGE parameter for gradle/0.4 to the multi-arch alternative. Currently the image is x86 only.

Added an Extra MAVEN_IMAGE parameter which is missing for the maven-0-3 test via linux-ppc64le.sh script.

Added a patch command to enable Step Actions on the cluster. This is needed for stepaction test.

Added a patch command to disable Affinity Assistant  on the cluster. This allow binding of two PVCs at the same time and is needed by the maven-0-3 test.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
