### PR TITLE
ci: update test matrix to use Tekton Pipelines v1.11.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
 
         include:
         - tekton-version: latest
-          pipeline-version: v1.9.0
+          pipeline-version: v1.11.0
         - tekton-version: lts-latest
           pipeline-version: v1.9.0
         - tekton-version: lts-latest-minus-one


### PR DESCRIPTION
Update the latest pipeline version in the CI test matrix from v1.9.0 to v1.11.0.

Release: https://github.com/tektoncd/pipeline/releases/tag/v1.11.0