### PR TITLE
ci: add CI summary fan-out job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,3 +181,35 @@ jobs:
             echo '::endgroup::'
           done
         fi
+
+  ci-summary:
+    name: CI summary
+    needs: [linting, e2e-tests]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+    - name: Check CI results
+      run: |
+        results=(
+          "linting=${NEEDS_LINTING_RESULT}"
+          "e2e-tests=${NEEDS_E2E_TESTS_RESULT}"
+        )
+        failed=0
+        for r in "${results[@]}"; do
+          name="${r%%=*}"
+          result="${r#*=}"
+          echo "${name}: ${result}"
+          if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+            failed=1
+          fi
+        done
+        if [ "$failed" -eq 1 ]; then
+          echo ""
+          echo "Some CI jobs failed or were cancelled"
+          exit 1
+        fi
+        echo ""
+        echo "All CI checks passed"
+      env:
+        NEEDS_LINTING_RESULT: ${{ needs.linting.result }}
+        NEEDS_E2E_TESTS_RESULT: ${{ needs.e2e-tests.result }}


### PR DESCRIPTION
# Changes

Add a single **CI summary** job that depends on all CI jobs (`linting` and the `e2e-tests` matrix) and surfaces an aggregate pass/fail status, matching the pattern used in `tektoncd/pipeline` and other tektoncd repos.

## Motivation

This provides a single required status check that fans out over the matrix legs. Branch protection (and Prow/tide) only needs to require **CI summary** rather than enumerating every matrix combination — which change over time as pipeline versions are bumped (e.g. `e2e tests (latest)` with `v1.9.0` → `v1.13.0`).

The job runs with `if: always()` and fails if any required job's result is not `success` or `skipped`.

/kind cleanup