### PR TITLE
Update buildah task with basic manifest list support

### DIFF
--- a/task/buildah/0.10/README.md
+++ b/task/buildah/0.10/README.md
@@ -1,0 +1,76 @@
+# Buildah
+
+This Task builds source into a container image using Project Atomic's
+[Buildah](https://github.com/projectatomic/buildah) build tool. It uses
+Buildah's support for building from
+[`Dockerfile`](https://docs.docker.com/engine/reference/builder/)s, using its
+`buildah bud` command. This command executes the directives in the `Dockerfile`
+to assemble a container image, then pushes that image to a container registry.
+
+## Install the Task
+
+```
+kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.9/raw
+```
+
+## Parameters
+
+* **IMAGE**: The name (reference) of the image to build.
+* **BUILDER_IMAGE:**: The name of the image containing the Buildah tool. See
+  note below.  (_default:_ `quay.io/buildah/stable:v1`)
+* **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_
+  `./Dockerfile`)
+* **CONTEXT**: Path to the directory to use as context (_default:_
+  `.`)
+* **TLSVERIFY**: Verify the TLS on the registry endpoint (for push/pull to a
+  non-TLS registry) (_default:_ `true`)
+* **FORMAT**: The format of the built container, oci or docker (_default:_
+ `oci`)
+* **BUILD_EXTRA_ARGS**: Extra parameters passed for the build command when
+  building images. WARNING - must be sanitized to avoid command injection 
+  (_default:_ `""`)
+* **PUSH_EXTRA_ARGS**: Extra parameters passed for the push command when
+  pushing images. WARNING - must be sanitized to avoid command injection
+  (_default:_ `""`)
+* **SKIP_PUSH**: Skip pushing the built image (_default:_ `false`)
+* **BUILD_ARGS**: Dockerfile build arguments, array of key=value (_default:_ [""])
+
+## Results
+
+* **IMAGE_URL**: Image repository where the built image would be pushed to
+* **IMAGE_DIGEST**: Digest of the image just built
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+* **sslcertdir**: An [*optional* Workspace](https://github.com/tektoncd/pipeline/blob/v0.17.0/docs/workspaces.md#optional-workspaces) containing your custom SSL certificates to connect to the registry. Buildah will look for files ending with *.crt, *.cert, *.key into this workspace. See [this sample](./samples/openshift-internal-registry.yaml) for a complete example on how to use it with OpenShift internal registry.
+- **dockerconfig**: An [optional workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#using-workspaces-in-tasks) that allows providing a `.docker/config.json` file for Buildah to access the container registry. The file should be placed at the root of the Workspace with name `config.json`. See [this sample](./samples/dockerconfig.yaml) for a complete example on how to use `dockerconfig` to access container registry. _(optional)_
+
+## Platforms
+
+The Task can be run on `linux/amd64`, `linux/s390x`, `linux/arm64` and `linux/ppc64le` platforms.
+
+## Usage
+
+This TaskRun runs the Task to fetch a Git repo, and build and push a container
+image using Buildah.
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: buildah-build-my-repo
+spec:
+  taskRef:
+    name: buildah
+  params:
+  - name: IMAGE
+    value: gcr.io/my-repo/my-image
+  workspaces:
+  - name: source
+    persistentVolumeClaim:
+      claimName: my-source
+```
+
+In this example, the Git repo being built is expected to have a `Dockerfile` at
+the root of the repository.

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: buildah
+  labels:
+    app.kubernetes.io/version: "0.9"
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: "0.50.0"
+    tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+    tekton.dev/displayName: buildah
+spec:
+  description: >-
+    Buildah task builds source into a container image and
+    then pushes it to a container registry.
+
+    Buildah Task builds source into a container image using Project Atomic's
+    Buildah build tool.It uses Buildah's support for building from Dockerfiles,
+    using its buildah bud command.This command executes the directives in the
+    Dockerfile to assemble a container image, then pushes that image to a
+    container registry.
+
+  params:
+  - name: IMAGE
+    description: Reference of the image buildah will produce.
+  - name: BUILDER_IMAGE
+    description: The location of the buildah builder image.
+    default: quay.io/buildah/stable:v1
+  - name: STORAGE_DRIVER
+    description: Set buildah storage driver
+    default: overlay
+  - name: DOCKERFILE
+    description: Path to the Dockerfile to build.
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: Path to the directory to use as context.
+    default: .
+  - name: TLSVERIFY
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    default: "true"
+  - name: FORMAT
+    description: The format of the built container, oci or docker
+    default: "oci"
+  - name: BUILD_EXTRA_ARGS
+    description: Extra parameters passed for the build command when building images. WARNING - must be sanitized to avoid command injection
+    default: ""
+  - name: PUSH_EXTRA_ARGS
+    description: Extra parameters passed for the push command when pushing images. WARNING - must be sanitized to avoid command injection
+    type: string
+    default: ""
+  - name: SKIP_PUSH
+    description: Skip pushing the built image
+    default: "false"
+  - name: BUILD_ARGS
+    description: Dockerfile build arguments, array of key=value
+    type: array
+    default:
+    - ""
+  workspaces:
+  - name: source
+  - name: sslcertdir
+    optional: true
+  - name: dockerconfig
+    description: >-
+      An optional workspace that allows providing a .docker/config.json file
+      for Buildah to access the container registry.
+      The file should be placed at the root of the Workspace with name config.json.
+    optional: true
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+  - name: IMAGE_URL
+    description: Image repository where the built image would be pushed to
+  steps:
+  - name: build-and-push
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)
+    env:
+    - name: PARAM_IMAGE
+      value: $(params.IMAGE)
+    - name: PARAM_STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: PARAM_DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: PARAM_CONTEXT
+      value: $(params.CONTEXT)
+    - name: PARAM_TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: PARAM_FORMAT
+      value: $(params.FORMAT)
+    - name: PARAM_BUILD_EXTRA_ARGS
+      value: $(params.BUILD_EXTRA_ARGS)
+    - name: PARAM_PUSH_EXTRA_ARGS
+      value: $(params.PUSH_EXTRA_ARGS)
+    - name: PARAM_SKIP_PUSH
+      value: $(params.SKIP_PUSH)
+    args:
+    - $(params.BUILD_ARGS[*])
+    script: |
+      BUILD_ARGS=()
+      for buildarg in "$@"
+      do
+        BUILD_ARGS+=("--build-arg=$buildarg")
+      done
+      [ "$(workspaces.sslcertdir.bound)" = "true" ] && CERT_DIR_FLAG="--cert-dir=$(workspaces.sslcertdir.path)"
+      [ "$(workspaces.dockerconfig.bound)" = "true" ] && DOCKER_CONFIG="$(workspaces.dockerconfig.path)" && export DOCKER_CONFIG
+      # build the image (CERT_DIR_FLAG should be omitted if empty and BUILD_EXTRA_ARGS can contain multiple args)
+      # shellcheck disable=SC2046,SC2086
+      buildah ${CERT_DIR_FLAG} "--storage-driver=${PARAM_STORAGE_DRIVER}" bud "${BUILD_ARGS[@]}" ${PARAM_BUILD_EXTRA_ARGS} \
+        "--format=${PARAM_FORMAT}" "--tls-verify=${PARAM_TLSVERIFY}" \
+        -f "${PARAM_DOCKERFILE}" -t "${PARAM_IMAGE}" "${PARAM_CONTEXT}"
+      [ "${PARAM_SKIP_PUSH}" = "true" ] && echo "Push skipped" && exit 0
+      # push the image (CERT_DIR_FLAG should be omitted if empty and PUSH_EXTRA_ARGS can contain multiple args)
+      # shellcheck disable=SC2046,SC2086
+      buildah ${CERT_DIR_FLAG} "--storage-driver=${PARAM_STORAGE_DRIVER}" push \
+        "--tls-verify=${PARAM_TLSVERIFY}" --digestfile /tmp/image-digest ${PARAM_PUSH_EXTRA_ARGS} \
+        "${PARAM_IMAGE}" "docker://${PARAM_IMAGE}"
+      tee "$(results.IMAGE_DIGEST.path)" < /tmp/image-digest
+      printf '%s' "${PARAM_IMAGE}" | tee "$(results.IMAGE_URL.path)"
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    securityContext:
+      privileged: true
+  volumes:
+  - name: varlibcontainers
+    emptyDir: {}

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: buildah
   labels:
-    app.kubernetes.io/version: "0.9"
+    app.kubernetes.io/version: "0.10"
   annotations:
     tekton.dev/categories: Image Build
     tekton.dev/pipelines.minVersion: "0.50.0"
@@ -17,10 +17,10 @@ spec:
     then pushes it to a container registry.
 
     Buildah Task builds source into a container image using Project Atomic's
-    Buildah build tool.It uses Buildah's support for building from Dockerfiles,
-    using its buildah bud command.This command executes the directives in the
+    Buildah build tool. It uses Buildah's support for building from Dockerfiles,
+    using its buildah bud command. This command executes the directives in the
     Dockerfile to assemble a container image, then pushes that image to a
-    container registry.
+    container registry, optionally as a manifest list.
 
   params:
   - name: IMAGE
@@ -50,7 +50,7 @@ spec:
     description: Extra parameters passed for the push command when pushing images. WARNING - must be sanitized to avoid command injection
     type: string
     default: ""
-  - name: SKIP_PUSH
+  - name: SKIP_PUSH  
     description: Skip pushing the built image
     default: "false"
   - name: BUILD_ARGS
@@ -58,6 +58,9 @@ spec:
     type: array
     default:
     - ""
+  - name: MANIFEST_LIST
+    description: Build the image as a manifest list instead of a single image. Architecture auto-detected from node.
+    default: "false"
   workspaces:
   - name: source
   - name: sslcertdir
@@ -73,6 +76,8 @@ spec:
     description: Digest of the image just built.
   - name: IMAGE_URL
     description: Image repository where the built image would be pushed to
+  - name: MANIFEST_LIST_DIGEST
+    description: Digest of the manifest list (when MANIFEST_LIST=true)
   steps:
   - name: build-and-push
     image: $(params.BUILDER_IMAGE)
@@ -96,29 +101,106 @@ spec:
       value: $(params.PUSH_EXTRA_ARGS)
     - name: PARAM_SKIP_PUSH
       value: $(params.SKIP_PUSH)
+    - name: PARAM_MANIFEST_LIST
+      value: $(params.MANIFEST_LIST)
     args:
     - $(params.BUILD_ARGS[*])
     script: |
+      #!/usr/bin/env bash
+      set -e
+      
       BUILD_ARGS=()
       for buildarg in "$@"
       do
         BUILD_ARGS+=("--build-arg=$buildarg")
       done
+      
       [ "$(workspaces.sslcertdir.bound)" = "true" ] && CERT_DIR_FLAG="--cert-dir=$(workspaces.sslcertdir.path)"
       [ "$(workspaces.dockerconfig.bound)" = "true" ] && DOCKER_CONFIG="$(workspaces.dockerconfig.path)" && export DOCKER_CONFIG
-      # build the image (CERT_DIR_FLAG should be omitted if empty and BUILD_EXTRA_ARGS can contain multiple args)
+      
+      if [ "${PARAM_MANIFEST_LIST}" = "true" ]; then
+        IS_MULTIARCH_BUILD="true"
+        echo "Building image as a manifest list"
+        
+        # Auto-detect architecture from node 
+        NODE_ARCH=$(uname -m)
+        case "${NODE_ARCH}" in
+          x86_64)
+            DETECTED_ARCH="amd64"
+            ;;
+          aarch64)
+            DETECTED_ARCH="arm64"
+            ;;
+          s390x)
+            DETECTED_ARCH="s390x"
+            ;;
+          ppc64le)
+            DETECTED_ARCH="ppc64le"
+            ;;
+          *)
+            echo "Warning: Unknown architecture ${NODE_ARCH}, defaulting to amd64"
+            DETECTED_ARCH="amd64"
+            ;;
+        esac
+        echo "Auto-detected architecture: ${DETECTED_ARCH}"
+      else
+        IS_MULTIARCH_BUILD="false"
+        echo "Single architecture build mode"
+      fi
+      
+      if [ "${IS_MULTIARCH_BUILD}" = "true" ]; then
+        TARGET_IMAGE="${PARAM_IMAGE}-${DETECTED_ARCH}"
+        ARCH_ARGS="--arch=${DETECTED_ARCH}"
+        echo "Multiarch build: targeting ${TARGET_IMAGE} for architecture ${DETECTED_ARCH}"
+      else
+        TARGET_IMAGE="${PARAM_IMAGE}"
+        ARCH_ARGS=""
+        echo "Single-arch build: targeting ${TARGET_IMAGE}"
+      fi
+      
+      # Build the image (CERT_DIR_FLAG should be omitted if empty and BUILD_EXTRA_ARGS can contain multiple args)
       # shellcheck disable=SC2046,SC2086
       buildah ${CERT_DIR_FLAG} "--storage-driver=${PARAM_STORAGE_DRIVER}" bud "${BUILD_ARGS[@]}" ${PARAM_BUILD_EXTRA_ARGS} \
-        "--format=${PARAM_FORMAT}" "--tls-verify=${PARAM_TLSVERIFY}" \
-        -f "${PARAM_DOCKERFILE}" -t "${PARAM_IMAGE}" "${PARAM_CONTEXT}"
-      [ "${PARAM_SKIP_PUSH}" = "true" ] && echo "Push skipped" && exit 0
-      # push the image (CERT_DIR_FLAG should be omitted if empty and PUSH_EXTRA_ARGS can contain multiple args)
+        ${ARCH_ARGS} "--format=${PARAM_FORMAT}" "--tls-verify=${PARAM_TLSVERIFY}" \
+        -f "${PARAM_DOCKERFILE}" -t "${TARGET_IMAGE}" "${PARAM_CONTEXT}"
+      
+      printf '%s' "${TARGET_IMAGE}" | tee "$(results.IMAGE_URL.path)"
+      
+      # Exit early if push is skipped
+      if [ "${PARAM_SKIP_PUSH}" = "true" ]; then
+        echo "Push skipped - exiting"
+        exit 0
+      fi
+      
+      # Push the individual architecture-specific image (required for manifest lists)
+      echo "Pushing image: ${TARGET_IMAGE}"
       # shellcheck disable=SC2046,SC2086
       buildah ${CERT_DIR_FLAG} "--storage-driver=${PARAM_STORAGE_DRIVER}" push \
         "--tls-verify=${PARAM_TLSVERIFY}" --digestfile /tmp/image-digest ${PARAM_PUSH_EXTRA_ARGS} \
-        "${PARAM_IMAGE}" "docker://${PARAM_IMAGE}"
+        "${TARGET_IMAGE}" "docker://${TARGET_IMAGE}"
+      
       tee "$(results.IMAGE_DIGEST.path)" < /tmp/image-digest
-      printf '%s' "${PARAM_IMAGE}" | tee "$(results.IMAGE_URL.path)"
+      
+      # Handle manifest list operations for multiarch builds
+      if [ "${PARAM_MANIFEST_LIST}" = "true" ]; then
+        echo "Creating manifest list if it doesn't exist: ${PARAM_IMAGE}"
+        # shellcheck disable=SC2046,SC2086
+        buildah ${CERT_DIR_FLAG} "--storage-driver=${PARAM_STORAGE_DRIVER}" manifest create "${PARAM_IMAGE}" || echo "Manifest list already exists"
+      
+        echo "Adding ${TARGET_IMAGE} to manifest list ${PARAM_IMAGE}"
+        # shellcheck disable=SC2046,SC2086
+        buildah ${CERT_DIR_FLAG} "--storage-driver=${PARAM_STORAGE_DRIVER}" manifest add \
+          "${PARAM_IMAGE}" "docker://${TARGET_IMAGE}"
+        
+        echo "Pushing manifest list: ${PARAM_IMAGE}"
+        # shellcheck disable=SC2046,SC2086
+        buildah ${CERT_DIR_FLAG} "--storage-driver=${PARAM_STORAGE_DRIVER}" manifest push \
+          "--tls-verify=${PARAM_TLSVERIFY}" --digestfile /tmp/manifest-digest ${PARAM_PUSH_EXTRA_ARGS} \
+          "${PARAM_IMAGE}" "docker://${PARAM_IMAGE}"
+        
+        tee "$(results.MANIFEST_LIST_DIGEST.path)" < /tmp/manifest-digest
+        echo "Manifest list operations completed successfully"
+      fi
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers

--- a/task/buildah/0.10/samples/dockerconfig.yaml
+++ b/task/buildah/0.10/samples/dockerconfig.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerconfig-secret
+stringData:
+  config.json: |
+    {
+      "auths" : {
+        "icr.io" : {
+          "auth" : "iamapikey",
+          "identitytoken" : "test123test123"
+        }
+      }
+    }
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: buildah-test-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+      - name: shared-workspace
+      - name: sslcertdir
+        optional: true
+      - name: dockerconfig-ws
+        optional: true
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: shared-workspace
+        params:
+          - name: url
+            value: https://github.com/sclorg/nodejs-ex
+          - name: subdirectory
+            value: ""
+          - name: deleteExisting
+            value: "true"
+      - name: buildah
+        taskRef:
+          name: buildah
+        runAfter:
+        - fetch-repository
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: dockerconfig
+          workspace: dockerconfig-ws
+        params:
+        - name: IMAGE
+          value: <IMAGE_NAME>
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Mi
+    - name: dockerconfig-ws
+      secret:
+        secretName: dockerconfig-secret

--- a/task/buildah/0.10/samples/multiarch-matrix-build.yaml
+++ b/task/buildah/0.10/samples/multiarch-matrix-build.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: buildah-multiarch-matrix-
+spec:
+  taskRunSpecs:
+  - pipelineTaskName: build-multiarch
+    podTemplate:
+      nodeSelector:
+        kubernetes.io/arch: $(params.ARCH)
+  
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: dockerconfig
+      optional: true
+    
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    
+    - name: build-multiarch
+      matrix:
+        params:
+        - name: ARCH
+          value: ["amd64", "arm64"]  
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      params:
+      - name: IMAGE
+        value: registry.example.com/nocode-multiarch:latest
+      - name: MANIFEST_LIST
+        value: "true"
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: dockerconfig
+        workspace: dockerconfig
+
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: dockerconfig
+    emptyDir: {}

--- a/task/buildah/0.10/samples/openshift-internal-registry.yaml
+++ b/task/buildah/0.10/samples/openshift-internal-registry.yaml
@@ -1,0 +1,87 @@
+# Your custom CA, on OpenShift to be able to get the internal registry custom
+# certificates you can just import it to your namespace with :
+# oc get configmaps \
+#   -n openshift-controller-manager openshift-service-ca -o yaml | \
+#   sed '/namespace/d'|kubectl apply -f-
+---
+kind: ConfigMap
+metadata:
+  name: openshift-service-ca
+apiVersion: v1
+data:
+  service-ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDUTCCAjmgAwIB................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ................................................................
+    ....................................................
+    -----END CERTIFICATE-----
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: buildah-custom-ca-
+spec:
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  # Make sure the path ends up as ca.crt or buildah would not be able to find
+  # it.
+  - name: sslcertdir
+    configMap:
+      name: openshift-service-ca
+      defaultMode: 420
+      items:
+      - key: service-ca.crt
+        path: ca.crt
+      namespace: openshift-controller-manager
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+        workspaces:
+        - name: output
+          workspace: shared-workspace
+        params:
+        - name: url
+          value: https://github.com/kelseyhightower/nocode
+      - name: buildah
+        taskRef:
+          name: buildah
+        runAfter:
+        - fetch-repository
+        workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: sslcertdir
+          workspace: sslcertdir
+        params:
+        # This will push to the openshift internal registry
+        - name: IMAGE
+          value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(context.pipelineRun.name)

--- a/task/buildah/0.10/tests/internal-registry/internal-registry.yaml
+++ b/task/buildah/0.10/tests/internal-registry/internal-registry.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+spec:
+  selector:
+    matchLabels:
+      run: registry
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: registry
+    spec:
+      containers:
+      - name: registry
+        image: docker.io/registry:2
+        ports:
+        - containerPort: 5000
+        volumeMounts:
+          - name: sslcert
+            mountPath: /certs
+        env:
+          - name: REGISTRY_HTTP_TLS_CERTIFICATE
+            value: "/certs/ca.crt"
+          - name: REGISTRY_HTTP_TLS_KEY
+            value: "/certs/ca.key"
+          - name: REGISTRY_HTTP_SECRET
+            value: "tekton"
+      volumes:
+        - name: sslcert
+          configMap:
+            defaultMode: 420
+            items:
+            - key: ca.crt
+              path: ca.crt
+            - key: ca.key
+              path: ca.key
+            name: sslcert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+spec:
+  ports:
+  - port: 5000
+  selector:
+    run: registry

--- a/task/buildah/0.10/tests/pre-apply-task-hook.sh
+++ b/task/buildah/0.10/tests/pre-apply-task-hook.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+add_sidecar_secure_registry
+
+# Add git-clone
+add_task git-clone latest

--- a/task/buildah/0.10/tests/run.yaml
+++ b/task/buildah/0.10/tests/run.yaml
@@ -124,3 +124,193 @@ spec:
       items:
       - key: ca.crt
         path: ca.crt
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: buildah-test-multiarch-params
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    
+    - name: buildah-amd64
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      params:
+      - name: IMAGE
+        value: registry:5000/nocode-test
+      - name: MANIFEST_LIST
+        value: "true"
+      - name: SKIP_PUSH
+        value: "true"
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: sslcertdir
+        workspace: sslcertdir
+    
+    - name: test-multiarch-results
+      runAfter:
+      - buildah-amd64
+      params:
+        - name: BUILT_IMAGE_URL
+          value: "$(tasks.buildah-amd64.results.IMAGE_URL)"
+      taskSpec:
+        params:
+          - name: BUILT_IMAGE_URL
+        steps:
+          - name: verify-architecture-suffix
+            image: alpine
+            script: |
+              #!/usr/bin/env sh
+              echo "Architecture-specific image: $(params.BUILT_IMAGE_URL)"
+              # Verify the architecture suffix was added
+              if [[ "$(params.BUILT_IMAGE_URL)" == *"-amd64" ]]; then
+                echo "Architecture suffix correctly added"
+                exit 0
+              else
+                echo "Architecture suffix missing or incorrect"
+                exit 1
+              fi
+
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: sslcertdir
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+      - key: ca.crt
+        path: ca.crt
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: buildah-test-manifest-list
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    
+    - name: buildah-with-manifest
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      params:
+      - name: IMAGE
+        value: registry:5000/nocode-manifest-test
+      - name: MANIFEST_LIST
+        value: "true"
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: sslcertdir
+        workspace: sslcertdir
+    
+    - name: verify-manifest-list
+      runAfter:
+      - buildah-with-manifest
+      params:
+        - name: MANIFEST_IMAGE
+          value: registry:5000/nocode-manifest-test
+        - name: ARCH_IMAGE
+          value: "$(tasks.buildah-with-manifest.results.IMAGE_URL)"
+        - name: MANIFEST_DIGEST
+          value: "$(tasks.buildah-with-manifest.results.MANIFEST_LIST_DIGEST)"
+      taskSpec:
+        params:
+          - name: MANIFEST_IMAGE
+          - name: ARCH_IMAGE
+          - name: MANIFEST_DIGEST
+        steps:
+          - name: verify-manifest-list-created
+            image: quay.io/buildah/stable:v1
+            script: |
+              #!/usr/bin/env bash
+              set -e
+              
+              echo "Verifying manifest list: $(params.MANIFEST_IMAGE)"
+              echo "Architecture-specific image: $(params.ARCH_IMAGE)"
+              echo "Manifest list digest: $(params.MANIFEST_DIGEST)"
+              
+              echo "Inspecting manifest list..."
+              buildah manifest inspect $(params.MANIFEST_IMAGE)
+              
+              # Verify the architecture-specific image is in the manifest list
+              echo "Checking if $(params.ARCH_IMAGE) is in the manifest list..."
+              
+              # Get the manifest list content and check for our architecture image
+              MANIFEST_CONTENT=$(buildah manifest inspect $(params.MANIFEST_IMAGE))
+              
+              # Extract just the image name with arch suffix for comparison
+              ARCH_IMAGE_NAME=$(echo "$(params.ARCH_IMAGE)" | sed 's|registry:5000/||')
+              
+              if echo "$MANIFEST_CONTENT" | grep -q "$ARCH_IMAGE_NAME"; then
+                echo "SUCCESS: Architecture-specific image found in manifest list"
+                exit 0
+              else
+                echo "FAILED: Architecture-specific image not found in manifest list"
+                echo "Expected to find: $ARCH_IMAGE_NAME"
+                echo "Manifest content: $MANIFEST_CONTENT"
+                exit 1
+              fi
+
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: sslcertdir
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+      - key: ca.crt
+        path: ca.crt

--- a/task/buildah/0.10/tests/run.yaml
+++ b/task/buildah/0.10/tests/run.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: buildah-test-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    - name: buildah
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: sslcertdir
+        workspace: sslcertdir
+      params:
+      - name: IMAGE
+        value: registry:5000/nocode
+    - name: test-buildah-results
+      params:
+        - name: OUTPUT_IMAGE
+          value: "$(tasks.buildah.results.IMAGE_URL)"
+        - name: ORIGINAL_IMAGE
+          value: registry:5000/nocode
+      taskSpec:
+        params:
+          - name: ORIGINAL_IMAGE
+          - name: OUTPUT_IMAGE
+        steps:
+          - name: evaluate
+            image: alpine
+            script: |
+              #!/usr/bin/env sh
+              [[ "$(params.ORIGINAL_IMAGE)" = "$(params.OUTPUT_IMAGE)" ]] && exit 0 || exit 1
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: sslcertdir
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+      - key: ca.crt
+        path: ca.crt
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: buildah-test-skip-push-pipeline-run
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: shared-workspace
+    - name: sslcertdir
+      optional: true
+    tasks:
+    - name: fetch-repository
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: shared-workspace
+      params:
+      - name: url
+        value: https://github.com/kelseyhightower/nocode
+      - name: subdirectory
+        value: ""
+      - name: deleteExisting
+        value: "true"
+    - name: buildah
+      taskRef:
+        name: buildah
+      runAfter:
+      - fetch-repository
+      workspaces:
+      - name: source
+        workspace: shared-workspace
+      - name: sslcertdir
+        workspace: sslcertdir
+      params:
+      - name: IMAGE
+        value: registry:5000/nocode
+      - name: SKIP_PUSH
+        value: "true"
+  workspaces:
+  - name: shared-workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Mi
+  - name: sslcertdir
+    configMap:
+      name: sslcert
+      defaultMode: 420
+      items:
+      - key: ca.crt
+        path: ca.crt


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Updates the buildah task with a MANIFEST_LIST param, which will create and add an arch-specific build of the image to a manifest list.

This is mainly to enable simpler multiarch builds on clusters with nodes of mixed architecture, and to work well with https://github.com/tektoncd/pipeline/pull/8599 in a PipelineRun. Modifying the buildah task provides and easy way to do this (see the multiarch pipeline in `samples/`)

I flip-flopped on what the structure of this should be and am wanting to get others' feedback on whether this would be more useful with more fine-grained parameter options or as a separate buildah-manifest task. Since this task is very build focused, I decided to keep the implementation minimal while still adding a useful feature.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
  - See the [end-to-end testing documentation][e2e] for guidance and CI details.
- [ ] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [ ] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [x] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages
