### PR TITLE
chore: bump apiVersion for StepActions and Pipelines

### DIFF
--- a/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
+++ b/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: build-push-gke-deploy

--- a/pipeline/buildpacks/0.1/buildpacks.yaml
+++ b/pipeline/buildpacks/0.1/buildpacks.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: buildpacks

--- a/pipeline/buildpacks/0.2/buildpacks.yaml
+++ b/pipeline/buildpacks/0.2/buildpacks.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: buildpacks

--- a/stepaction/git-clone/0.1/git-clone.yaml
+++ b/stepaction/git-clone/0.1/git-clone.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
   name: git-clone

--- a/stepaction/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
+++ b/stepaction/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
   name: tekton-catalog-publish

--- a/stepaction/tekton-catalog-publish/0.2/tekton-catalog-publish.yaml
+++ b/stepaction/tekton-catalog-publish/0.2/tekton-catalog-publish.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: StepAction
 metadata:
   name: tekton-catalog-publish

--- a/task/generate-build-id/0.1/README.md
+++ b/task/generate-build-id/0.1/README.md
@@ -87,7 +87,7 @@ In the task to build the service api, we then pass the generated build from the 
 For the sake of completeness, here is what the task to build the service api (`build-service-api.yaml`) looks like:
 
 ```
-apiVersion: tekton.dev/v1betal
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: build-service-api


### PR DESCRIPTION
# Changes

Bump primary manifests to the current recommended API versions (easy/mechanical subset of the API-version modernization):

- **StepAction** `tekton.dev/v1alpha1` → `tekton.dev/v1beta1`
  - `stepaction/git-clone/0.1`
  - `stepaction/tekton-catalog-publish/0.1` and `0.2`
- **Pipeline** `tekton.dev/v1beta1` → `tekton.dev/v1`
  - `pipeline/buildpacks/0.1` and `0.2`
  - `pipeline/build-push-gke-deploy/0.1`
- Fix a `v1betal` → `v1beta1` typo in the `generate-build-id` README example.

All bumped resources were checked: none use PipelineResources (`spec.resources`), `conditions:`, or `taskRef.bundle`, so this is a pure `apiVersion` change.

> [!NOTE]
> `catlin validate` (currently `@latest`) does not yet recognize `Pipeline` at `tekton.dev/v1`, but the catalog CI only runs `catlin validate` on `task/` directories, so these changes are unaffected. The catlin staleness is tracked as part of the broader catalog analysis.

The remaining ~252 `Task` v1beta1→v1 bumps (and 11 PipelineResource-using tasks needing migration) will be handled separately.

/kind cleanup

# Submitter Checklist

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)