### PR TITLE
New version of tekton catalog publish with labels

### DIFF
--- a/stepaction/tekton-catalog-publish/0.2/README.md
+++ b/stepaction/tekton-catalog-publish/0.2/README.md
@@ -1,0 +1,119 @@
+# Tekton Catalog Publish
+
+This stepaction publishes each Task/StepAction in a Tekton catalog as [Tekton Bundles](https://tekton.dev/docs/pipelines/pipelines/#tekton-bundles).
+The catalog must be structured as a [Tekton Catalog](https://github.com/tektoncd/catalog#catalog-structure).
+
+Bundles are published to `$REGISTRY/$PATH/<task/stepaction-name>:<task/stepaction-version>` and, when `TAG` is provided, to
+`$REGISTRY/$PATH/<task/stepaction-name>:$TAG`. An example of extra tag could be the git sha of the catalog repo that
+is being published. The task uses the `tkn bundle` command to publish and support for decoding `StepActions`, which is available
+in `tkn` starting with version `v0.34.0`.
+
+Bundles are published with two OCI labels by default:
+- `org.opencontainers.image.description`: The individual resource name, obtained from the containing folder name
+- `org.opencontainers.image.version`: The individual resource version, obtained from the containing folder name and `$(params.TAG)`, if provided
+
+## Install the StepAction
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/stepaction/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml 
+```
+
+## Parameters
+
+| name             | description                                                                    | default                               |
+| ---------------- | ------------------------------------------------------------------------------ | ------------------------------------- |
+| TKN_IMAGE        | `tkn` CLI container image to run this task.                                    | gcr.io/tekton-releases/dogfooding/tkn |
+| TKN_ARGS         | Extra command line arguments passed as last to the `tkn` CLI.                  | "--label org.opencontainers.image.source=github.com/tektoncd/catalog" |
+| REGISTRY         | The registry where bundles are published to                                    |                                       |
+| RESOURCE         | The type of resouce being published: task or stepaction                        | task                                  |
+| PATH             | The path in the registry                                                       | tekton/catalog/tasks                  |
+| TAG              | An optional extra tag (optional)                                               | ""                                    |
+| catalogPath      | The directory containing the catalog to be published                           |                                       |
+| dockerconfigPath | The directory providing `.docker/config.json`.                                 | no-path                               |                                      
+|                  | The file should be placed at the root of the Workspace with name `config.json` |                                       | 
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platforms.
+
+## Usage
+
+1. Passing `REGISTRY` and catalog workspace:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: tekton-catalog-publish-
+spec:
+  taskSpec:
+    workspaces:
+      - name: source
+    steps:
+    - name: publish
+      ref:
+        name: tekton-catalog-publish
+      params:
+        - name: catalogPath
+          value: $(workspaces.source.path)
+        - name: REGISTRY
+          value: $(params.REGISTRY)
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+     - name: REGISTRY
+       value: icr.io
+```
+
+2. Passing `REGISTRY`, `PATH`, `TAG`, `TKN_ARGS` and both workspaces
+
+   1. Sample secret can be found [here](https://github.com/tektoncd/catalog/tree/main/task/tekton-catalog-publish/0.1/samples/secrets.yaml)
+
+   2. Create `TaskRun`
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: tekton-catalog-publish-
+spec:
+  taskSpec:
+    workspaces:
+      - name: source
+      - name: dockerconfig
+    steps:
+    - name: publish
+      ref:
+        name: tekton-catalog-publish
+      params:
+        - name: catalogPath
+          value: $(workspaces.source.path)
+        - name: dockerconfigPath
+          value: $(workspaces.dockerconfig.path)
+        - name: REGISTRY
+          value: $(params.REGISTRY)
+        - name: PATH
+          value: $(params.PATH)
+        - name: TAG
+          value: $(params.TAG)
+        - name: TKN_ARGS
+          value: $(params.TKN_ARGS)
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+    - name: dockerconfig
+      secret:
+        secretName: regcred
+  params:
+    - name: REGISTRY
+      value: icr.io
+    - name: PATH
+      value: tekton/mycatalog/tasks
+    - name: TAG
+      value: 49456927aef7e81a48a972db2bfd6e19a64d9a77
+    - name: TKN_ARGS
+      value: "--label org.opencontainers.image.source=github.com/tektoncd/catalog"
+```

--- a/stepaction/tekton-catalog-publish/0.2/samples/run-with-workspace-secret.yaml
+++ b/stepaction/tekton-catalog-publish/0.2/samples/run-with-workspace-secret.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: tekton-catalog-publish-
+spec:
+  taskSpec:
+    workspaces:
+      - name: dockerconfig
+      - name: source
+    ref:
+      name: tekton-catalog-publish
+    params:
+      - name: catalogPath
+        value: $(workspaces.source.path)
+      - name: dockerconfigPath
+        value: $(workspaces.dockerconfig.path)
+      - name: REGISTRY
+        value: $(params.REGISTRY)
+      - name: PATH
+        value: $(params.PATH)
+      - name: TAG
+        value: $(params.TAG)
+      - name: TKN_ARGS
+        value: $(params.TKN_ARGS)
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+    - name: dockerconfig
+      secret:
+        secretName: regcred
+  params:
+    - name: REGISTRY
+      value: icr.io
+    - name: PATH
+      value: tekton/mycatalog/tasks
+    - name: TAG
+      value: 49456927aef7e81a48a972db2bfd6e19a64d9a77
+    - name: TKN_ARGS
+      value: "--label org.opencontainers.image.source=github.com/tektoncd/catalog"

--- a/stepaction/tekton-catalog-publish/0.2/samples/run-without-workspace-secret.yaml
+++ b/stepaction/tekton-catalog-publish/0.2/samples/run-without-workspace-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  generateName: tekton-catalog-publish-
+spec:
+  taskSpec:
+    workspaces:
+      - name: source
+    ref:
+      name: tekton-catalog-publish
+    params:
+      - name: catalogPath
+        value: $(workspaces.source.path)
+      - name: REGISTRY
+        value: $(params.REGISTRY)
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: my-source
+  params:
+    - name: REGISTRY
+      value: icr.io

--- a/stepaction/tekton-catalog-publish/0.2/samples/secrets.yaml
+++ b/stepaction/tekton-catalog-publish/0.2/samples/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+stringData:
+  config.json: |
+    {
+      "auths" : {
+        "icr.io" : {
+          "auth" : "iamapikey",
+          "identitytoken" : "test123test123"
+        },
+      }
+    }

--- a/stepaction/tekton-catalog-publish/0.2/tekton-catalog-publish.yaml
+++ b/stepaction/tekton-catalog-publish/0.2/tekton-catalog-publish.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: tekton-catalog-publish
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/categories: Publishing
+    tekton.dev/pipelines.minVersion: "0.54.0"
+    tekton.dev/cli.minVersion: "0.34.0"
+    tekton.dev/tags: catalog, bundles
+    tekton.dev/displayName: "Publish a Tekton Catalog"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  params:
+    - name: TKN_IMAGE
+      type: string
+      description: tkn CLI container image to run this stepaction
+      default: gcr.io/tekton-releases/dogfooding/tkn@sha256:328b4a98eb566ccad4aafcd7fb8307a97c5771e681d85bda669e21e37c071a81
+    - name: TKN_ARGS
+      description: Extra args to be passed to tkn, as a single string
+      default: ""
+    - name: REGISTRY
+      type: string
+      description: The registry where bundles are published to
+    - name: PATH
+      type: string
+      description: The path in the registry
+      default: tekton/catalog/tasks
+    - name: RESOURCE
+      type: string
+      description: task or stepaction. It must match the resource name in the root of the catalog path.
+      default: task
+    - name: TAG
+      type: string
+      description: An optional extra tag. If provided, tasks are tagged with it too.
+      default: ""
+    - name: catalogPath
+      description: >-
+        A directory that holds the catalog to be published. The catalog must be stored
+        in the root of the directory, and is must follow the
+        [Tetkon Catalog](https://github.com/tektoncd/catalog#catalog-structure) structure.
+    - name: dockerconfigPath
+      description: >-
+        An optional directory that allows providing a .docker/config.json
+        file for tkn to access the container registry. The file should be placed at
+        the root of the Directory with name config.json.
+      default: "no-path"
+  image: "$(params.TKN_IMAGE)"
+  workingDir: "$(params.catalogPath)"
+  env:
+    - name: REGISTRY
+      value: $(params.REGISTRY)
+    - name: REGISTRY_PATH
+      value: $(params.PATH)
+    - name: TAG
+      value: $(params.TAG)
+    - name: DOCKER_CONFIG_PATH
+      value: $(params.dockerconfigPath)
+    - name: RESOURCE
+      value: $(params.RESOURCE)
+    - name: TKN_ARGS
+      value: $(params.TKN_ARGS)
+  script: |
+    #!/usr/bin/env sh
+    set -e -o pipefail
+    TARGET="${REGISTRY}"
+    [ "${REGISTRY_PATH}" != "" ] && TARGET="${TARGET}/${REGISTRY_PATH}"
+    # If a dockerconfig workspace was provided, set DOCKER_CONFIG to point to it
+    if [ -d "$DOCKER_CONFIG_PATH" ]; then
+        export DOCKER_CONFIG="${DOCKER_CONFIG_PATH}"
+    fi
+    find ${RESOURCE} -type f -mindepth 3 -maxdepth 3 -name '*.yaml' -o -name '*.yml'| while read -r resource_version_dir; do
+      FOLDER=$(dirname "$resource_version_dir")
+      VERSION=$(basename "$FOLDER")
+      RESOURCE_NAME=$(basename "$(dirname "$FOLDER")")
+      tkn bundle push \
+          --label org.opencontainers.image.description="${RESOURCE_NAME}" \
+          --label org.opencontainers.image.version="${VERSION}" \
+          ${TKN_ARGS} "${TARGET}/${RESOURCE_NAME}:${VERSION}" -f "$resource_version_dir"
+      [ "${TAG}" != "" ] && \
+        tkn bundle push \
+          --label org.opencontainers.image.description="${RESOURCE_NAME}" \
+          --label org.opencontainers.image.version="${TAG}" \
+           ${TKN_ARGS} "${TARGET}/${RESOURCE_NAME}:${TAG}" -f "$resource_version_dir"
+      sleep 0.1
+    done

--- a/stepaction/tekton-catalog-publish/0.2/tests/pre-apply-task-hook.sh
+++ b/stepaction/tekton-catalog-publish/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Add git-clone
+add_stepaction git-clone latest

--- a/stepaction/tekton-catalog-publish/0.2/tests/run.yaml
+++ b/stepaction/tekton-catalog-publish/0.2/tests/run.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: catalog-publish-test-task
+spec:
+  workspaces:
+    - name: shared-workspace
+  steps:
+    - name: fetch-repository
+      ref:
+        name: git-clone
+      params:
+        - name: url
+          value: https://github.com/tektoncd/catalog
+        - name: subdirectory
+          value: ""
+        - name: deleteExisting
+          value: "true"
+        - name: output-path
+          value: $(workspaces.shared-workspace.path)
+    - name: reduce
+      image: alpine
+      script: |
+        set -e
+        cd "$(workspaces.shared-workspace.path)/stepaction"
+        ls | grep -v 'git-clone' | xargs rm -rf
+    - name: publish
+      params:
+        - name: REGISTRY
+          value: localhost:5000
+        - name: RESOURCE
+          value: stepaction
+        - name: PATH
+          value: tekton/catalog/stepactions
+        - name: TAG
+          value: $(steps.fetch-repository.results.commit)
+        - name: catalogPath
+          value: $(workspaces.shared-workspace.path)
+      ref:
+        name: tekton-catalog-publish
+  sidecars:
+    - name: registry
+      image: registry
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: catalog-publish-test-task-run
+spec:
+  taskRef:
+    name: catalog-publish-test-task
+  workspaces:
+    - name: shared-workspace
+      emptyDir: {}


### PR DESCRIPTION
# Changes

Add a new version of the catalog publish step action. This new version API is backwards compatible, as it adds one new optional parameter only, `TKN_ARGS`.

The new version includes the following changes:
- latest version of tkn image set by default
- sets two OCI labels org.opencontainers.image.description and org.opencontainers.image.version for each resource
- accepts TKN_ARGS which is passed to all resources and can be used to set additional OCI labels as well as other settings

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages

/kind feature