### PR TITLE
fix catalog test failures on s390x

### DIFF
--- a/test/linux-s390x.sh
+++ b/test/linux-s390x.sh
@@ -39,3 +39,9 @@ find task/gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipe
 
 echo "Add extra BUILDER_IMAGE parameter"
 find task/jib-gradle/*/tests/run.yaml | xargs -I{} yq eval '(..|select(.kind?=="Pipeline")|.spec.tasks[1].params) |= . +{"name": "BUILDER_IMAGE","value": env(BUILDER_IMAGE)}' -i {}
+
+echo "Add extra MAVEN_IMAGE parameter for maven-0-3 test"
+yq eval '(..|select(.kind?=="Pipeline")|select(.metadata.name?=="jib-maven-test-pipeline"|"maven-test-pipeline")|.spec.tasks[2].params) |= . +{"name": "MAVEN_IMAGE","value": env(MAVEN_IMAGE)}' -i task/maven/0.3/tests/run.yaml
+
+echo "Patch to Enable Step Actions,Disable Affinity Assistant  on the cluster"
+kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-step-actions":"true","disable-affinity-assistant":"true"}}'


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replaces the GRADLE_IMAGE parameter for gradle/0.4 to the multi-arch alternative. Currently the image is x86 only.

Added an Extra MAVEN_IMAGE parameter which is missing for the maven-0-3 test via linux-s390x.sh script.

Added a patch command to enable Step Actions on the cluster. This is needed for stepaction test.

Added a patch command to disable Affinity Assistant on the cluster. This allow binding of two PVCs at the same time and is needed by the maven-0-3 test.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
