### PR TITLE
chore: deprecate git-clone and golang tasks/stepactions

### DIFF
--- a/stepaction/git-clone/0.2/README.md
+++ b/stepaction/git-clone/0.2/README.md
@@ -1,5 +1,12 @@
 # `git-clone`
 
+> [!WARNING]
+> **Deprecated.** This StepAction is no longer actively maintained here. It now
+> lives in its own repository with proper releases:
+> [tektoncd-catalog/git-clone](https://github.com/tektoncd-catalog/git-clone)
+> ([browse on Artifact Hub](https://artifacthub.io/packages/search?kind=11&repo=git-clone-stepaction)).
+> Please migrate to that version.
+
 **Note: this StepAction is only compatible with Tekton Pipelines versions 0.54.0 and greater!**
 
 **Note: this StepAction is not backwards compatible with the previous versions as it is now run as a non-root user!**

--- a/stepaction/git-clone/0.2/git-clone.yaml
+++ b/stepaction/git-clone/0.2/git-clone.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: git
     tekton.dev/displayName: "git clone"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+    tekton.dev/deprecated: "true"
 spec:
   params:
     - name: output-path

--- a/task/git-clone/0.10/README.md
+++ b/task/git-clone/0.10/README.md
@@ -1,5 +1,12 @@
 # `git-clone`
 
+> [!WARNING]
+> **Deprecated.** This Task is no longer actively maintained here. It now lives
+> in its own repository with proper releases:
+> [tektoncd-catalog/git-clone](https://github.com/tektoncd-catalog/git-clone)
+> ([browse on Artifact Hub](https://artifacthub.io/packages/search?kind=7&repo=git-clone)).
+> Please migrate to that version.
+
 **Note: this Task is only compatible with Tekton Pipelines versions 0.38.0 and greater!**
 
 **Note: this Task is not backwards compatible with the previous versions as it is now run as a non-root user!**

--- a/task/git-clone/0.10/git-clone.yaml
+++ b/task/git-clone/0.10/git-clone.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: git
     tekton.dev/displayName: "git clone"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     These Tasks are Git tasks to work with repositories used by other tasks

--- a/task/golang-build/0.3/README.md
+++ b/task/golang-build/0.3/README.md
@@ -1,5 +1,12 @@
 # Golang Build
 
+> [!WARNING]
+> **Deprecated.** This Task is no longer actively maintained here. It now lives
+> in the consolidated Golang repository with proper releases:
+> [tektoncd-catalog/golang](https://github.com/tektoncd-catalog/golang)
+> ([browse on Artifact Hub](https://artifacthub.io/packages/search?kind=7&repo=golang)).
+> Please migrate to that version.
+
 This Task is Golang task to build Go projects.
 
 ## Install the task

--- a/task/golang-build/0.3/golang-build.yaml
+++ b/task/golang-build/0.3/golang-build.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: build-tool
     tekton.dev/displayName: "golang build"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     This Task is Golang task to build Go projects.

--- a/task/golang-test/0.2/README.md
+++ b/task/golang-test/0.2/README.md
@@ -1,5 +1,12 @@
 # Golang Test
 
+> [!WARNING]
+> **Deprecated.** This Task is no longer actively maintained here. It now lives
+> in the consolidated Golang repository with proper releases:
+> [tektoncd-catalog/golang](https://github.com/tektoncd-catalog/golang)
+> ([browse on Artifact Hub](https://artifacthub.io/packages/search?kind=7&repo=golang)).
+> Please migrate to that version.
+
 This task is a Golang task to test Go projects.
 
 ## Install the task

--- a/task/golang-test/0.2/golang-test.yaml
+++ b/task/golang-test/0.2/golang-test.yaml
@@ -10,6 +10,7 @@ metadata:
     tekton.dev/tags: test
     tekton.dev/displayName: "golang test"
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+    tekton.dev/deprecated: "true"
 spec:
   description: >-
     This Task is Golang task to test Go projects.


### PR DESCRIPTION
# Changes

These resources now live in dedicated repositories with proper releases in the
[`tektoncd-catalog`](https://github.com/tektoncd-catalog) organization, so the
versions here are marked deprecated to steer users to the maintained ones:

| Resource (here) | Successor | Artifact Hub |
|---|---|---|
| `task/git-clone/0.10` | [tektoncd-catalog/git-clone](https://github.com/tektoncd-catalog/git-clone) | [Task](https://artifacthub.io/packages/search?kind=7&repo=git-clone) |
| `stepaction/git-clone/0.2` | [tektoncd-catalog/git-clone](https://github.com/tektoncd-catalog/git-clone) | [StepAction](https://artifacthub.io/packages/search?kind=11&repo=git-clone-stepaction) |
| `task/golang-build/0.3` | [tektoncd-catalog/golang](https://github.com/tektoncd-catalog/golang) | [Tasks](https://artifacthub.io/packages/search?kind=7&repo=golang) |
| `task/golang-test/0.2` | [tektoncd-catalog/golang](https://github.com/tektoncd-catalog/golang) | [Tasks](https://artifacthub.io/packages/search?kind=7&repo=golang) |

For each, this PR:

- adds the `tekton.dev/deprecated: "true"` annotation to the latest version
  (older versions were already deprecated, so **all** versions are now
  deprecated). This annotation is now honored by Artifact Hub
  (see [artifacthub/hub#4774](https://github.com/artifacthub/hub/pull/4774)),
  which surfaces a deprecated badge.
- adds a migration note to the version `README.md` linking to the successor
  repository and its Artifact Hub entry.

Per [TEP-0003][TEP], "deprecated" keeps the resource available and tested but
read-only — this matches the "taken over by another one" deprecation case.

`golangci-lint` and `golang-fuzz` are intentionally left as-is: they have no
equivalent in the new `tektoncd-catalog/golang` repository (and `golang-fuzz`
was already deprecated).

# Submitter Checklist

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing) — README migration notes
- [ ] Includes [tests][tests] (for new tasks or changed functionality) — N/A, metadata/docs only
- [x] Meets the [Tekton contributor standards][contributor]
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label — `/kind cleanup`
- [x] Complies with [Catalog Organization TEP][TEP]
  - [x] File path follows `<kind>/<name>/<version>/name.yaml`
  - [x] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [x] Has mandatory `metadata.labels` - `app.kubernetes.io/version`
  - [x] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [x] mandatory `spec.description` follows the convention

/kind cleanup

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages