### PR TITLE
ci: only run catlin validate on the resource version directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,11 +49,14 @@ jobs:
       env:
         PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
-        # Detect changed task directories
+        # Detect changed task version directories (task/<name>/<version>).
+        # Reduce every changed file to its version directory so that catlin
+        # only validates the catalog resource itself, never the test
+        # manifests under tests/ (TaskRun/Pipeline) or files under samples/,
+        # which are not catalog resources and would fail validation.
         changed_tasks=$(
           git --no-pager diff --name-only ${PULL_BASE_SHA}..HEAD | \
-          { grep 'task/[^/]*/[^/]*/' || true; } | \
-          xargs -I {} dirname {} | \
+          { grep -oE '^task/[^/]+/[^/]+' || true; } | \
           sort -u
         )
         if [[ -z "$changed_tasks" ]]; then
@@ -75,11 +78,11 @@ jobs:
       env:
         PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
-        # Detect changed task directories
+        # Detect changed task version directories (task/<name>/<version>).
+        # See the note in the "catlin validate" step above.
         changed_tasks=$(
           git --no-pager diff --name-only ${PULL_BASE_SHA}..HEAD | \
-          { grep 'task/[^/]*/[^/]*/' || true; } | \
-          xargs -I {} dirname {} | \
+          { grep -oE '^task/[^/]+/[^/]+' || true; } | \
           sort -u
         )
         if [[ -z "$changed_tasks" ]]; then


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `catlin validate` gate (introduced in #_the Prow→GHA migration_, commit `51a8540f`) reduces every changed file to its containing directory with `dirname` and passes the result to `catlin validate`. For a **new task version** the changed set includes the `tests/` and `tests/fixtures/` subdirectories, so catlin validates the **test manifests** (a `TaskRun` or `Pipeline`) as if they were catalog resources:

```
FILE: task/<name>/<version>/tests/run.yaml
ERROR: Resource path is invalid; expected path: pipeline/<name>/<name>.yaml
ERROR: Pipeline "<name>" must have a label "app.kubernetes.io/version" ...
```

catlin also errors with `unknown kind TaskRun` for `TaskRun`-based tests, so **any** new task version that ships a `tests/run.yaml` fails the gate. Because no new task version has been added since the gate landed, this went unnoticed until now (surfaced by #1386).

## Fix

Reduce each changed path to its `task/<name>/<version>` **version directory** (`grep -oE '^task/[^/]+/[^/]+' | sort -u`) instead of `dirname` on every file. catlin then validates only the catalog resource in that directory and does **not** descend into `tests/` or `samples/`, which are not catalog resources. The existing `[[ -d ]]` filter still drops removed directories and non-directory matches such as `task/<name>/OWNERS`. The same detection is applied to the informational "catlin lint scripts" step.

Verified locally with the pinned catlin version CI installs: validating `task/<name>/<version>` only checks the resource `.yaml` and ignores `tests/`.

# Submitter Checklist

- [x] Follows the [authoring recommendations][authoring]
- [x] Includes [docs][docs] (if user facing) — N/A, CI-only change
- [x] Includes [tests][tests] (for new tasks or changed functionality) — N/A, CI-only change
- [x] Meets the [Tekton contributor standards][contributor]
- [x] Commit messages follow [commit message best practices][commit]
- [x] Has a kind label — `/kind bug`
- [x] Complies with [Catalog Organization TEP][TEP] — no catalog resources changed

/kind bug

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md) for more details._

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[authoring]: https://github.com/tektoncd/catalog/blob/main/recommendations.md
[docs]: https://github.com/tektoncd/community/blob/master/standards.md#docs
[tests]: https://github.com/tektoncd/community/blob/master/standards.md#tests
[contributor]: https://github.com/tektoncd/community/blob/main/standards.md
[commit]: https://github.com/tektoncd/community/blob/master/standards.md#commit-messages