### PR TITLE
Move bobcatfish to alumni

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- bobcatfish
 - vdemeester
 - vinamra28
 ## alumni
@@ -10,3 +9,4 @@ approvers:
 # ImJasonH
 # dlorenc
 # chmouel
+# bobcatfish


### PR DESCRIPTION
# Changes

Move bobcatfish to alumni in OWNERS. Zero catalog activity in the last 12 months. Zero devstats contributions in the last 2 years (1,595 in last 5 years — previously active across the org).

Per the [contributor ladder inactivity policy](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md#inactivity), >4 months of no contributions warrants moving to emeritus.

Full triage report: https://gist.github.com/vdemeester/c7ce8d4fea6f7a2f9b3f685558ce8ded

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label.

[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages