### PR TITLE
Fix trailing spaces in openshift-client task

### DIFF
--- a/task/openshift-client/0.2/openshift-client.yaml
+++ b/task/openshift-client/0.2/openshift-client.yaml
@@ -43,7 +43,7 @@ spec:
     - name: RESULT
       description: Can be used to store output in order to be used by following tasks (with tasks.taskname.results.RESULT). Default value is empty string
       type: string
-      
+
   steps:
     - name: oc
       image: quay.io/openshift/origin-cli:$(params.VERSION)
@@ -56,7 +56,7 @@ spec:
         [[ "$(workspaces.kubeconfig-dir.bound)" == "true" ]] && \
         [[ -f $(workspaces.kubeconfig-dir.path)/kubeconfig ]] && \
         export KUBECONFIG=$(workspaces.kubeconfig-dir.path)/kubeconfig
-        
+
         echo "" > $(results.RESULT.path)
-        
+
         $(params.SCRIPT)


### PR DESCRIPTION
# Changes

Fix pre-existing trailing whitespace on lines 46, 59, and 61 of
`task/openshift-client/0.2/openshift-client.yaml` that causes the
yamllint CI check to fail with `trailing-spaces` errors on **all PRs**
touching this repository.

The three affected lines were blank/empty lines inside the `results`
block and `script` block that had invisible trailing spaces. Removed
with `sed`.

# Submitter Checklist

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing) — N/A, no functional change
- [x] Includes [tests][tests] (for new tasks or changed functionality) — N/A, whitespace-only fix
- [x] Meets the [Tekton contributor standards][contributor]
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label (`/kind cleanup`)
- [x] Complies with [Catalog Organization TEP][TEP] — N/A, no structural change

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages