### PR TITLE
docs: replace defunct hub.tekton.dev URLs with working alternatives

### DIFF
--- a/.claude/skills/task-authoring/SKILL.md
+++ b/.claude/skills/task-authoring/SKILL.md
@@ -120,7 +120,7 @@ One-line description of what this task does.
 
 ## Install the Task
 
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/<task-name>/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/<task-name>/0.1/<task-name>.yaml
 
 ## Parameters
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,18 +49,21 @@ jobs:
       env:
         PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
-        # Detect changed task version directories (task/<name>/<version>).
-        # Reduce every changed file to its version directory so that catlin
-        # only validates the catalog resource itself, never the test
-        # manifests under tests/ (TaskRun/Pipeline) or files under samples/,
-        # which are not catalog resources and would fail validation.
+        # Detect task version directories (task/<name>/<version>) whose
+        # resource manifest changed. Only consider YAML files that live
+        # directly in the version directory (task/<name>/<version>/*.yaml);
+        # this excludes README/OWNERS-only changes as well as the test
+        # manifests under tests/ (TaskRun/Pipeline) and files under samples/,
+        # none of which are catalog resources. Reducing to the version
+        # directory means catlin only ever validates the catalog resource.
         changed_tasks=$(
           git --no-pager diff --name-only ${PULL_BASE_SHA}..HEAD | \
+          { grep -E '^task/[^/]+/[^/]+/[^/]+\.yaml$' || true; } | \
           { grep -oE '^task/[^/]+/[^/]+' || true; } | \
           sort -u
         )
         if [[ -z "$changed_tasks" ]]; then
-          echo "No file changes detected in task directories"
+          echo "No changed task resource manifests detected"
           exit 0
         fi
         # Filter out removed directories
@@ -78,15 +81,16 @@ jobs:
       env:
         PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
-        # Detect changed task version directories (task/<name>/<version>).
+        # Detect task version directories whose resource manifest changed.
         # See the note in the "catlin validate" step above.
         changed_tasks=$(
           git --no-pager diff --name-only ${PULL_BASE_SHA}..HEAD | \
+          { grep -E '^task/[^/]+/[^/]+/[^/]+\.yaml$' || true; } | \
           { grep -oE '^task/[^/]+/[^/]+' || true; } | \
           sort -u
         )
         if [[ -z "$changed_tasks" ]]; then
-          echo "No file changes detected in task directories"
+          echo "No changed task resource manifests detected"
           exit 0
         fi
         # Script linting is informational (matching previous Prow behavior)

--- a/pipeline/build-push-gke-deploy/0.1/README.md
+++ b/pipeline/build-push-gke-deploy/0.1/README.md
@@ -8,17 +8,17 @@ This Pipeline builds, pushes, and deploys your application to a Google Kubernete
 Both `Kaniko` and `Gke-deploy` tasks have been used from tekton catalog
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.2/kaniko.yaml
 ```
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gke-deploy/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gke-deploy/0.1/gke-deploy.yaml
 ```
 
 ## Install the Pipeline
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/pipeline/build-push-gke-deploy/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
 ```
 
 ## Workspaces

--- a/pipeline/build-push-gke-deploy/0.1/samples/build-push-gke-deploy-example.md
+++ b/pipeline/build-push-gke-deploy/0.1/samples/build-push-gke-deploy-example.md
@@ -109,7 +109,7 @@ Install the Tekton Pipelines CLI to view your logs by following the instructions
 4. Install the `build-push-gke-deploy` Pipeline.
 
   ```bash
-  kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/pipeline/build-push-gke-deploy/0.1/raw
+  kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/build-push-gke-deploy/0.1/build-push-gke-deploy.yaml
   ```
 
 5. Create the `PipelineRun` config to run your Pipeline.

--- a/pipeline/buildpacks/0.1/README.md
+++ b/pipeline/buildpacks/0.1/README.md
@@ -24,15 +24,15 @@ This pipeline builds source into a container image using [Cloud Native Buildpack
 #### Install dependencies (if missing)
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.3/raw
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildpacks/0.3/raw
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildpacks-phases/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks/0.3/buildpacks.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
 ```
 
 #### Install pipeline
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/pipeline/buildpacks/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/buildpacks/0.1/buildpacks.yaml
 ```
 
 ## Workspaces

--- a/pipeline/buildpacks/0.2/README.md
+++ b/pipeline/buildpacks/0.2/README.md
@@ -24,15 +24,15 @@ This pipeline builds source into a container image using [Cloud Native Buildpack
 #### Install dependencies (if missing)
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.3/raw
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildpacks/0.3/raw
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildpacks-phases/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks/0.3/buildpacks.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
 ```
 
 #### Install pipeline
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/pipeline/buildpacks/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/pipeline/buildpacks/0.2/buildpacks.yaml
 ```
 
 ## Workspaces

--- a/roadmap.md
+++ b/roadmap.md
@@ -7,7 +7,7 @@ The catalog is a key piece of
 
 In 2019 we got a solid start on a catalog of reusable `Tasks` and in 2020 our ecosystem grew and
 a lot many `Tasks` were added in the catalog. Also our catalog was restructured so that `Tasks` present
-in the catalog could be versioned and tools like [`hub`](https://hub.tekton.dev) was able to display
+in the catalog could be versioned and tools like [`hub`](https://artifacthub.io) was able to display
 those tasks in a clean and better way. In 2021 we want to keep this momentum going and make the catalog
 even more useful by adding:
 

--- a/task/42crunch-api-security-audit/0.1/README.md
+++ b/task/42crunch-api-security-audit/0.1/README.md
@@ -9,7 +9,7 @@ and data coming in and going out.
 Install `42crunch-api-security-audit` task:
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/42crunch-api-security-audit/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/42crunch-api-security-audit/0.1/42crunch-api-security-audit.yaml
 ```
 
 ## Prerequisites

--- a/task/42crunch-api-security-audit/0.1/samples/README.md
+++ b/task/42crunch-api-security-audit/0.1/samples/README.md
@@ -15,9 +15,9 @@
 Run these commands to create and execute the pipeline:
 
 ```sh
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.6/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.6/git-clone.yaml
 
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/42crunch-api-security-audit/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/42crunch-api-security-audit/0.1/42crunch-api-security-audit.yaml
 
 
 kubectl apply -f secret.yaml

--- a/task/42crunch-api-security-audit/0.2/README.md
+++ b/task/42crunch-api-security-audit/0.2/README.md
@@ -9,7 +9,7 @@ and data coming in and going out.
 Install `42crunch-api-security-audit` task:
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/42crunch-api-security-audit/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/42crunch-api-security-audit/0.2/42crunch-api-security-audit.yaml
 ```
 
 ## Prerequisites

--- a/task/42crunch-api-security-audit/0.2/samples/README.md
+++ b/task/42crunch-api-security-audit/0.2/samples/README.md
@@ -15,9 +15,9 @@
 Run these commands to create and execute the pipeline:
 
 ```sh
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.6/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.6/git-clone.yaml
 
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/42crunch-api-security-audit/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/42crunch-api-security-audit/0.1/42crunch-api-security-audit.yaml
 
 
 kubectl apply -f secret.yaml

--- a/task/42crunch-api-security-audit/0.3/README.md
+++ b/task/42crunch-api-security-audit/0.3/README.md
@@ -9,7 +9,7 @@ and data coming in and going out.
 Install `42crunch-api-security-audit` task:
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/42crunch-api-security-audit/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/42crunch-api-security-audit/0.3/42crunch-api-security-audit.yaml
 ```
 
 ## Prerequisites

--- a/task/42crunch-api-security-audit/0.3/samples/README.md
+++ b/task/42crunch-api-security-audit/0.3/samples/README.md
@@ -15,9 +15,9 @@
 Run these commands to create and execute the pipeline:
 
 ```sh
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.6/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.6/git-clone.yaml
 
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/42crunch-api-security-audit/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/42crunch-api-security-audit/0.1/42crunch-api-security-audit.yaml
 
 
 kubectl apply -f secret.yaml

--- a/task/ansible-builder/0.1/README.md
+++ b/task/ansible-builder/0.1/README.md
@@ -9,7 +9,7 @@ It means a further task that works with Dockerfile/Containerfile such as `builda
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/ansible-builder/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-builder/0.1/ansible-builder.yaml
 ```
 
 ## Parameters

--- a/task/ansible-runner/0.1/README.md
+++ b/task/ansible-runner/0.1/README.md
@@ -10,7 +10,7 @@ Ansible Runner Task allows running the Ansible Playbooks using the [ansible-runn
 Create the Task and other resources:
 
 ```shell
-kubectl apply --filename https://api.hub.tekton.dev/v1/resource/tekton/task/ansible-runner/0.1/raw
+kubectl apply --filename https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-runner/0.1/ansible-runner.yaml
 ```
 
 Verify the created tasks:
@@ -47,7 +47,7 @@ All the examples will be run in namespace called `funstuff`. Create the namespac
 ### Create the PVC and clone example sources
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw \
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml \
   -f  https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-runner/0.1/support/playbooks-pvc.yaml
 ```
 

