### PR TITLE
Fix e2e tests by deprecating the failing tasks

### DIFF
--- a/task/gitleaks/0.1/gitleaks.yaml
+++ b/task/gitleaks/0.1/gitleaks.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: Security, Secrets
     tekton.dev/displayName: "Gitleaks"
     tekton.dev/platforms: "linux/amd64"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     This task makes it possible to use Gitleaks within your Tekton pipelines.

--- a/task/grype/0.1/grype.yaml
+++ b/task/grype/0.1/grype.yaml
@@ -11,6 +11,7 @@ metadata:
     tekton.dev/tags: CLI, grype
     tekton.dev/displayName: "grype"
     tekton.dev/platforms: "linux/amd64,linux/arm64,linux/ppc64le,linux/390x"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     A vulnerability scanner for container images and filesystems.

--- a/task/jib-gradle/0.2/jib-gradle.yaml
+++ b/task/jib-gradle/0.2/jib-gradle.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: image-build
     tekton.dev/displayName: "jib gradle"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google’s Jib tool.

--- a/task/jib-gradle/0.3/jib-gradle.yaml
+++ b/task/jib-gradle/0.3/jib-gradle.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: image-build
     tekton.dev/displayName: "jib gradle"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google’s Jib tool.

--- a/task/jib-gradle/0.4/jib-gradle.yaml
+++ b/task/jib-gradle/0.4/jib-gradle.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: image-build
     tekton.dev/displayName: "jib gradle"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     This Task builds Java/Kotlin/Groovy/Scala source into a container image using Google’s Jib tool.

--- a/task/redhat-dependency-analytics/0.2/redhat-dependency-analytics.yaml
+++ b/task/redhat-dependency-analytics/0.2/redhat-dependency-analytics.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: Security, Vulnenrability, CVE
     tekton.dev/displayName: "Red Hat Dependency Analytics"
     tekton.dev/platforms: "linux/amd64"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     The Red Hat Dependency Analytics task is an interface between Tekton and Red Hat Dependency Analytics (RHDA) platform.


### PR DESCRIPTION
# Changes

Following are the tasks which were failing in e2e tests:
1. gitleaks - v0.1
2. grype - v0.1
3. jib-gradle - v0.2, v0.3, v0.4
4. redhat-dependency-analytics v0.2

Marking them as deprecated until they are fixed or there is a new version available for that task. Also there are couple of PRs which are waiting for the CI to be green, this PR will unblock them.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Follows the [authoring recommendations][authoring]
- [ ] Includes [docs][docs] (if user facing)
- [ ] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [X] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [X] Commit messages follow [commit message best practices][commit]
- [X] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [X] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [X] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [X] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [X] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [X] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [X] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