--- a/task/ansible-runner/0.2/README.md
+++ b/task/ansible-runner/0.2/README.md
@@ -9,7 +9,7 @@ The latest versions of ansible-runner requires [`community.general`](https://git
 Create the Task and other resources:
 
 ```shell
-kubectl apply --filename https://api.hub.tekton.dev/v1/resource/tekton/task/ansible-runner/0.2/raw
+kubectl apply --filename https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-runner/0.2/ansible-runner.yaml
 ```
 
 Verify the created tasks:
@@ -46,7 +46,7 @@ All the examples will be run in namespace called `funstuff`. Create the namespac
 ### Create the PVC and clone example sources
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.5/raw \
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.5/git-clone.yaml \
   -f  https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-runner/0.2/support/playbooks-pvc.yaml
 ```
 

--- a/task/ansible-tower-cli/0.1/README.md
+++ b/task/ansible-tower-cli/0.1/README.md
@@ -7,7 +7,7 @@
 
 Install `tower-cli` task:
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/ansible-tower-cli/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ansible-tower-cli/0.1/ansible-tower-cli.yaml
 ```
 
 ## Parameters

--- a/task/argocd-task-connect-repo/0.1/README.md
+++ b/task/argocd-task-connect-repo/0.1/README.md
@@ -5,7 +5,7 @@
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/argocd-task-connect-repo/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/argocd-task-connect-repo/0.1/argocd-task-connect-repo.yaml
 ```
 
 ## Parameters

--- a/task/argocd-task-sync-and-wait/0.1/README.md
+++ b/task/argocd-task-sync-and-wait/0.1/README.md
@@ -5,7 +5,7 @@ This task syncs (deploys) an [Argo CD](https://argoproj.github.io/argo-cd/) appl
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/argocd-task-sync-and-wait/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/argocd-task-sync-and-wait/0.1/argocd-task-sync-and-wait.yaml
 ```
 
 ## Parameters

--- a/task/argocd-task-sync-and-wait/0.2/README.md
+++ b/task/argocd-task-sync-and-wait/0.2/README.md
@@ -5,7 +5,7 @@ This task syncs (deploys) an [Argo CD](https://argoproj.github.io/argo-cd/) appl
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/argocd-task-sync-and-wait/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/argocd-task-sync-and-wait/0.2/argocd-task-sync-and-wait.yaml
 ```
 
 ## Parameters

--- a/task/asciidoctor/0.1/README.md
+++ b/task/asciidoctor/0.1/README.md
@@ -8,13 +8,13 @@ The resulting document can be sent by email, uploaded to the artifact repository
 
 ## Install the Task
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/asciidoctor/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/asciidoctor/0.1/asciidoctor.yaml
 ```
 
 ## Pre-requisite
 Install git-clone task from catalog
 ```
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.3/raw
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
 ```
 
 ## Workspaces

--- a/task/aws-cli/0.1/README.md
+++ b/task/aws-cli/0.1/README.md
@@ -7,7 +7,7 @@ All aws cli commands can be found [here](https://docs.aws.amazon.com/cli/latest/
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/aws-cli/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/aws-cli/0.1/aws-cli.yaml
 ```
 
 ## Parameters

--- a/task/aws-cli/0.2/README.md
+++ b/task/aws-cli/0.2/README.md
@@ -7,7 +7,7 @@ All aws cli commands can be found [here](https://docs.aws.amazon.com/cli/latest/
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/aws-cli/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/aws-cli/0.2/aws-cli.yaml
 ```
 
 ## Parameters

--- a/task/aws-ecr-login/0.1/README.md
+++ b/task/aws-ecr-login/0.1/README.md
@@ -12,7 +12,7 @@ registry as long as your IAM principal has access to do so until the token expir
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/aws-ecr-login/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/aws-ecr-login/0.1/aws-ecr-login.yaml
 ```
 
 ## Parameters

--- a/task/az/0.1/README.md
+++ b/task/az/0.1/README.md
@@ -5,7 +5,7 @@ This task performs operations on Microsoft Azure resources using `az`.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/az/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/az/0.1/az.yaml
 ```
 
 ## Parameters

--- a/task/black/0.1/README.md
+++ b/task/black/0.1/README.md
@@ -5,7 +5,7 @@ This task can be used to format the python source code using [Black](https://git
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/black/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/black/0.1/black.yaml
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/black/0.2/README.md
+++ b/task/black/0.2/README.md
@@ -5,7 +5,7 @@ This task can be used to format the python source code using [Black](https://git
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/black/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/black/0.2/black.yaml
 ```
 
 ## Parameters
@@ -28,7 +28,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/blue-green-deploy/0.1/README.md
+++ b/task/blue-green-deploy/0.1/README.md
@@ -8,7 +8,7 @@ The following task can help you to deploy an application using the Blue-Green de
 ## Installing the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/blue-green-deploy/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/blue-green-deploy/0.1/blue-green-deploy.yaml
 ```
 
 ## Installing the ClusterRoleBinding

--- a/task/blue-green-deploy/0.2/README.md
+++ b/task/blue-green-deploy/0.2/README.md
@@ -8,7 +8,7 @@ The following task can help you to deploy an application using the Blue-Green de
 ## Installing the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/blue-green-deploy/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/blue-green-deploy/0.2/blue-green-deploy.yaml
 ```
 
 ## Installing the ClusterRoleBinding

--- a/task/buildah-manifest-create/0.1/README.md
+++ b/task/buildah-manifest-create/0.1/README.md
@@ -5,7 +5,7 @@ This Task creates a manifest list (also known as an image index) from pre-built 
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah-manifest-create/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah-manifest-create/0.1/buildah-manifest-create.yaml
 ```
 
 ## Parameters

--- a/task/buildah-manifest-push/0.1/README.md
+++ b/task/buildah-manifest-push/0.1/README.md
@@ -5,7 +5,7 @@ This Task pushes a locally created manifest list to a container registry using [
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah-manifest-push/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah-manifest-push/0.1/buildah-manifest-push.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.1/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.2/README.md
+++ b/task/buildah/0.2/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.2/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.3/README.md
+++ b/task/buildah/0.3/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.3/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.4/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.5/README.md
+++ b/task/buildah/0.5/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.5/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.5/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.6/README.md
+++ b/task/buildah/0.6/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.6/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.6/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.7/README.md
+++ b/task/buildah/0.7/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.7/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.7/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.8/README.md
+++ b/task/buildah/0.8/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.8/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.8/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildah/0.9/README.md
+++ b/task/buildah/0.9/README.md
@@ -10,7 +10,7 @@ to assemble a container image, then pushes that image to a container registry.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.9/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.9/buildah.yaml
 ```
 
 ## Parameters

--- a/task/buildkit-daemonless/0.1/README.md
+++ b/task/buildkit-daemonless/0.1/README.md
@@ -13,7 +13,7 @@ This `buildkit-daemonless` Task is similar to [`buildkit`](../../buildkit) but d
 ## Install
 
 ```console
-$ kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildkit-daemonless/0.1/raw
+$ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildkit-daemonless/0.1/buildkit-daemonless.yaml
 task.tekton.dev/buildkit-daemonless created
 ```
 

--- a/task/buildpacks-phases/0.1/README.md
+++ b/task/buildpacks-phases/0.1/README.md
@@ -12,7 +12,7 @@ See also [`buildpacks`](../buildpacks) for the combined version of this task, wh
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildpacks-phases/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks-phases/0.1/buildpacks-phases.yaml
 ```
 
 > **NOTE:** This task is currently only compatible with Tekton **v0.11.0** and above, and CNB Platform API 0.3 (lifecycle v0.7.0 and above). For previous Platform API versions, [see below](#previous-platform-api-versions).

--- a/task/buildpacks/0.1/README.md
+++ b/task/buildpacks/0.1/README.md
@@ -9,7 +9,7 @@ See also [`buildpacks-phases`](../../buildpacks-phases) for the deconstructed ve
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildpacks/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks/0.1/buildpacks.yaml
 ```
 
 > **NOTE:** This task is currently only compatible with Tekton **v0.11.0** and above, and CNB Platform API 0.3 (lifecycle v0.7.0 and above). For previous Platform API versions, [see below](#previous-platform-api-versions).

--- a/task/buildpacks/0.2/README.md
+++ b/task/buildpacks/0.2/README.md
@@ -9,7 +9,7 @@ See also [`buildpacks-phases`](../../buildpacks-phases) for the deconstructed ve
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/buildpacks/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks/0.2/buildpacks.yaml
 ```
 
 > **NOTE:** This task is currently only compatible with Tekton **v0.11.0** and above, and CNB Platform API 0.3 (lifecycle v0.7.0 and above). For previous Platform API versions, [see below](#previous-platform-api-versions).

--- a/task/check-make/0.1/README.md
+++ b/task/check-make/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to provide static analysis on YAML files mounted usin
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/check-make/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/check-make/0.1/check-make.yaml
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/codecov/0.1/README.md
+++ b/task/codecov/0.1/README.md
@@ -5,7 +5,7 @@ Upload your code coverage to [codecov.io](https://codecov.io)
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/codecov/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/codecov/0.1/codecov.yaml
 ```
 
 ## Parameters

--- a/task/codecov/0.2/README.md
+++ b/task/codecov/0.2/README.md
@@ -5,7 +5,7 @@ Upload your code coverage to [codecov.io](https://codecov.io)
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/codecov/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/codecov/0.1/codecov.yaml
 ```
 
 ## Parameters

--- a/task/conftest/0.1/README.md
+++ b/task/conftest/0.1/README.md
@@ -8,7 +8,7 @@ your Tekton pipelines. Conftest is a tool for testing configuration files using 
 In order to use Conftest with Tekton you need to first install the task.
 
 ```console
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/conftest/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/conftest/0.1/conftest.yaml
 ```
 
 ## Platforms

--- a/task/conftest/0.2/README.md
+++ b/task/conftest/0.2/README.md
@@ -8,7 +8,7 @@ your Tekton pipelines. Conftest is a tool for testing configuration files using 
 In order to use Conftest with Tekton you need to first install the task.
 
 ```console
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/conftest/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/conftest/0.2/conftest.yaml
 ```
 
 ## Platforms

--- a/task/create-github-release/0.1/README.md
+++ b/task/create-github-release/0.1/README.md
@@ -13,7 +13,7 @@ Task can also be used to upload multiple `assets` including `binaries` of the re
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/create-github-release/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/create-github-release/0.1/create-github-release.yaml
 ```
 
 ## Parameters

--- a/task/create-gitlab-release/0.1/README.md
+++ b/task/create-gitlab-release/0.1/README.md
@@ -13,7 +13,7 @@ Task can also be used to upload `assets` including `binaries` of the released ve
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/create-gitlab-release/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/create-gitlab-release/0.1/create-gitlab-release.yaml
 ```
 
 ## Parameters

--- a/task/curl/0.1/README.md
+++ b/task/curl/0.1/README.md
@@ -6,7 +6,7 @@ This task performs curl operation to transfer data from internet .
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/curl/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/curl/0.1/curl.yaml
 ```
 
 ## Parameters

--- a/task/datree/0.1/README.md
+++ b/task/datree/0.1/README.md
@@ -8,7 +8,7 @@ Task can also be customised with the various parameters that are passed as flags
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/datree/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/datree/0.1/datree.yaml
 ```
 
 ## Parameters

--- a/task/docker-build/0.1/README.md
+++ b/task/docker-build/0.1/README.md
@@ -7,7 +7,7 @@ The Docker Build task builds source into a container image using [Docker](https:
 ### Install the Docker Build Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/docker-build/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/docker-build/0.1/docker-build.yaml
 ```
 
 ### Parameters

--- a/task/dockerslim-build/0.1/README.md
+++ b/task/dockerslim-build/0.1/README.md
@@ -7,7 +7,7 @@ The Dockerslim Build task builds source into a container image using [Dockerslim
 ### Install the Docker Build Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/dockerslim-build/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/dockerslim-build/0.1/dockerslim-build.yaml
 ```
 
 ### Parameters

--- a/task/flake8/0.1/README.md
+++ b/task/flake8/0.1/README.md
@@ -11,7 +11,7 @@ The task provides linting based on [flake8](https://pypi.org/project/flake8/) fo
 ### Install the flake8 task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/flake8/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/flake8/0.1/flake8.yaml
 ```
 
 ## Parameters

--- a/task/gcloud/0.1/README.md
+++ b/task/gcloud/0.1/README.md
@@ -5,7 +5,7 @@ This task performs operations on Google Cloud Platform resources using `gcloud`.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gcloud/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gcloud/0.1/gcloud.yaml
 ```
 
 ## Parameters

--- a/task/gcloud/0.2/README.md
+++ b/task/gcloud/0.2/README.md
@@ -5,7 +5,7 @@ This task performs operations on Google Cloud Platform resources using `gcloud`.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gcloud/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gcloud/0.2/gcloud.yaml
 ```
 
 ## Parameters

--- a/task/gcloud/0.3/README.md
+++ b/task/gcloud/0.3/README.md
@@ -11,7 +11,7 @@ For details on the underlying image, see https://github.com/GoogleCloudPlatform/
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gcloud/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gcloud/0.3/gcloud.yaml
 ```
 
 ## Parameters

--- a/task/generate-build-id/0.1/README.md
+++ b/task/generate-build-id/0.1/README.md
@@ -5,7 +5,7 @@ Given a base version, this task generates a unique build id by appending the bas
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/generate-build-id/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/generate-build-id/0.1/generate-build-id.yaml
 ```
 
 ## Parameters

--- a/task/git-version/0.1/README.md
+++ b/task/git-version/0.1/README.md
@@ -5,7 +5,7 @@ The `git-version` task let you generate a version from git history using `https:
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-version/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-version/0.1/git-version.yaml
 ```
 
 ## Workspaces

--- a/task/gitea-set-status/0.1/README.md
+++ b/task/gitea-set-status/0.1/README.md
@@ -25,7 +25,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gitea-set-status/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitea-set-status/0.1/gitea-set-status.yaml
 ```
 
 ### Parameters

--- a/task/github-add-comment/0.1/README.md
+++ b/task/github-add-comment/0.1/README.md
@@ -6,7 +6,7 @@ issue.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-comment/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-comment/0.1/github-add-comment.yaml
 ```
 
 ### Parameters

--- a/task/github-add-comment/0.2/README.md
+++ b/task/github-add-comment/0.2/README.md
@@ -6,7 +6,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-comment/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-comment/0.2/github-add-comment.yaml
 ```
 
 ## Secrets

--- a/task/github-add-comment/0.3/README.md
+++ b/task/github-add-comment/0.3/README.md
@@ -16,7 +16,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-comment/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-comment/0.3/github-add-comment.yaml
 ```
 
 ## Secrets

--- a/task/github-add-comment/0.4/README.md
+++ b/task/github-add-comment/0.4/README.md
@@ -11,7 +11,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-comment/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-comment/0.4/github-add-comment.yaml
 ```
 
 ## Secrets

--- a/task/github-add-comment/0.5/README.md
+++ b/task/github-add-comment/0.5/README.md
@@ -11,7 +11,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-comment/0.5/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-comment/0.5/github-add-comment.yaml
 ```
 
 ## Secrets

--- a/task/github-add-comment/0.6/README.md
+++ b/task/github-add-comment/0.6/README.md
@@ -6,7 +6,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-comment/0.6/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-comment/0.6/github-add-comment.yaml
 ```
 
 ## Secrets

--- a/task/github-add-comment/0.7/README.md
+++ b/task/github-add-comment/0.7/README.md
@@ -6,7 +6,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-comment/0.7/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-comment/0.7/github-add-comment.yaml
 ```
 
 ## Secrets

--- a/task/github-add-gist/0.1/README.md
+++ b/task/github-add-gist/0.1/README.md
@@ -6,7 +6,7 @@ and outputs the raw url as the result.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-gist/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-gist/0.1/github-add-gist.yaml
 ```
 
 ## Secrets

--- a/task/github-add-gist/0.2/README.md
+++ b/task/github-add-gist/0.2/README.md
@@ -6,7 +6,7 @@ and outputs the raw url as the result.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-gist/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-gist/0.2/github-add-gist.yaml
 ```
 
 ## Secrets

--- a/task/github-add-labels/0.1/README.md
+++ b/task/github-add-labels/0.1/README.md
@@ -6,7 +6,7 @@ This `task` can be used to add labels to a github `pull request` or an `issue`.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-add-labels/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-add-labels/0.1/github-add-labels.yaml
 ```
 
 ## Parameters

--- a/task/github-app-token/0.1/README.md
+++ b/task/github-app-token/0.1/README.md
@@ -27,7 +27,7 @@ Refer [this](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-c
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-app-token/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-app-token/0.1/github-app-token.yaml
 ```
 
 ## Platforms

--- a/task/github-app-token/0.2/README.md
+++ b/task/github-app-token/0.2/README.md
@@ -29,7 +29,7 @@ Refer [this](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-c
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-app-token/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-app-token/0.2/github-app-token.yaml
 ```
 
 ## Platforms

--- a/task/github-close-issue/0.1/README.md
+++ b/task/github-close-issue/0.1/README.md
@@ -6,7 +6,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-close-issue/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-close-issue/0.1/github-close-issue.yaml
 ```
 
 ## Secrets

--- a/task/github-close-issue/0.2/README.md
+++ b/task/github-close-issue/0.2/README.md
@@ -7,7 +7,7 @@ issue.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-close-issue/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-close-issue/0.2/github-close-issue.yaml
 ```
 
 ## Secrets

--- a/task/github-create-deployment-status/0.1/README.md
+++ b/task/github-create-deployment-status/0.1/README.md
@@ -7,7 +7,7 @@ See GitHub's deployment API on [Create a deployment status](https://docs.github.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-create-deployment-status/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-create-deployment-status/0.1/github-create-deployment-status.yaml
 ```
 
 ### Secrets

--- a/task/github-create-deployment/0.1/README.md
+++ b/task/github-create-deployment/0.1/README.md
@@ -7,7 +7,7 @@ See GitHub's deployment API on [creating a deployment](https://developer.github.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-create-deployment/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-create-deployment/0.1/github-create-deployment.yaml
 ```
 
 ### Secrets

--- a/task/github-create-deployment/0.2/README.md
+++ b/task/github-create-deployment/0.2/README.md
@@ -7,7 +7,7 @@ See GitHub's deployment API on [Create a deployment](https://docs.github.com/res
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-create-deployment/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-create-deployment/0.2/github-create-deployment.yaml
 ```
 
 ### Secrets

--- a/task/github-open-pr/0.1/README.md
+++ b/task/github-open-pr/0.1/README.md
@@ -22,7 +22,7 @@ to open pull requests on Github. It is able to fill in a title and body of the p
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-open-pr/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-open-pr/0.1/github-open-pr.yaml
 ```
 
 ### Parameters

--- a/task/github-open-pr/0.2/README.md
+++ b/task/github-open-pr/0.2/README.md
@@ -22,7 +22,7 @@ to open pull requests on Github. It is able to fill in a title and body of the p
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-open-pr/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-open-pr/0.2/github-open-pr.yaml
 ```
 
 ### Parameters

--- a/task/github-request-reviewers/0.1/README.md
+++ b/task/github-request-reviewers/0.1/README.md
@@ -9,7 +9,7 @@ The `github-request-reviewers` task lets one request reviewers on a pull request
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-request-reviewers/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-request-reviewers/0.1/github-request-reviewers.yaml
 ```
 
 ## Secrets

--- a/task/github-set-status/0.1/README.md
+++ b/task/github-set-status/0.1/README.md
@@ -25,7 +25,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-set-status/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-set-status/0.1/github-set-status.yaml
 ```
 
 ### Parameters

--- a/task/github-set-status/0.2/README.md
+++ b/task/github-set-status/0.2/README.md
@@ -25,7 +25,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-set-status/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-set-status/0.2/github-set-status.yaml
 ```
 
 ### Parameters

--- a/task/github-set-status/0.3/README.md
+++ b/task/github-set-status/0.3/README.md
@@ -25,7 +25,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-set-status/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-set-status/0.3/github-set-status.yaml
 ```
 
 ### Parameters

--- a/task/github-set-status/0.4/README.md
+++ b/task/github-set-status/0.4/README.md
@@ -25,7 +25,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/github-set-status/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/github-set-status/0.3/github-set-status.yaml
 ```
 
 ### Parameters

--- a/task/gitlab-add-label/0.1/README.md
+++ b/task/gitlab-add-label/0.1/README.md
@@ -34,7 +34,7 @@ stringData:
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gitlab-add-label/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitlab-add-label/0.1/gitlab-add-label.yaml
 ```
 
 ### Parameters

--- a/task/gitlab-set-status/0.1/README.md
+++ b/task/gitlab-set-status/0.1/README.md
@@ -14,7 +14,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gitlab-set-status/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitlab-set-status/0.1/gitlab-set-status.yaml
 ```
 
 ### Parameters

--- a/task/gitlab-set-status/0.2/README.md
+++ b/task/gitlab-set-status/0.2/README.md
@@ -14,7 +14,7 @@ informations about the CI statuses or a direct link to the full log.
 ### Install the Task
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gitlab-set-status/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitlab-set-status/0.2/gitlab-set-status.yaml
 ```
 
 ### Parameters

--- a/task/gitleaks/0.1/README.md
+++ b/task/gitleaks/0.1/README.md
@@ -5,13 +5,13 @@ This task makes it possible to use [gitleaks](https://github.com/zricethezav/git
 
 ## Installation
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gitleaks/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gitleaks/0.1/gitleaks.yaml
 ```
 
 ## Pre-requisite
 Install git-clone task from catalog
 ```
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.3/raw
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
 ```
 
 

--- a/task/gke-deploy/0.1/README.md
+++ b/task/gke-deploy/0.1/README.md
@@ -5,7 +5,7 @@ This Task deploys an application to a Google Kubernetes Engine cluster using [`g
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gke-deploy/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gke-deploy/0.1/gke-deploy.yaml
 ```
 
 ## Parameters

--- a/task/gke-deploy/0.1/samples/build-push-gke-deploy-example.md
+++ b/task/gke-deploy/0.1/samples/build-push-gke-deploy-example.md
@@ -108,7 +108,7 @@ Install the Tekton Pipelines CLI to view your logs by following the instructions
 4. Install the `build-push-gke-deploy` Pipeline.
 
   ```bash
-  kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/gke-deploy/raw
+  kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gke-deploy/
   ```
 
 5. Create the `PipelineRun` config to run your Pipeline.

--- a/task/gogit/0.1/README.md
+++ b/task/gogit/0.1/README.md
@@ -9,7 +9,7 @@ See more details from https://github.com/linuxsuren/gogit
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gogit/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gogit/0.1/gogit.yaml
 ```
 
 ## Platforms

--- a/task/golang-build/0.1/README.md
+++ b/task/golang-build/0.1/README.md
@@ -5,7 +5,7 @@ This Task is Golang task to build Go projects.
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golang-build/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.1/golang-build.yaml
 
 ```
 

--- a/task/golang-build/0.2/README.md
+++ b/task/golang-build/0.2/README.md
@@ -5,7 +5,7 @@ This Task is Golang task to build Go projects.
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golang-build/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.2/golang-build.yaml
 
 ```
 

--- a/task/golang-build/0.3/README.md
+++ b/task/golang-build/0.3/README.md
@@ -12,7 +12,7 @@ This Task is Golang task to build Go projects.
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golang-build/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.3/golang-build.yaml
 
 ```
 

--- a/task/golang-fuzz/0.1/README.md
+++ b/task/golang-fuzz/0.1/README.md
@@ -5,7 +5,7 @@ This task is a Golang task to fuzz Go projects
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golang-test/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-test/0.1/golang-test.yaml
 ```
 
 ### Parameters

--- a/task/golang-test/0.1/README.md
+++ b/task/golang-test/0.1/README.md
@@ -5,7 +5,7 @@ This task is a Golang task to test Go projects.
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golang-test/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-test/0.1/golang-test.yaml
 ```
 
 ### Parameters

--- a/task/golang-test/0.2/README.md
+++ b/task/golang-test/0.2/README.md
@@ -12,7 +12,7 @@ This task is a Golang task to test Go projects.
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golang-test/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-test/0.2/golang-test.yaml
 ```
 
 ### Parameters

--- a/task/golangci-lint/0.1/README.md
+++ b/task/golangci-lint/0.1/README.md
@@ -5,7 +5,7 @@ This Task is a Golang task to validate Go projects.
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golangci-lint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golangci-lint/0.1/golangci-lint.yaml
 
 ```
 

--- a/task/golangci-lint/0.2/README.md
+++ b/task/golangci-lint/0.2/README.md
@@ -5,7 +5,7 @@ This Task is a Golang task to validate Go projects.
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/golangci-lint/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golangci-lint/0.2/golangci-lint.yaml
 
 ```
 

--- a/task/goreleaser/0.1/README.md
+++ b/task/goreleaser/0.1/README.md
@@ -5,7 +5,7 @@
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/goreleaser/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/goreleaser/0.1/goreleaser.yaml
 ```
 
 ## Parameters

--- a/task/goreleaser/0.2/README.md
+++ b/task/goreleaser/0.2/README.md
@@ -5,7 +5,7 @@
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/goreleaser/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/goreleaser/0.2/goreleaser.yaml
 ```
 
 ## Parameters

--- a/task/gradle/0.1/README.md
+++ b/task/gradle/0.1/README.md
@@ -5,7 +5,7 @@ This Task can be used to run a Gradle build on a gradle project.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gradle/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gradle/0.1/gradle.yaml
 ```
 
 ## Parameters

--- a/task/gradle/0.2/README.md
+++ b/task/gradle/0.2/README.md
@@ -5,7 +5,7 @@ This Task can be used to run a Gradle build on a gradle project.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gradle/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gradle/0.2/gradle.yaml
 ```
 
 ## Parameters

--- a/task/gradle/0.3/README.md
+++ b/task/gradle/0.3/README.md
@@ -5,7 +5,7 @@ This Task can be used to run a Gradle build on a gradle project.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gradle/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gradle/0.3/gradle.yaml
 ```
 
 ## Parameters

--- a/task/gradle/0.4/README.md
+++ b/task/gradle/0.4/README.md
@@ -6,7 +6,7 @@ If the project contains a gradle wrapper, the wrapper will be invoked instead of
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/gradle/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/gradle/0.4/gradle.yaml
 ```
 
 ## Parameters

--- a/task/hadolint/0.1/README.md
+++ b/task/hadolint/0.1/README.md
@@ -8,13 +8,13 @@ It stands on the shoulders of ShellCheck to lint the Bash code inside `RUN` inst
 
 ## Install the Task
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/hadolint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/hadolint/0.1/hadolint.yaml
 ```
 
 ## Pre-requisite
 Install git-clone task from catalog
 ```
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.3/raw
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
 ```
 
 ## Workspaces

--- a/task/helm-conftest/0.1/README.md
+++ b/task/helm-conftest/0.1/README.md
@@ -8,7 +8,7 @@ your Tekton pipelines. Conftest is a tool for testing configuration files using 
 Conftest also has a Helm plugin, which redners the Helm chart before applying the policy. For that task use:
 
 ```console
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-conftest/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-conftest/0.1/helm-conftest.yaml
 ```
 
 ## Helm usage

--- a/task/helm-upgrade-from-repo/0.1/README.md
+++ b/task/helm-upgrade-from-repo/0.1/README.md
@@ -11,7 +11,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from repo
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-repo/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-upgrade-from-repo/0.1/helm-upgrade-from-repo.yaml
 ```
 
 #### Parameters

--- a/task/helm-upgrade-from-repo/0.2/README.md
+++ b/task/helm-upgrade-from-repo/0.2/README.md
@@ -11,7 +11,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from repo
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-repo/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-upgrade-from-repo/0.2/helm-upgrade-from-repo.yaml
 ```
 
 #### Parameters

--- a/task/helm-upgrade-from-repo/0.3/README.md
+++ b/task/helm-upgrade-from-repo/0.3/README.md
@@ -11,7 +11,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from repo
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-repo/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-upgrade-from-repo/0.3/helm-upgrade-from-repo.yaml
 ```
 
 #### Parameters

--- a/task/helm-upgrade-from-source/0.1/README.md
+++ b/task/helm-upgrade-from-source/0.1/README.md
@@ -7,7 +7,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from source code
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-source/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-upgrade-from-source/0.1/helm-upgrade-from-source.yaml
 ```
 
 #### Parameters

--- a/task/helm-upgrade-from-source/0.2/README.md
+++ b/task/helm-upgrade-from-source/0.2/README.md
@@ -7,7 +7,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from source code
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-source/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-upgrade-from-source/0.2/helm-upgrade-from-source.yaml
 ```
 
 #### Parameters

--- a/task/helm-upgrade-from-source/0.3/README.md
+++ b/task/helm-upgrade-from-source/0.3/README.md
@@ -7,7 +7,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from source code
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-source/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-upgrade-from-source/0.3/helm-upgrade-from-source.yaml
 ```
 
 #### Parameters

--- a/task/helm-upgrade-from-source/0.4/README.md
+++ b/task/helm-upgrade-from-source/0.4/README.md
@@ -7,7 +7,7 @@ These tasks will install / upgrade a helm chart into your Kubernetes / OpenShift
 ### helm install / upgrade from source code
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/helm-upgrade-from-source/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/helm-upgrade-from-source/0.3/helm-upgrade-from-source.yaml
 ```
 
 #### Parameters

--- a/task/ibmcloud/0.1/README.md
+++ b/task/ibmcloud/0.1/README.md
@@ -5,7 +5,7 @@ This task performs operations on IBM Cloud using the `ibmcloud`
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/ibmcloud/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ibmcloud/0.1/ibmcloud.yaml
 ```
 
 ## Parameters

--- a/task/istio-canary-release/0.1/README.md
+++ b/task/istio-canary-release/0.1/README.md
@@ -13,13 +13,13 @@ For more details about canary release please refer [here](https://martinfowler.c
 1. For Application Manifests deployment we can use the existing `kubenetes-actions` task from the catalog
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kubernetes-actions/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubernetes-actions/0.1/kubernetes-actions.yaml
 ```
 
 2. For Istio Services
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/istio-canary-release/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/istio-canary-release/0.1/istio-canary-release.yaml
 ```
 
 ## Installing the ClusterRoleBinding

--- a/task/jenkins/0.1/README.md
+++ b/task/jenkins/0.1/README.md
@@ -7,7 +7,7 @@ More details on Remote Access API can be found [here](https://www.jenkins.io/doc
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jenkins/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jenkins/0.1/jenkins.yaml
 ```
 
 ## Parameters

--- a/task/jib-gradle/0.1/README.md
+++ b/task/jib-gradle/0.1/README.md
@@ -7,7 +7,7 @@ Jib works with [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-gradle/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-gradle/0.1/jib-gradle.yaml
 ```
 
 

--- a/task/jib-gradle/0.2/README.md
+++ b/task/jib-gradle/0.2/README.md
@@ -7,7 +7,7 @@ Jib works with [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-gradle/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-gradle/0.2/jib-gradle.yaml
 ```
 
 ## Parameters

--- a/task/jib-gradle/0.3/README.md
+++ b/task/jib-gradle/0.3/README.md
@@ -7,7 +7,7 @@ Jib works with [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-gradle/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-gradle/0.3/jib-gradle.yaml
 ```
 
 ## Parameters

--- a/task/jib-gradle/0.4/README.md
+++ b/task/jib-gradle/0.4/README.md
@@ -7,7 +7,7 @@ Jib works with [Gradle](https://github.com/GoogleContainerTools/jib/tree/master/
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-gradle/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-gradle/0.4/jib-gradle.yaml
 ```
 
 ## Parameters

--- a/task/jib-maven/0.1/README.md
+++ b/task/jib-maven/0.1/README.md
@@ -7,7 +7,7 @@ Jib works with [Maven](https://github.com/GoogleContainerTools/jib/tree/master/j
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-maven/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-maven/0.1/jib-maven.yaml
 ```
 
 ## Parameters

--- a/task/jib-maven/0.2/README.md
+++ b/task/jib-maven/0.2/README.md
@@ -7,7 +7,7 @@ Jib works with [Maven](https://github.com/GoogleContainerTools/jib/tree/master/j
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-maven/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-maven/0.2/jib-maven.yaml
 ```
 
 ## Parameters

--- a/task/jib-maven/0.3/README.md
+++ b/task/jib-maven/0.3/README.md
@@ -7,7 +7,7 @@ Jib works with [Maven](https://github.com/GoogleContainerTools/jib/tree/master/j
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-maven/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-maven/0.3/jib-maven.yaml
 ```
 
 ## Parameters

--- a/task/jib-maven/0.4/README.md
+++ b/task/jib-maven/0.4/README.md
@@ -7,7 +7,7 @@ Jib works with [Maven](https://github.com/GoogleContainerTools/jib/tree/master/j
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-maven/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-maven/0.4/jib-maven.yaml
 ```
 
 ## Parameters

--- a/task/jib-maven/0.5/README.md
+++ b/task/jib-maven/0.5/README.md
@@ -7,7 +7,7 @@ Jib works with [Maven](https://github.com/GoogleContainerTools/jib/tree/master/j
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jib-maven/0.5/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jib-maven/0.5/jib-maven.yaml
 ```
 
 ## Parameters

--- a/task/jira-get-ticket-status/0.1/README.md
+++ b/task/jira-get-ticket-status/0.1/README.md
@@ -5,7 +5,7 @@ This task helps you to get the current status of a Jira ticket.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jira-get-ticket-status/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jira-get-ticket-status/0.1/jira-get-ticket-status.yaml
 ```
 
 ## Parameters

--- a/task/jq/0.1/README.md
+++ b/task/jq/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to execute a given JQ script and expose its result. I
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jq/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jq/0.1/jq.yaml
 ```
 
 ## Parameters

--- a/task/jumpstarter-get-lease/0.1/README.md
+++ b/task/jumpstarter-get-lease/0.1/README.md
@@ -5,7 +5,7 @@ This Tekton task acquires a lease from the [Jumpstarter](https://github.com/jump
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jumpstarter-get-lease/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jumpstarter-get-lease/0.1/jumpstarter-get-lease.yaml
 ```
 
 ## Parameters

--- a/task/jumpstarter-release-lease/0.1/README.md
+++ b/task/jumpstarter-release-lease/0.1/README.md
@@ -5,7 +5,7 @@ This Tekton task releases an existing lease in the [Jumpstarter](https://github.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jumpstarter-release-lease/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jumpstarter-release-lease/0.1/jumpstarter-release-lease.yaml
 ```
 
 ## Parameters

--- a/task/jumpstarter-run-cmd/0.1/README.md
+++ b/task/jumpstarter-run-cmd/0.1/README.md
@@ -5,7 +5,7 @@ This Tekton task runs one or more commands on a remote device using the [Jumpsta
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/jumpstarter-run-command/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/jumpstarter-run-command/0.1/jumpstarter-run-command.yaml
 ```
 
 ## Parameters

--- a/task/kamel-run/0.1/README.md
+++ b/task/kamel-run/0.1/README.md
@@ -7,7 +7,7 @@ If you have installed Camel K operator, you can configure the `kamel-run` task t
 ## Install the Task
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kamel-run/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kamel-run/0.1/kamel-run.yaml
 ```
 
 ## Parameters

--- a/task/kaniko/0.1/README.md
+++ b/task/kaniko/0.1/README.md
@@ -15,7 +15,7 @@ makes it a perfect tool to be part of Tekton.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.1/kaniko.yaml
 ```
 
 ## Parameters

--- a/task/kaniko/0.2/README.md
+++ b/task/kaniko/0.2/README.md
@@ -15,7 +15,7 @@ makes it a perfect tool to be part of Tekton.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.2/kaniko.yaml
 ```
 
 ## Parameters

--- a/task/kaniko/0.3/README.md
+++ b/task/kaniko/0.3/README.md
@@ -22,7 +22,7 @@ makes it a perfect tool to be part of Tekton.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.3/kaniko.yaml
 ```
 
 ## Parameters

--- a/task/kaniko/0.4/README.md
+++ b/task/kaniko/0.4/README.md
@@ -22,7 +22,7 @@ makes it a perfect tool to be part of Tekton.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.4/kaniko.yaml
 ```
 
 ## Parameters

--- a/task/kaniko/0.5/README.md
+++ b/task/kaniko/0.5/README.md
@@ -19,7 +19,7 @@ makes it a perfect tool to be part of Tekton.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.5/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.5/kaniko.yaml
 ```
 
 ## Parameters

--- a/task/kaniko/0.6/README.md
+++ b/task/kaniko/0.6/README.md
@@ -23,7 +23,7 @@ Both these results are needed in order for Chains to sign the image. See Chains 
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.6/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.6/kaniko.yaml
 ```
 
 ## Parameters

--- a/task/kaniko/0.7/README.md
+++ b/task/kaniko/0.7/README.md
@@ -23,7 +23,7 @@ Both these results are needed in order for Chains to sign the image. See Chains 
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.7/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.7/kaniko.yaml
 ```
 
 ## Parameters

--- a/task/kn-apply/0.1/README.md
+++ b/task/kn-apply/0.1/README.md
@@ -6,7 +6,7 @@ This task deploys a given image to a Knative Service using
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kn-apply/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.1/kn-apply.yaml
 ```
 
 ## Parameters

--- a/task/kn-apply/0.2/README.md
+++ b/task/kn-apply/0.2/README.md
@@ -6,7 +6,7 @@ This task deploys a given image to a Knative Service using
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kn-apply/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn-apply/0.2/kn-apply.yaml
 ```
 
 ## Parameters

--- a/task/kn/0.1/README.md
+++ b/task/kn/0.1/README.md
@@ -6,7 +6,7 @@ This Task performs operations on Knative resources (services, revisions, routes)
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kn/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.1/kn.yaml
 ```
 
 ## Parameters

--- a/task/kn/0.2/README.md
+++ b/task/kn/0.2/README.md
@@ -6,7 +6,7 @@ This Task performs operations on Knative resources (services, revisions, routes)
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kn/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/kn.yaml
 ```
 
 ## Parameters

--- a/task/kn/0.2/knative-dockerfile-deploy/README.md
+++ b/task/kn/0.2/knative-dockerfile-deploy/README.md
@@ -82,17 +82,17 @@ kubectl create -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/k
 
 4 - Install buildah task from tektoncd/catalog
 ```bash
-https://api.hub.tekton.dev/v1/resource/tekton/task/buildah/0.4/buildah.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildah/0.4/buildah.yaml
 ```
 
 5 - Install the kn task from the tektoncd/catalog
 ```bash
-https://api.hub.tekton.dev/v1/resource/tekton/task/kn/0.2/kn.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/kn/0.2/kn.yaml
 ```
 
 5 - Install the git-clone task from the tektoncd/catalog
 ```bash
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.8/git-clone.yaml
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.8/git-clone.yaml
 ```
 
 ## Pipelines:

--- a/task/ko/0.1/README.md
+++ b/task/ko/0.1/README.md
@@ -6,7 +6,7 @@ This Task builds source into a container image using [ko](https://ko.build/).
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/ko/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ko/0.1/ko.yaml
 ```
 
 ## Parameters

--- a/task/kube-linter/0.1/README.md
+++ b/task/kube-linter/0.1/README.md
@@ -4,13 +4,13 @@ The [KubeLinter](https://github.com/stackrox/kube-linter) tool by StackRox is an
 
 ## Install the Task
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kube-linter/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kube-linter/0.1/kube-linter.yaml
 ```
 
 ## Pre-requisite
 Install git-clone task from catalog
 ```
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.3/raw
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
 ```
 
 ## Workspaces

--- a/task/kubeconfig-creator/0.1/README.md
+++ b/task/kubeconfig-creator/0.1/README.md
@@ -23,7 +23,7 @@ This task provides users variety of ways to authenticate:
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kubeconfig-creator/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml
 ```
 
 ## Workspace

--- a/task/kubeconfig-creator/0.2/README.md
+++ b/task/kubeconfig-creator/0.2/README.md
@@ -23,7 +23,7 @@ This task provides users variety of ways to authenticate:
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kubeconfig-creator/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml
 ```
 
 ## Workspace

--- a/task/kubectl-deploy-pod/0.1/README.md
+++ b/task/kubectl-deploy-pod/0.1/README.md
@@ -6,7 +6,7 @@ This Task deploys (or delete) a Kubernetes resource (pod). It uses
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kubectl-deploy-pod/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubectl-deploy-pod/0.1/kubectl-deploy-pod.yaml
 ```
 
 ## Install ClusterRole

--- a/task/kubernetes-actions/0.1/README.md
+++ b/task/kubernetes-actions/0.1/README.md
@@ -5,7 +5,7 @@ This is a generic task used to perform kubernetes actions such as `kubectl get d
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kubernetes-actions/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubernetes-actions/0.1/kubernetes-actions.yaml
 ```
 
 ## Inputs

--- a/task/kubernetes-actions/0.2/README.md
+++ b/task/kubernetes-actions/0.2/README.md
@@ -5,7 +5,7 @@ This is a generic task used to perform kubernetes actions such as `kubectl get d
 ## Install the task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kubernetes-actions/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubernetes-actions/0.2/kubernetes-actions.yaml
 ```
 
 ## Inputs

--- a/task/kubeval/0.1/README.md
+++ b/task/kubeval/0.1/README.md
@@ -8,7 +8,7 @@ your Tekton pipelines. Kubeval is a tool used for validating Kubernetes configur
 In order to use Kubeval with Tekton you need to first install the task.
 
 ```console
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/kubeval/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/kubeval/0.1/kubeval.yaml
 ```
 
 ## Platforms

--- a/task/makisu/0.1/README.md
+++ b/task/makisu/0.1/README.md
@@ -39,7 +39,7 @@ kubectl --namespace default create secret generic docker-registry-config --from-
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/makisu/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/makisu/0.1/makisu.yaml
 ```
 
 ## Parameters

--- a/task/markdown-lint/0.1/README.md
+++ b/task/markdown-lint/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to provide static analysis on README files mounted us
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/markdown-lint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/markdown-lint/0.1/markdown-lint.yaml
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/maven/0.1/README.md
+++ b/task/maven/0.1/README.md
@@ -5,7 +5,7 @@ This Task can be used to run a Maven goals on a simple maven project.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/maven/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/maven/0.1/maven.yaml
 ```
 
 ## Parameters

--- a/task/maven/0.2/README.md
+++ b/task/maven/0.2/README.md
@@ -5,7 +5,7 @@ This Task can be used to run a Maven goals on a simple maven project or on a mul
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/maven/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/maven/0.2/maven.yaml
 ```
 
 ## Parameters

--- a/task/maven/0.3/README.md
+++ b/task/maven/0.3/README.md
@@ -5,7 +5,7 @@ This Task can be used to run a Maven goals on a simple maven project or on a mul
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/maven/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/maven/0.3/maven.yaml
 ```
 
 ## Parameters

--- a/task/maven/0.4/README.md
+++ b/task/maven/0.4/README.md
@@ -5,7 +5,7 @@ This Task can be used to run a Maven goals on a simple maven project or on a mul
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/maven/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/maven/0.4/maven.yaml
 ```
 
 ## Parameters

--- a/task/mypy-lint/0.1/README.md
+++ b/task/mypy-lint/0.1/README.md
@@ -7,7 +7,7 @@ The following task is used to provide static analysis on python files mounted us
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/mypy-lint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/mypy-lint/0.1/mypy-lint.yaml
 ```
 
 ## Parameters
@@ -27,7 +27,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/mypy-lint/0.2/README.md
+++ b/task/mypy-lint/0.2/README.md
@@ -7,7 +7,7 @@ The following task is used to provide static analysis on python files mounted us
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/mypy-lint/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/mypy-lint/0.2/mypy-lint.yaml
 ```
 
 ## Parameters
@@ -29,7 +29,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/nexus-lifecycle-scan/0.1/README.md
+++ b/task/nexus-lifecycle-scan/0.1/README.md
@@ -17,7 +17,7 @@ Invokes a Nexus Lifecycle scan
 #### Install Task
 
 ```shell
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/nexus-lifecycle-scan/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/nexus-lifecycle-scan/0.1/nexus-lifecycle-scan.yaml
 ```
 
 #### Parameters

--- a/task/npm/0.1/README.md
+++ b/task/npm/0.1/README.md
@@ -5,7 +5,7 @@ This task can be used to run `npm` goals on a source code with the default envir
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/npm/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/npm/0.1/npm.yaml
 ```
 
 ## Parameters
@@ -26,7 +26,7 @@ The Task can be run on `linux/amd64`, `linux/s390x`, and `linux/ppc64le` platfor
 
 ## Usage
 
-1. Apply the [`git-clone`](https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.2/raw) task which will help to clone the repository.
+1. Apply the [`git-clone`](https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.2/git-clone.yaml) task which will help to clone the repository.
 
 2. Apply the sample [run.yaml](https://raw.githubusercontent.com/tektoncd/catalog/main/task/npm/0.1/tests/run.yaml) which will clone the [tektoncd/hub](https://github.com/tektoncd/hub) repo and perform few npm goals:-
    - install dependencies using `npm clean-install`

--- a/task/openshift-client-kubecfg/0.1/README.md
+++ b/task/openshift-client-kubecfg/0.1/README.md
@@ -7,7 +7,7 @@ Openshift-client-kubecfg runs commands against any cluster that is provided to i
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/openshift-client-kubecfg/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/openshift-client-kubecfg/0.1/openshift-client-kubecfg.yaml
 ```
 
 

--- a/task/openshift-client-python/0.1/README.md
+++ b/task/openshift-client-python/0.1/README.md
@@ -11,7 +11,7 @@ The set of possible scripts can be found in the docs [here](https://github.com/o
 
 ## Install the Task
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/openshift-client-python/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/openshift-client-python/0.1/openshift-client-python.yaml
 ```
 
 ## Parameters

--- a/task/openshift-client/0.1/README.md
+++ b/task/openshift-client/0.1/README.md
@@ -7,7 +7,7 @@ Openshift-client runs commands against the cluster where the task run is being e
 
 ## Install the Task
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/openshift-client/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/openshift-client/0.1/openshift-client.yaml
 ```
 
 ## Parameters

--- a/task/openshift-client/0.2/README.md
+++ b/task/openshift-client/0.2/README.md
@@ -14,7 +14,7 @@ Openshift-client runs commands against the cluster provided by the user via opti
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/openshift-client/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/openshift-client/0.2/openshift-client.yaml
 ```
 
 ## Parameters

--- a/task/openshift-install/0.1/README.md
+++ b/task/openshift-install/0.1/README.md
@@ -14,7 +14,7 @@ The following task is used to create the cluster.
 ### **Install the Task**
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/openshift-install/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/openshift-install/0.1/openshift-install.yaml
 ```
 
 ### **Parameters**

--- a/task/openshift-uninstall/0.1/README.md
+++ b/task/openshift-uninstall/0.1/README.md
@@ -13,7 +13,7 @@ Guide to provision a cluster on AWS can be found [here](https://docs.openshift.c
 ### **Install the Task**
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/openshift-uninstall/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/openshift-uninstall/0.1/openshift-uninstall.yaml
 ```
 
 ### **Workspaces**

--- a/task/pluto/0.1/README.md
+++ b/task/pluto/0.1/README.md
@@ -6,7 +6,7 @@ in their code repositories and their helm releases.
 Install `pluto` task:
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pluto/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pluto/0.1/pluto.yaml
 ```
 
 ## Parameters

--- a/task/powershell/0.1/README.md
+++ b/task/powershell/0.1/README.md
@@ -5,7 +5,7 @@ The following task helps you to run powershell commands.
 ### Install powershell
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/powershell/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/powershell/0.1/powershell.yaml
 ```
 
 ## Parameters

--- a/task/pull-request/0.1/README.md
+++ b/task/pull-request/0.1/README.md
@@ -29,7 +29,7 @@ workspace.
 To install the Task:
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pull-request/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pull-request/0.1/pull-request.yaml
 ```
 
 ## Configuring the Tasks

--- a/task/pull-request/0.2/README.md
+++ b/task/pull-request/0.2/README.md
@@ -29,7 +29,7 @@ workspace.
 To install the Task:
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pull-request/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pull-request/0.1/pull-request.yaml
 ```
 
 ## Configuring the Tasks

--- a/task/pylint/0.1/README.md
+++ b/task/pylint/0.1/README.md
@@ -13,7 +13,7 @@ The task provides linting based on [pylint](https://pypi.org/project/pylint/) fo
 ### Install pylint
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pylint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pylint/0.1/pylint.yaml
 ```
 
 ## Parameters

--- a/task/pylint/0.2/README.md
+++ b/task/pylint/0.2/README.md
@@ -10,7 +10,7 @@ The task provides linting based on [pylint](https://pypi.org/project/pylint/) fo
 ### Install the pylint task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pylint/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pylint/0.2/pylint.yaml
 ```
 
 ## Parameters

--- a/task/pylint/0.3/README.md
+++ b/task/pylint/0.3/README.md
@@ -11,7 +11,7 @@ The task provides linting based on [pylint](https://pypi.org/project/pylint/) fo
 ### Install the pylint task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pylint/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pylint/0.3/pylint.yaml
 ```
 
 ## Parameters

--- a/task/pytest/0.1/README.md
+++ b/task/pytest/0.1/README.md
@@ -13,7 +13,7 @@ The task provides test execution based on [pytest](https://pypi.org/project/pyte
 ### Install pytest
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pytest/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pytest/0.1/pytest.yaml
 ```
 
 ## Parameters

--- a/task/pytest/0.2/README.md
+++ b/task/pytest/0.2/README.md
@@ -14,7 +14,7 @@ The task provides test execution based on [pytest](https://pypi.org/project/pyte
 ### Install pytest
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/pytest/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/pytest/0.2/pytest.yaml
 ```
 
 ## Parameters

--- a/task/python-coverage/0.1/README.md
+++ b/task/python-coverage/0.1/README.md
@@ -13,7 +13,7 @@ The task provides code coverage based on [coverage](https://coverage.readthedocs
 ### Install pytest
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/python-coverage/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/python-coverage/0.1/python-coverage.yaml
 ```
 
 ## Parameters

--- a/task/redhat-codeready-dependency-analysis/0.1/README.md
+++ b/task/redhat-codeready-dependency-analysis/0.1/README.md
@@ -1,6 +1,6 @@
 # ⛔️ DEPRECATED
 
-THIS TEKTON TASK IS NOW DEPRECATED. Please consider using the [redhat-dependency-analytics](https://hub.tekton.dev/tekton/task/redhat-dependency-analytics) Tekton Task instead.
+THIS TEKTON TASK IS NOW DEPRECATED. Please consider using the [redhat-dependency-analytics](https://artifacthub.io/packages/tekton-task/tekton-catalog-tasks/redhat-dependency-analytics) Tekton Task instead.
 
 # `redhat-codeready-dependency-analysis`
 
@@ -109,7 +109,7 @@ The link to detailed report will take users to a browser window having similar f
 
 ## Install the Task
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/redhat-codeready-dependency-analysis/0.1/raw -n <NAMESPACE>
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/redhat-codeready-dependency-analysis/0.1/redhat-codeready-dependency-analysis.yaml -n <NAMESPACE>
 ```
 
 ## Platforms

--- a/task/redhat-dependency-analytics/0.1/README.md
+++ b/task/redhat-dependency-analytics/0.1/README.md
@@ -138,7 +138,7 @@ An example PipelineRun and TaskRun are provided in the `samples` directory in or
 
 #### For PipelineRun Example:
 
-1. Deploy the [git-clone](https://hub.tekton.dev/tekton/task/git-clone) Tekton Task to your environment. Refer to the `git-clone` documentation for instructions on setting up the pipeline with the appropriate parameters to align with your GitHub repository.
+1. Deploy the [git-clone](https://artifacthub.io/packages/tekton-task/tekton-catalog-tasks/git-clone) Tekton Task to your environment. Refer to the `git-clone` documentation for instructions on setting up the pipeline with the appropriate parameters to align with your GitHub repository.
 
     **NOTE** that the sample pipeline has been pre-configured to facilitate the cloning of public repositories in a straightforward manner. In this setup, simply providing an HTTPS URL for a public repository is adequate to ensure the functionality of the pipeline.
 

--- a/task/redhat-dependency-analytics/0.2/README.md
+++ b/task/redhat-dependency-analytics/0.2/README.md
@@ -129,7 +129,7 @@ An example PipelineRun and TaskRun are provided in the `samples` directory in or
 
 #### For PipelineRun Example:
 
-1. Deploy the [git-clone](https://hub.tekton.dev/tekton/task/git-clone) Tekton Task to your environment. Refer to the `git-clone` documentation for instructions on setting up the pipeline with the appropriate parameters to align with your GitHub repository.
+1. Deploy the [git-clone](https://artifacthub.io/packages/tekton-task/tekton-catalog-tasks/git-clone) Tekton Task to your environment. Refer to the `git-clone` documentation for instructions on setting up the pipeline with the appropriate parameters to align with your GitHub repository.
 
     **NOTE** that the sample pipeline has been pre-configured to facilitate the cloning of public repositories in a straightforward manner. In this setup, simply providing an HTTPS URL for a public repository is adequate to ensure the functionality of the pipeline.
 

--- a/task/redhat-dependency-analytics/0.3/README.md
+++ b/task/redhat-dependency-analytics/0.3/README.md
@@ -142,7 +142,7 @@ An example PipelineRun and TaskRun are provided in the `samples` directory in or
 
 #### For PipelineRun Example:
 
-1. Deploy the [git-clone](https://hub.tekton.dev/tekton/task/git-clone) Tekton Task to your environment. Refer to the `git-clone` documentation for instructions on setting up the pipeline with the appropriate parameters to align with your GitHub repository.
+1. Deploy the [git-clone](https://artifacthub.io/packages/tekton-task/tekton-catalog-tasks/git-clone) Tekton Task to your environment. Refer to the `git-clone` documentation for instructions on setting up the pipeline with the appropriate parameters to align with your GitHub repository.
 
     **NOTE** that the sample pipeline has been pre-configured to facilitate the cloning of public repositories in a straightforward manner. In this setup, simply providing an HTTPS URL for a public repository is adequate to ensure the functionality of the pipeline.
 

--- a/task/remote-scp/0.1/README.md
+++ b/task/remote-scp/0.1/README.md
@@ -3,7 +3,7 @@ Remote SCP is a simple tool to copy files from a remote local machine to your se
 
 ## Install the Task
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/remote-scp/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/remote-scp/0.1/remote-scp.yaml
 ```
 ## Parameters
 HOST: The server host to which you want to connect. (Required)

--- a/task/remote-ssh-commands/0.1/README.md
+++ b/task/remote-ssh-commands/0.1/README.md
@@ -5,7 +5,7 @@ This task can be used to run shell commands on remote machine and produce the re
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/remote-ssh-commands/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/remote-ssh-commands/0.1/remote-ssh-commands.yaml
 ```
 
 ## Parameters

--- a/task/replace-tokens/0.1/README.md
+++ b/task/replace-tokens/0.1/README.md
@@ -35,7 +35,7 @@ The above same can be done for the `YAML` file also.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/replace-tokens/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/replace-tokens/0.1/replace-tokens.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-deployment-check/3.71/README.md
+++ b/task/rhacs-deployment-check/3.71/README.md
@@ -11,7 +11,7 @@ This task requires an active installation of [Red Hat Advanced Cluster Security 
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-deployment-check/3.71/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-deployment-check/3.71/rhacs-deployment-check.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-deployment-check/4.0/README.md
+++ b/task/rhacs-deployment-check/4.0/README.md
@@ -21,7 +21,7 @@ an authorization token with at least CI privileges.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-deployment-check/4.0/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-deployment-check/4.0/rhacs-deployment-check.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-generic/0.1/README.md
+++ b/task/rhacs-generic/0.1/README.md
@@ -21,7 +21,7 @@ machine-to-machine integration.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-generic/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-generic/0.1/rhacs-generic.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-image-check/3.71/README.md
+++ b/task/rhacs-image-check/3.71/README.md
@@ -11,7 +11,7 @@ This task requires an active installation of [Red Hat Advanced Cluster Security 
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-image-check/3.71/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-image-check/3.71/rhacs-image-check.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-image-check/4.0/README.md
+++ b/task/rhacs-image-check/4.0/README.md
@@ -23,7 +23,7 @@ an authorization token with at least CI privileges.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-image-check/4.0/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-image-check/4.0/rhacs-image-check.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-image-scan/3.71/README.md
+++ b/task/rhacs-image-scan/3.71/README.md
@@ -11,7 +11,7 @@ This task requires an active installation of [Red Hat Advanced Cluster Security 
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-image-scan/3.71/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-image-scan/3.71/rhacs-image-scan.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-image-scan/4.0/README.md
+++ b/task/rhacs-image-scan/4.0/README.md
@@ -23,7 +23,7 @@ authorization token with at least CI privileges.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-image-scan/4.0/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-image-scan/4.0/rhacs-image-scan.yaml
 ```
 
 ## Parameters

--- a/task/rhacs-m2m-authenticate/0.1/README.md
+++ b/task/rhacs-m2m-authenticate/0.1/README.md
@@ -17,7 +17,7 @@ machine-to-machine integration.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rhacs-m2m-authenticate/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rhacs-m2m-authenticate/0.1/rhacs-m2m-authenticate.yaml
 ```
 
 ## Parameters

--- a/task/robot-framework/0.1/README.md
+++ b/task/robot-framework/0.1/README.md
@@ -5,7 +5,7 @@ This task runs [Robot Framework](https://robotframework.org/) tests that are pro
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/robot-framework/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/robot-framework/0.1/robot-framework.yaml
 ```
 
 ## Workspaces

--- a/task/rsync/0.1/README.md
+++ b/task/rsync/0.1/README.md
@@ -5,7 +5,7 @@ This task provides synchronization of files between container and remote host. I
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/rsync/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/rsync/0.1/rsync.yaml
 ```
 
 ## Workspaces

--- a/task/ruby-lint/0.1/README.md
+++ b/task/ruby-lint/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to provide static analysis on YAML files mounted usin
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/ruby-lint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ruby-lint/0.1/ruby-lint.yaml
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/s2i/0.1/README.md
+++ b/task/s2i/0.1/README.md
@@ -11,7 +11,7 @@ source code.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/s2i/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/s2i/0.1/s2i.yaml
 ```
 
 ## Parameters

--- a/task/s2i/0.2/README.md
+++ b/task/s2i/0.2/README.md
@@ -11,7 +11,7 @@ source code.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/s2i/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/s2i/0.2/s2i.yaml
 ```
 
 ## Parameters

--- a/task/s2i/0.3/README.md
+++ b/task/s2i/0.3/README.md
@@ -16,7 +16,7 @@ source code.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/s2i/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/s2i/0.3/s2i.yaml
 ```
 
 ## Parameters

--- a/task/scorecard/0.1/README.md
+++ b/task/scorecard/0.1/README.md
@@ -5,7 +5,7 @@ These tasks provides scorecard results based on the [OSSF Scorecards](https://gi
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/scorecard/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/scorecard/0.1/scorecard.yaml
 ```
 
 ## Parameters

--- a/task/send-to-channel-slack/0.1/README.md
+++ b/task/send-to-channel-slack/0.1/README.md
@@ -13,7 +13,7 @@ The app must join the channel before the message posted by this task run. (invit
 ## Install the Task and create a secret
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/send-to-channel-slack/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/send-to-channel-slack/0.1/send-to-channel-slack.yaml
 ```
 
 Create a secret that has the OAuth token of the bot app.

--- a/task/send-to-microsoft-teams/0.1/README.md
+++ b/task/send-to-microsoft-teams/0.1/README.md
@@ -10,7 +10,7 @@ Create this webhook as described [here](https://docs.microsoft.com/en-us/microso
 ## Install the Task and create a secret
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/send-to-microsoft-teams/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/send-to-microsoft-teams/0.1/send-to-microsoft-teams.yaml
 ```
 
 Create a secret that has the webhook URL in it.

--- a/task/send-to-telegram/0.1/README.md
+++ b/task/send-to-telegram/0.1/README.md
@@ -10,7 +10,7 @@ Create a bot as decribed over [here](https://core.telegram.org/bots).
 ## Install the Task and create a secret
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/send-to-telegram/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/send-to-telegram/0.1/send-to-telegram.yaml
 ```
 
 Create a secret that has bot token.

--- a/task/send-to-webex-room/0.1/README.md
+++ b/task/send-to-webex-room/0.1/README.md
@@ -10,7 +10,7 @@ Create a bot as decribed over [here](https://developer.webex.com/docs/bots).
 ## Install the Task and create a secret
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/send-to-webex-room/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/send-to-webex-room/0.1/send-to-webex-room.yaml
 ```
 
 Create a secret that has the Webex API bot token.

--- a/task/send-to-webhook-discord/0.1/README.md
+++ b/task/send-to-webhook-discord/0.1/README.md
@@ -10,7 +10,7 @@ Follow instructions [here](https://support.discord.com/hc/en-us/articles/2283836
 ## Install the Task and create a secret
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/send-to-webhook-discord/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/send-to-webhook-discord/0.1/send-to-webhook-discord.yaml
 ```
 
 Create a secret that has the generated webhook URL

--- a/task/send-to-webhook-slack/0.1/README.md
+++ b/task/send-to-webhook-slack/0.1/README.md
@@ -11,7 +11,7 @@ Follow instructions [here](https://api.slack.com/messaging/webhooks) to generate
 ## Install the Task and create a secret
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/send-to-webhook-slack/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/send-to-webhook-slack/0.1/send-to-webhook-slack.yaml
 ```
 
 Create a secret that has the generated webhook URL

--- a/task/sendmail/0.1/README.md
+++ b/task/sendmail/0.1/README.md
@@ -5,7 +5,7 @@ This task sends a simple email to receivers via SMTP server
 ## Install the Task and create a secret
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sendmail/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sendmail/0.1/sendmail.yaml
 ```
 
 Create a secret that has the SMTP server information

--- a/task/sendmail/0.2/README.md
+++ b/task/sendmail/0.2/README.md
@@ -5,7 +5,7 @@ This task sends a simple email to receivers via SMTP server
 ## Install the Task and create a secret
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sendmail/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sendmail/0.2/sendmail.yaml
 ```
 
 Create a secret that has the SMTP server information

--- a/task/shellcheck/0.1/README.md
+++ b/task/shellcheck/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to provide static analysis on YAML files mounted usin
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/shellcheck/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/shellcheck/0.1/shellcheck.yaml
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/skopeo-copy/0.1/README.md
+++ b/task/skopeo-copy/0.1/README.md
@@ -39,7 +39,7 @@ This `task` can be used to copy one or more than one images to-and fro various s
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/skopeo-copy/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/skopeo-copy/0.1/skopeo-copy.yaml
 ```
 
 ## Parameters

--- a/task/skopeo-copy/0.2/README.md
+++ b/task/skopeo-copy/0.2/README.md
@@ -39,7 +39,7 @@ This `task` can be used to copy one or more than one images to-and fro various s
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/skopeo-copy/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/skopeo-copy/0.2/skopeo-copy.yaml
 ```
 
 ## Parameters

--- a/task/skopeo-copy/0.3/README.md
+++ b/task/skopeo-copy/0.3/README.md
@@ -39,7 +39,7 @@ This `task` can be used to copy one or more than one images to-and fro various s
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/skopeo-copy/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/skopeo-copy/0.3/skopeo-copy.yaml
 ```
 
 ## Parameters

--- a/task/skopeo-copy/0.4/README.md
+++ b/task/skopeo-copy/0.4/README.md
@@ -39,7 +39,7 @@ This `task` can be used to copy one or more than one images to-and fro various s
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/skopeo-copy/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/skopeo-copy/0.4/skopeo-copy.yaml
 ```
 
 ## Parameters

--- a/task/sonarqube-scanner/0.1/README.md
+++ b/task/sonarqube-scanner/0.1/README.md
@@ -9,7 +9,7 @@ For creating your own `sonar-project.properties` please follow the guide [here](
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-scanner/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sonarqube-scanner/0.1/sonarqube-scanner.yaml
 ```
 
 ## Pre-requisite

--- a/task/sonarqube-scanner/0.2/README.md
+++ b/task/sonarqube-scanner/0.2/README.md
@@ -9,7 +9,7 @@ For creating your own `sonar-project.properties` please follow the guide [here](
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-scanner/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sonarqube-scanner/0.2/sonarqube-scanner.yaml
 ```
 
 ## Pre-requisite
@@ -17,7 +17,7 @@ kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-sc
 Install the `git-clone` task from the catalog
 
 ```
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.5/raw
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.5/git-clone.yaml
 ```
 
 ## Parameters

--- a/task/sonarqube-scanner/0.3/README.md
+++ b/task/sonarqube-scanner/0.3/README.md
@@ -9,7 +9,7 @@ For creating your own `sonar-project.properties` please follow the guide [here](
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-scanner/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sonarqube-scanner/0.3/sonarqube-scanner.yaml
 ```
 
 ## Pre-requisite
@@ -17,7 +17,7 @@ kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-sc
 Install the `git-clone` task from the catalog
 
 ```
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.7/raw
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.7/git-clone.yaml
 ```
 
 ## Parameters

--- a/task/sonarqube-scanner/0.4/README.md
+++ b/task/sonarqube-scanner/0.4/README.md
@@ -9,7 +9,7 @@ For creating your own `sonar-project.properties` please follow the guide [here](
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-scanner/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/sonarqube-scanner/0.4/sonarqube-scanner.yaml
 ```
 
 ## Pre-requisite
@@ -17,7 +17,7 @@ kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/sonarqube-sc
 Install the `git-clone` task from the catalog
 
 ```
-https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.7/raw
+https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.7/git-clone.yaml
 ```
 
 ## Parameters

--- a/task/stackrox-image-check/0.1/README.md
+++ b/task/stackrox-image-check/0.1/README.md
@@ -9,7 +9,7 @@ This task requires an active installation of [Red Hat Advanced Cluster Security 
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/stackrox-image-scan/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/stackrox-image-scan/0.1/stackrox-image-scan.yaml
 ```
 
 ## Parameters

--- a/task/stackrox-image-scan/0.1/README.md
+++ b/task/stackrox-image-scan/0.1/README.md
@@ -9,7 +9,7 @@ This task requires an active installation of [Red Hat Advanced Cluster Security 
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/stackrox-image-scan/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/stackrox-image-scan/0.1/stackrox-image-scan.yaml
 ```
 
 ## Parameters

--- a/task/tekton-catalog-publish/0.1/README.md
+++ b/task/tekton-catalog-publish/0.1/README.md
@@ -11,7 +11,7 @@ in `tkn` starting with version v0.18.0.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/tekton-catalog-publish/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
 ```
 
 ## Parameters

--- a/task/tekton-catalog-publish/0.2/README.md
+++ b/task/tekton-catalog-publish/0.2/README.md
@@ -11,7 +11,7 @@ in `tkn` starting with version v0.18.0.
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/tekton-catalog-publish/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tekton-catalog-publish/0.1/tekton-catalog-publish.yaml
 ```
 
 ## Parameters

--- a/task/tekton-operator-install/0.1/README.md
+++ b/task/tekton-operator-install/0.1/README.md
@@ -5,7 +5,7 @@ This task can be used to install Tekton pipelines and also it's components using
 ## Install the Task
 
 ```shell
-kubectl apply --filename https://api.hub.tekton.dev/v1/resource/tekton/task/tekton-operator-install/0.1/raw
+kubectl apply --filename https://raw.githubusercontent.com/tektoncd/catalog/main/task/tekton-operator-install/0.1/tekton-operator-install.yaml
 ```
 
 ## Parameters

--- a/task/terraform-cli/0.1/README.md
+++ b/task/terraform-cli/0.1/README.md
@@ -8,7 +8,7 @@
 
 Install `terraform-cli` task for kubernetes 1.6+:
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/terraform-cli/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/terraform-cli/0.1/terraform-cli.yaml
 ```
 This task currently works only on kubernetes 1.6+ support for a task that works on older versions of kubernetes will be added soon.
 

--- a/task/tkn/0.1/README.md
+++ b/task/tkn/0.1/README.md
@@ -6,7 +6,7 @@ This task performs operations on Tekton resources using
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.1/tkn.yaml
 ```
 
 ## Parameters

--- a/task/tkn/0.2/README.md
+++ b/task/tkn/0.2/README.md
@@ -6,7 +6,7 @@ This task performs operations on Tekton resources using
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.2/tkn.yaml
 ```
 
 ## Parameters

--- a/task/tkn/0.3/README.md
+++ b/task/tkn/0.3/README.md
@@ -6,7 +6,7 @@ This task performs operations on Tekton resources using
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.3/tkn.yaml
 ```
 
 ## Parameters

--- a/task/tkn/0.4/README.md
+++ b/task/tkn/0.4/README.md
@@ -6,7 +6,7 @@ This task performs operations on Tekton resources using
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.4/tkn.yaml
 ```
 
 ## Parameters

--- a/task/tkn/0.5/README.md
+++ b/task/tkn/0.5/README.md
@@ -6,7 +6,7 @@ This task performs operations on Tekton resources using
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/tkn/0.4/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/tkn/0.4/tkn.yaml
 ```
 
 ## Parameters

--- a/task/trigger-jenkins-job/0.1/README.md
+++ b/task/trigger-jenkins-job/0.1/README.md
@@ -7,7 +7,7 @@ More details on Remote Access API can be found [here](https://www.jenkins.io/doc
 ## Install the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/trigger-jenkins-job/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml
 ```
 
 ## Parameters

--- a/task/ts-lint/0.1/README.md
+++ b/task/ts-lint/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to provide static analysis on YAML files mounted usin
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/ts-lint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/ts-lint/0.1/ts-lint.yaml
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/wget/0.1/README.md
+++ b/task/wget/0.1/README.md
@@ -6,7 +6,7 @@ This task uses wget to download files from the internet to a workspace  .
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/wget/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/wget/0.1/wget.yaml
 ```
 
 ## Parameters

--- a/task/write-file/0.1/README.md
+++ b/task/write-file/0.1/README.md
@@ -7,7 +7,7 @@ file. It can also set specific permissions on the file.
 ## Install the Task
 
 ```
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/write-file/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/write-file/0.1/write-file.yaml
 ```
 
 ## Parameters

--- a/task/yaml-lint/0.1/README.md
+++ b/task/yaml-lint/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to provide static analysis on YAML files mounted usin
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/yaml-lint/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/yaml-lint/0.1/yaml-lint.yaml
 ```
 
 ## Parameters
@@ -25,7 +25,7 @@ The Task can be run on `linux/amd64` platform.
 1. Create the `git-clone` task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/git-clone/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.1/git-clone.yaml
 ```
 
 2. Create the PVC

--- a/task/yq/0.1/README.md
+++ b/task/yq/0.1/README.md
@@ -5,7 +5,7 @@ The following task is used to replace a specific field in a yaml in the workspac
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/yq/0.1/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/yq/0.1/yq.yaml
 ```
 
 ## Parameters

--- a/task/yq/0.2/README.md
+++ b/task/yq/0.2/README.md
@@ -5,7 +5,7 @@ The following task is used to replace a specific field in a yaml in the workspac
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/yq/0.2/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/yq/0.2/yq.yaml
 ```
 
 ## Parameters

--- a/task/yq/0.3/README.md
+++ b/task/yq/0.3/README.md
@@ -5,7 +5,7 @@ The following task is used to replace a specific field in a yaml in the workspac
 ## Installing the Task
 
 ```bash
-kubectl apply -f https://api.hub.tekton.dev/v1/resource/tekton/task/yq/0.3/raw
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/yq/0.3/yq.yaml
 ```
 
 ## Parameters


### PR DESCRIPTION
# Changes

`hub.tekton.dev` and `api.hub.tekton.dev` no longer resolve DNS, breaking all
install commands in README files across the catalog.

- Replace `api.hub.tekton.dev/v1/resource/tekton/task/*/raw` URLs with
  `raw.githubusercontent.com` equivalents
- Replace `api.hub.tekton.dev` pipeline URLs similarly
- Replace `hub.tekton.dev` browsing links with `artifacthub.io` equivalents

238 files updated across all tasks and pipelines.

Fixes #1383

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing)
- [x] Includes [tests][tests] (for new tasks or changed functionality)
  - N/A — docs-only change, no task or functionality changes
- [x] Meets the [Tekton contributor standards][contributor] (including functionality, content, code)
- [x] Commit messages follow [commit message best practices][commit]
- [ ] Has a kind label. You can add one by adding a comment on this PR that
  contains `/kind <type>`. Valid types are bug, cleanup, design, documentation,
  feature, flake, misc, question, tep
- [x] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - N/A — no resource YAML changes

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]: https://github.com/tektoncd/catalog/issues/413
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[e2e]: https://github.com/tektoncd/catalog/blob/main/CONTRIBUTING.md#end-to-end-testing
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages